### PR TITLE
feat: auto-resurrect + quit button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented here.
 
+## [0.2.6] — 2026-04-24
+
+### Added
+
+- **Auto-resurrect.** The MCP-stdio child now loops reconnect: if the
+  GUI is gone (user quit, crash) and an agent call arrives, the child
+  spawns aiui back up automatically. Net effect: aiui is always
+  available as long as Claude Desktop is running. No more "I quit it
+  and now the agent can't reach me" paper cut.
+- **Quit button in Settings** (with honest wording that the next agent
+  call will relaunch aiui anyway). Useful for debugging or forcing a
+  clean state; for normal use, the red X is enough.
+
 ## [0.2.5] — 2026-04-24
 
 ### Fixed

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "aiui companion \u2014 renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.2.4"
+version = "0.2.6"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.2.5"
+version = "0.2.6"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -40,6 +40,17 @@ async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
 /// An Accessory-mode app (LSUIElement) doesn't own a Dock entry, and macOS
 /// won't reliably bring its dialogs to the foreground — we temporarily
 /// promote the app to Regular so the prompt actually becomes visible.
+/// Exit the companion immediately. Bypasses the ExitRequested trap
+/// (which otherwise intercepts Cmd-Q / window-close) by going straight
+/// to `std::process::exit`. The tunnel-manager children are killed via
+/// `kill_on_drop`. If Claude Desktop still has an MCP-stdio child
+/// running, that child will spawn the GUI again on its next lifetime-
+/// socket reconnect attempt (usually within a few seconds).
+#[tauri::command]
+fn force_quit() -> Result<(), String> {
+    std::process::exit(0);
+}
+
 #[tauri::command]
 async fn surface_for_dialog(app: tauri::AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
@@ -255,6 +266,7 @@ pub fn run() {
             dialog_submit,
             dialog_cancel,
             close_window,
+            force_quit,
             surface_for_dialog,
             status,
             add_remote,

--- a/companion/src-tauri/src/lifetime.rs
+++ b/companion/src-tauri/src/lifetime.rs
@@ -103,40 +103,55 @@ pub async fn gui_serve(sock: PathBuf, app: AppHandle) {
     }
 }
 
-/// MCP-stdio-side: connect to the GUI socket, launching the GUI first if the
-/// socket isn't there yet. Hold the connection open until the process exits.
+/// MCP-stdio-side: keep the GUI alive for the entire lifetime of this
+/// MCP child process. If the GUI isn't running, launch it. If it dies
+/// (user Cmd-Q'd, crash, whatever), relaunch and reattach. The loop only
+/// exits when this MCP-stdio process itself is terminated — which
+/// happens when Claude Desktop tears down its MCP children.
+///
+/// This is the "auto-resurrect" contract: as long as Claude Desktop is
+/// running, any agent tool call from the remote will find aiui's HTTP
+/// server back up by the time it tries to POST.
 pub async fn mcp_attach(sock: PathBuf) {
-    let mut launched = false;
-    for attempt in 1..=30u32 {
-        match UnixStream::connect(&sock).await {
-            Ok(mut stream) => {
-                trace(&format!(
-                    "lifetime: mcp attached to {} (attempt {attempt})",
-                    sock.display()
-                ));
-                let mut buf = [0u8; 64];
-                loop {
-                    match stream.read(&mut buf).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(_) => continue,
-                    }
-                }
-                trace("lifetime: mcp socket closed");
-                return;
-            }
-            Err(e) => {
-                if !launched {
+    loop {
+        // Try to attach. If the socket isn't there, spawn the GUI and retry.
+        let mut attached = false;
+        for attempt in 1..=30u32 {
+            match UnixStream::connect(&sock).await {
+                Ok(mut stream) => {
                     trace(&format!(
-                        "lifetime: gui socket not ready ({e}), launching GUI via `open --auto`"
+                        "lifetime: mcp attached to {} (attempt {attempt})",
+                        sock.display()
                     ));
-                    let _ = std::process::Command::new("open")
-                        .args(["-g", "-a", "aiui", "--args", "--auto"])
-                        .spawn();
-                    launched = true;
+                    attached = true;
+                    let mut buf = [0u8; 64];
+                    loop {
+                        match stream.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(_) => continue,
+                        }
+                    }
+                    trace("lifetime: mcp socket closed — GUI is gone, will relaunch");
+                    break;
                 }
-                tokio::time::sleep(Duration::from_millis(500)).await;
+                Err(e) => {
+                    if attempt == 1 {
+                        trace(&format!(
+                            "lifetime: gui socket not ready ({e}), launching GUI via `open --auto`"
+                        ));
+                        let _ = std::process::Command::new("open")
+                            .args(["-g", "-a", "aiui", "--args", "--auto"])
+                            .spawn();
+                    }
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
             }
         }
+        if !attached {
+            trace("lifetime: mcp gave up waiting for gui socket after 30 attempts; retrying in 5s");
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+        // GUI was connected and has now closed; loop back to resurrect it
+        // (or wait + retry if launch failed).
     }
-    trace("lifetime: mcp gave up waiting for gui socket after 30 attempts");
 }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -26,7 +26,11 @@
     "skill.button": "Skill installieren",
     "skill.hint": "Kopiert das aiui-Skill nach ~/.claude/skills/aiui/ — lokal und auf allen Remote-Hosts. Gibt Agents konkrete Regeln, damit sie saubere Dialoge bauen.",
     "report.button": "Problem melden",
-    "report.hint": "Öffnet ein neues Issue auf GitHub mit Version und Build vorausgefüllt."
+    "report.hint": "Öffnet ein neues Issue auf GitHub mit Version und Build vorausgefüllt.",
+    "quit.button": "Beenden",
+    "quit.hint": "Beendet aiui sofort. Beim nächsten Agent-Zugriff startet sich aiui automatisch wieder — für normale Bedienung reicht das rote Schließen-Kreuz.",
+    "quit.confirm": "Beenden? aiui ist kurz offline, bis ein Agent erneut zugreift.",
+    "quit.do": "Jetzt beenden"
   },
   "dialog": {
     "cancel": "Abbrechen",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -26,7 +26,11 @@
     "skill.button": "Install skill",
     "skill.hint": "Copies the aiui skill into ~/.claude/skills/aiui/ — locally and on every registered remote. Gives agents concrete rules so they build clean dialogs.",
     "report.button": "Report issue",
-    "report.hint": "Opens a new GitHub issue with version and build pre-filled."
+    "report.hint": "Opens a new GitHub issue with version and build pre-filled.",
+    "quit.button": "Quit",
+    "quit.hint": "Terminates aiui immediately. The next agent call auto-relaunches it — for normal use, just close the window.",
+    "quit.confirm": "Quit? aiui will be offline briefly until an agent accesses it again.",
+    "quit.do": "Quit now"
   },
   "dialog": {
     "cancel": "Cancel",

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -75,6 +75,13 @@
     }
   }
 
+  let confirmQuit = $state(false);
+
+  async function doQuit() {
+    await invoke("force_quit");
+    // Never returns; app exits.
+  }
+
   async function reinstallSkill() {
     busy = true;
     try {
@@ -201,6 +208,16 @@
         <button class="danger" onclick={doUninstall} disabled={busy}
           >{$_("settings.uninstall.do")}</button
         >
+      {:else if confirmQuit}
+        <span class="subtitle" style="margin-right: auto; align-self: center;">
+          {$_("settings.quit.confirm")}
+        </span>
+        <button onclick={() => (confirmQuit = false)} disabled={busy}
+          >{$_("settings.uninstall.back")}</button
+        >
+        <button class="danger" onclick={doQuit} disabled={busy}
+          >{$_("settings.quit.do")}</button
+        >
       {:else}
         <button onclick={openIssue} title={$_("settings.report.hint")}>
           {$_("settings.report.button")}
@@ -211,6 +228,9 @@
         <button onclick={() => checkForUpdates({ silent: false })} disabled={busy}>
           {$_("settings.updates.check")}
         </button>
+        <button onclick={() => (confirmQuit = true)} disabled={busy}
+          title={$_("settings.quit.hint")}>{$_("settings.quit.button")}</button
+        >
         <button onclick={() => (confirmUninstall = true)} disabled={busy}
           >{$_("settings.uninstall.button")}</button
         >


### PR DESCRIPTION
Solves the 'I quit aiui and now the agent can't reach me' paper cut: the MCP-stdio child running under Claude Desktop now relaunches the GUI on demand via a persistent reconnect loop.