### PR TITLE
cleanup: drop the quit-trap, let X and Cmd-Q terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented here.
 
+## [0.2.7] — 2026-04-24
+
+### Changed
+
+- **Close + quit now terminate the app** (as any macOS user would
+  expect). The prevent-close / prevent-exit machinery from 0.2.5 is
+  gone. The auto-resurrect loop in 0.2.6 means aiui comes back on the
+  next agent call anyway, so there's no reason to keep a hidden
+  process running after the user asked it to go away.
+
+### Removed
+
+- The "Quit" button in Settings, along with its confirmation flow and
+  associated i18n strings. Redundant now that red X already terminates.
+
 ## [0.2.6] — 2026-04-24
 
 ### Added

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "aiui companion \u2014 renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.2.6"
+version = "0.2.7"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -40,17 +40,6 @@ async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
 /// An Accessory-mode app (LSUIElement) doesn't own a Dock entry, and macOS
 /// won't reliably bring its dialogs to the foreground — we temporarily
 /// promote the app to Regular so the prompt actually becomes visible.
-/// Exit the companion immediately. Bypasses the ExitRequested trap
-/// (which otherwise intercepts Cmd-Q / window-close) by going straight
-/// to `std::process::exit`. The tunnel-manager children are killed via
-/// `kill_on_drop`. If Claude Desktop still has an MCP-stdio child
-/// running, that child will spawn the GUI again on its next lifetime-
-/// socket reconnect attempt (usually within a few seconds).
-#[tauri::command]
-fn force_quit() -> Result<(), String> {
-    std::process::exit(0);
-}
-
 #[tauri::command]
 async fn surface_for_dialog(app: tauri::AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
@@ -266,7 +255,6 @@ pub fn run() {
             dialog_submit,
             dialog_cancel,
             close_window,
-            force_quit,
             surface_for_dialog,
             status,
             add_remote,
@@ -348,45 +336,23 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                api.prevent_close();
-                let _ = window.hide();
-                // Dock icon came up because the user brought the window
-                // forward. On close, drop back to Accessory mode so aiui
-                // vanishes from the Dock/Cmd-Tab until next time.
-                #[cfg(target_os = "macos")]
-                {
-                    let _ = window
-                        .app_handle()
-                        .set_activation_policy(tauri::ActivationPolicy::Accessory);
-                }
+            // Red X quits the app outright — the MCP-stdio child's
+            // lifetime-socket loop will resurrect aiui on the next agent
+            // call, so there is no reason to keep a headless process
+            // running once the user asks for it to go away.
+            if let tauri::WindowEvent::CloseRequested { .. } = event {
+                window.app_handle().exit(0);
             }
         })
         .build(tauri::generate_context!())
         .expect("error building tauri application")
         .run(|app, event| {
-            match event {
-                // macOS: Dock-Klick, "open" bei laufender App, File-Assoc etc.
-                // → Settings-Fenster nach vorn holen.
-                tauri::RunEvent::Reopen { .. } => {
-                    show_settings_window(app);
-                }
-                // User-initiated quit (Cmd-Q, App menu → aiui beenden, dock
-                // right-click → Beenden): block it, hide the window, drop to
-                // Accessory. aiui must keep serving HTTP so the agent can
-                // still open dialogs. The only legitimate exit path is the
-                // lifetime-socket watchdog that calls std::process::exit().
-                tauri::RunEvent::ExitRequested { api, .. } => {
-                    api.prevent_exit();
-                    if let Some(win) = app.get_webview_window("main") {
-                        let _ = win.hide();
-                    }
-                    #[cfg(target_os = "macos")]
-                    {
-                        let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
-                    }
-                }
-                _ => {}
+            // macOS: Dock-Klick, "open" bei laufender App, File-Assoc etc.
+            // → Settings-Fenster nach vorn holen.
+            if let tauri::RunEvent::Reopen { .. } = event {
+                show_settings_window(app);
             }
+            // Cmd-Q and window-close both just let the app terminate;
+            // auto-resurrect in mcp_attach brings aiui back when needed.
         });
 }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -26,11 +26,7 @@
     "skill.button": "Skill installieren",
     "skill.hint": "Kopiert das aiui-Skill nach ~/.claude/skills/aiui/ — lokal und auf allen Remote-Hosts. Gibt Agents konkrete Regeln, damit sie saubere Dialoge bauen.",
     "report.button": "Problem melden",
-    "report.hint": "Öffnet ein neues Issue auf GitHub mit Version und Build vorausgefüllt.",
-    "quit.button": "Beenden",
-    "quit.hint": "Beendet aiui sofort. Beim nächsten Agent-Zugriff startet sich aiui automatisch wieder — für normale Bedienung reicht das rote Schließen-Kreuz.",
-    "quit.confirm": "Beenden? aiui ist kurz offline, bis ein Agent erneut zugreift.",
-    "quit.do": "Jetzt beenden"
+    "report.hint": "Öffnet ein neues Issue auf GitHub mit Version und Build vorausgefüllt."
   },
   "dialog": {
     "cancel": "Abbrechen",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -26,11 +26,7 @@
     "skill.button": "Install skill",
     "skill.hint": "Copies the aiui skill into ~/.claude/skills/aiui/ — locally and on every registered remote. Gives agents concrete rules so they build clean dialogs.",
     "report.button": "Report issue",
-    "report.hint": "Opens a new GitHub issue with version and build pre-filled.",
-    "quit.button": "Quit",
-    "quit.hint": "Terminates aiui immediately. The next agent call auto-relaunches it — for normal use, just close the window.",
-    "quit.confirm": "Quit? aiui will be offline briefly until an agent accesses it again.",
-    "quit.do": "Quit now"
+    "report.hint": "Opens a new GitHub issue with version and build pre-filled."
   },
   "dialog": {
     "cancel": "Cancel",

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -75,13 +75,6 @@
     }
   }
 
-  let confirmQuit = $state(false);
-
-  async function doQuit() {
-    await invoke("force_quit");
-    // Never returns; app exits.
-  }
-
   async function reinstallSkill() {
     busy = true;
     try {
@@ -208,16 +201,6 @@
         <button class="danger" onclick={doUninstall} disabled={busy}
           >{$_("settings.uninstall.do")}</button
         >
-      {:else if confirmQuit}
-        <span class="subtitle" style="margin-right: auto; align-self: center;">
-          {$_("settings.quit.confirm")}
-        </span>
-        <button onclick={() => (confirmQuit = false)} disabled={busy}
-          >{$_("settings.uninstall.back")}</button
-        >
-        <button class="danger" onclick={doQuit} disabled={busy}
-          >{$_("settings.quit.do")}</button
-        >
       {:else}
         <button onclick={openIssue} title={$_("settings.report.hint")}>
           {$_("settings.report.button")}
@@ -228,9 +211,6 @@
         <button onclick={() => checkForUpdates({ silent: false })} disabled={busy}>
           {$_("settings.updates.check")}
         </button>
-        <button onclick={() => (confirmQuit = true)} disabled={busy}
-          title={$_("settings.quit.hint")}>{$_("settings.quit.button")}</button
-        >
         <button onclick={() => (confirmUninstall = true)} disabled={busy}
           >{$_("settings.uninstall.button")}</button
         >


### PR DESCRIPTION
Auto-resurrect made the intercept logic unnecessary; simpler model is 'close = quit, agent call = revive'.