### PR TITLE
v0.3.0: native MCP server eliminates uv dep + /aiui:update + /aiui:version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project are documented here.
 
+## [0.3.0] — 2026-04-24
+
+### Added
+
+- **Unified native MCP server.** aiui.app now ships a full-featured MCP
+  server as native Rust code inside the app bundle — confirm, ask, form,
+  aiui_health, plus the new `update` and `version` tools and three
+  prompts (`widgets`, `update`, `version`). Claude Code points directly
+  at the app binary with `--mcp-stdio`, eliminating the `uv`/`uvx`/Python
+  dependency from the onboarding path. Drag DMG → Applications → Launch
+  is the whole install now.
+- **`/aiui:update` slash-command.** Agent calls the `update` tool, aiui
+  checks the release feed, installs any available update silently, and
+  reports `{updated, current, available}` back to the agent *before*
+  scheduling its own relaunch. Explicit `tokio::sleep` buffer between
+  response and `app.restart()` guarantees the wire response lands before
+  the process exits.
+- **`/aiui:version` slash-command.** Reports the installed version,
+  build info, binary path, and updater endpoint in one call.
+- **`/version` HTTP endpoint** on the companion, returning structured
+  build metadata (bearer-auth protected like `/render`).
+
+### Changed
+
+- `patch_claude_code_config` writes `{command: <aiui.app binary>, args:
+  ["--mcp-stdio"]}` instead of `{command: "uvx", args: ["aiui-mcp"]}`.
+- **Auto-migration** on GUI startup: existing installs from ≤ v0.2.x
+  have their legacy `uvx aiui-mcp` entry in `~/.claude.json` rewritten
+  to the native binary transparently. The Python `aiui-mcp` package
+  stays on PyPI and remains the path of choice for remote SSH hosts
+  where aiui.app isn't installed locally.
+- README install section reduced from a three-step "brew + download +
+  drag" to a single "download + drag + launch". The `uv` FAQ entry now
+  answers "no, you don't need it."
+
 ## [0.2.8] — 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,21 +56,18 @@ automatically sets up a tunnel so the remote agent can pop dialogs right
 on your Mac. Register the host once in settings; from then on it just
 works.
 
-## Install in 3 minutes
+## Install
 
-**Prerequisite**: [`uv`](https://docs.astral.sh/uv/) — the fast Python
-tool-runner that pulls the MCP server on demand. If you don't have it:
-```sh
-brew install uv
-```
-
-Then:
+No Terminal. No Homebrew. No Python. No `uv`.
 
 1. **[Download aiui.app](https://github.com/byte5ai/aiui/releases/latest)**
-   (DMG, Apple Silicon), open it, drag into `Applications`.
-2. **Launch once** from Finder. aiui registers itself with Claude Desktop
-   and Claude Code automatically.
-3. **Restart Claude Desktop.** That's it.
+   (DMG, Apple Silicon).
+2. Drag into `Applications`.
+3. Launch it once from Finder.
+
+That's it. aiui registers itself with Claude Desktop and Claude Code
+automatically. The MCP server ships inside the app bundle as native
+code, so you don't need a Python toolchain on your Mac.
 
 From now on aiui runs silently in the background — only while Claude
 Desktop is open. No dock icon, no menu-bar clutter, no lingering
@@ -81,8 +78,8 @@ Try it straight away in any Claude Code session: *"Ask me with aiui
 which of three deploy strategies we want today."* The agent opens an
 options dialog, you click, it keeps going.
 
-Future updates install themselves: aiui quietly prompts "update
-available", one click, done.
+Future updates: use `/aiui:update` in Claude Code, or wait for the
+auto-check the next time aiui's settings window opens.
 
 ## What you get
 
@@ -99,6 +96,14 @@ aiui runs purely locally on your Mac. No telemetry, no usage data, no
 content leaves your system. A local auth token lives in `~/.config/aiui/`
 (mode 0600) and is only scp'd to hosts you explicitly register in
 settings.
+
+## Slash commands in Claude Code
+
+| Command | What it does |
+|---|---|
+| `/aiui:widgets` | Loads the full widget catalog into the session. Use this right before UI-heavy work so the agent has the rules in context. |
+| `/aiui:update` | Agent calls the `update` tool; aiui checks the release feed, silently installs any available update, and reports the version delta back. Responds before the background relaunch, so the agent always gets the answer. |
+| `/aiui:version` | Reports the currently installed aiui version in one line. |
 
 ## For agents: the skill
 
@@ -117,10 +122,14 @@ Developer-ID signed and notarized. It never phones home. The auth token
 stays under `~/.config/aiui/` on your machine and is only copied to
 hosts you explicitly register in settings.
 
-**Why do I need `uv`?** aiui's MCP server runs as a Python package
-published on PyPI. `uvx aiui-mcp` is the one-liner that fetches and runs
-it, with zero global environment pollution. If your Mac doesn't have
-`uv`, `brew install uv` is a one-time 10-second install.
+**Do I need `uv` or Python?** No. Since v0.3.0 the MCP server ships
+inside the aiui.app bundle as native Rust code — drag-and-drop install
+with no outside dependencies.
+
+For the special case of a remote SSH host that doesn't have aiui.app
+locally, the standalone Python package `aiui-mcp` is still on PyPI and
+gets used via `uvx aiui-mcp`. aiui registers that automatically when you
+add the remote in settings.
 
 **How much memory does it use?** The companion idles around 30–50 MB.
 The underlying WebKit view loads only while a dialog is on screen.

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "aiui companion \u2014 renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.2.8"
+version = "0.3.0"
 dependencies = [
  "axum",
  "chrono",
@@ -40,6 +40,7 @@ dependencies = [
  "log",
  "rand 0.8.6",
  "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -1538,8 +1539,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1549,9 +1552,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1864,6 +1869,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2303,6 +2309,12 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3147,6 +3159,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,6 +3266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,6 +3296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3356,6 +3452,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3541,6 +3675,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4291,7 +4426,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4497,7 +4632,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -5351,6 +5486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5411,6 +5556,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.2.8"
+version = "0.3.0"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""
@@ -41,3 +41,4 @@ hex = "0.4"
 futures = "0.3"
 regex = "1"
 chrono = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -10,8 +10,10 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use crate::logging::trace;
 use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_updater::UpdaterExt;
 
 #[derive(Clone)]
 struct AppState {
@@ -40,6 +42,23 @@ struct HealthResponse {
     ready: bool,
 }
 
+#[derive(Serialize)]
+struct VersionResponse {
+    version: String,
+    build_info: String,
+    binary_path: String,
+    updater_endpoint: String,
+}
+
+#[derive(Serialize)]
+struct UpdateResponse {
+    updated: bool,
+    current: String,
+    available: Option<String>,
+    error: Option<String>,
+    note: Option<String>,
+}
+
 pub async fn serve(
     cfg: Arc<AppConfig>,
     dialog: Arc<DialogState>,
@@ -51,6 +70,8 @@ pub async fn serve(
     let router = Router::new()
         .route("/health", get(health))
         .route("/render", post(render))
+        .route("/version", get(version))
+        .route("/update", post(update))
         .route("/ping", get(ping))
         .with_state(state);
 
@@ -88,6 +109,118 @@ async fn health(
     Ok(Json(HealthResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
         ready: true,
+    }))
+}
+
+async fn version(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<VersionResponse>, StatusCode> {
+    if !auth_ok(&headers, &state.cfg.token) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(Json(VersionResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        build_info: crate::logging::BUILD_INFO.to_string(),
+        binary_path: crate::setup::app_binary_path(),
+        updater_endpoint:
+            "https://github.com/byte5ai/aiui/releases/latest/download/latest.json".to_string(),
+    }))
+}
+
+/// Check for an aiui update, download-and-install it if present, and answer
+/// the caller *before* scheduling the relaunch. The 500ms delay between
+/// returning the response and calling `app.restart()` gives Axum time to
+/// finalize the wire response so the MCP client receives `{updated: true,
+/// from, to}` even though the process exits shortly after.
+async fn update(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<UpdateResponse>, (StatusCode, Json<UpdateResponse>)> {
+    let current = env!("CARGO_PKG_VERSION").to_string();
+    if !auth_ok(&headers, &state.cfg.token) {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(UpdateResponse {
+                updated: false,
+                current: current.clone(),
+                available: None,
+                error: Some("unauthorized".into()),
+                note: None,
+            }),
+        ));
+    }
+
+    let updater = match state.app.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            trace(&format!("update: updater unavailable: {e}"));
+            return Ok(Json(UpdateResponse {
+                updated: false,
+                current,
+                available: None,
+                error: Some(format!("updater unavailable: {e}")),
+                note: None,
+            }));
+        }
+    };
+
+    let check = updater.check().await;
+    let update = match check {
+        Ok(opt) => opt,
+        Err(e) => {
+            trace(&format!("update: check failed: {e}"));
+            return Ok(Json(UpdateResponse {
+                updated: false,
+                current,
+                available: None,
+                error: Some(format!("check failed: {e}")),
+                note: None,
+            }));
+        }
+    };
+
+    let Some(update) = update else {
+        trace("update: already on latest");
+        return Ok(Json(UpdateResponse {
+            updated: false,
+            current,
+            available: None,
+            error: None,
+            note: Some("already on latest".into()),
+        }));
+    };
+
+    let to_version = update.version.clone();
+    trace(&format!("update: installing {current} -> {to_version}"));
+
+    if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
+        trace(&format!("update: install failed: {e}"));
+        return Ok(Json(UpdateResponse {
+            updated: false,
+            current,
+            available: Some(to_version),
+            error: Some(format!("install failed: {e}")),
+            note: None,
+        }));
+    }
+
+    // Install succeeded. Schedule the relaunch AFTER we've returned this
+    // response so the agent receives the version delta. 500ms is plenty for
+    // Axum to flush + close the TCP write side before exit.
+    let app_handle = state.app.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        trace("update: restarting into new binary");
+        app_handle.restart();
+    });
+
+    Ok(Json(UpdateResponse {
+        updated: true,
+        current,
+        available: Some(to_version),
+        error: None,
+        note: Some("relaunching into new version".into()),
     }))
 }
 

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -296,9 +296,10 @@ pub fn run() {
             }
 
             // Auto-register aiui as a global MCP server in Claude Code
-            // (~/.claude.json), so every session sees it without a per-project
-            // .mcp.json file.
-            let _ = setup::patch_claude_code_config();
+            // (~/.claude.json) and auto-migrate any legacy `uvx aiui-mcp`
+            // entries from ≤ v0.2.x installs to the native app binary, so
+            // every session sees aiui without a uv/uvx dependency.
+            let _ = setup::patch_claude_code_config(&bin);
 
             // Auto-install the aiui skill into the local Claude Code skill
             // directory on every GUI launch. Idempotent: overwrites old copies

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -1,77 +1,458 @@
+//! aiui MCP stdio server (native Rust).
+//!
+//! Exposes confirm/ask/form/aiui_health/update/version tools plus the
+//! widgets/update/version prompts over the MCP JSON-RPC protocol. Dialog
+//! rendering is forwarded over HTTP to the GUI companion on
+//! localhost:<http_port>; the updater runs inside the companion process via
+//! `UpdaterExt`.
+//!
+//! This server replaces the Python `aiui-mcp` PyPI package for the common
+//! case of "aiui.app is installed on the same Mac". Claude Code's
+//! `~/.claude.json` points directly at this binary with `--mcp-stdio`, so
+//! there is no `uv`/`uvx`/`pipx` dependency on the onboarding path.
+//!
+//! The Python package stays on PyPI for remote/headless scenarios where
+//! aiui.app isn't installed locally (typically SSH targets).
+
 use crate::config::AppConfig;
+use crate::logging::trace;
 use serde_json::{json, Value};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-/// Minimal MCP stdio handler. Purpose: keep the companion alive while Claude
-/// Desktop is running. Exposes one introspection tool (`aiui_info`) so the
-/// integration is visible in Claude Desktop's UI; future tools slot in here.
+const SKILL_MD: &str = include_str!("../../../docs/skill.md");
+
+const UPDATE_PROMPT: &str = "\
+Check whether an aiui update is available and install it if so. Call the \
+`update` tool now, then report back concisely:
+
+- If `updated: true`, report \"aiui updated {current} -> {available}\" and \
+  mention that aiui will relaunch itself silently; the next agent call \
+  will hit the new version.
+- If `updated: false` and `note: \"already on latest\"`, report \"aiui is \
+  on the latest version ({current})\".
+- If `error` is set, report the error verbatim.
+
+Keep the reply to one short sentence unless the user asked for detail.
+";
+
+const VERSION_PROMPT: &str = "\
+Report the current aiui version to the user. Call the `version` tool and \
+reply with one short line containing the version plus the build date \
+parsed from `build_info` (format \"v{ver} (commit, yyyy-mm-dd)\"). If the \
+user asked for more, include the binary path and updater endpoint.
+";
+
+/// Top-level entry: read JSON-RPC messages from stdin, dispatch to handlers,
+/// write responses to stdout. Runs until stdin closes.
 pub async fn run_stdio(cfg: Arc<AppConfig>) {
     let stdin = tokio::io::stdin();
     let mut reader = BufReader::new(stdin).lines();
     let mut stdout = tokio::io::stdout();
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .expect("reqwest client");
+
+    trace("mcp-stdio: run_stdio entered");
 
     while let Ok(Some(line)) = reader.next_line().await {
         let Ok(msg) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
-        let Some(id) = msg.get("id").cloned() else {
-            // notification, ignore
+        let id_opt = msg.get("id").cloned();
+        let method = msg.get("method").and_then(|v| v.as_str()).unwrap_or("");
+        let params = msg.get("params").cloned().unwrap_or(Value::Null);
+
+        // Notifications (no id) — we only care about "initialized"; everything
+        // else is silently dropped per JSON-RPC spec.
+        let Some(id) = id_opt else {
             continue;
         };
-        let method = msg.get("method").and_then(|v| v.as_str()).unwrap_or("");
 
-        let result: Value = match method {
-            "initialize" => json!({
-                "protocolVersion": "2025-06-18",
-                "capabilities": { "tools": {} },
-                "serverInfo": { "name": "aiui-local", "version": env!("CARGO_PKG_VERSION") }
+        let response = match dispatch(method, params, &cfg, &http).await {
+            Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+            Err(err) => json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": err.code, "message": err.message }
             }),
-            "tools/list" => json!({
-                "tools": [
-                    {
-                        "name": "aiui_info",
-                        "description": "Returns aiui companion status and pairing info.",
-                        "inputSchema": { "type": "object", "properties": {} }
-                    }
-                ]
-            }),
-            "tools/call" => {
-                let name = msg
-                    .get("params")
-                    .and_then(|p| p.get("name"))
-                    .and_then(|n| n.as_str())
-                    .unwrap_or("");
-                match name {
-                    "aiui_info" => json!({
-                        "content": [{
-                            "type": "text",
-                            "text": format!(
-                                "aiui companion v{} running on localhost:{}\nToken path: {}",
-                                env!("CARGO_PKG_VERSION"),
-                                cfg.http_port,
-                                cfg.token_path.display()
-                            )
-                        }]
-                    }),
-                    _ => json!({ "content": [{"type":"text","text":"unknown tool"}], "isError": true }),
-                }
-            }
-            _ => {
-                // unsupported method → JSON-RPC error
-                let err = json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "error": { "code": -32601, "message": "method not found" }
-                });
-                let _ = stdout.write_all(format!("{err}\n").as_bytes()).await;
-                let _ = stdout.flush().await;
-                continue;
-            }
         };
-
-        let response = json!({ "jsonrpc": "2.0", "id": id, "result": result });
-        let _ = stdout.write_all(format!("{response}\n").as_bytes()).await;
+        let _ = stdout
+            .write_all(format!("{response}\n").as_bytes())
+            .await;
         let _ = stdout.flush().await;
     }
+
+    trace("mcp-stdio: stdin closed, exiting");
+}
+
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+async fn dispatch(
+    method: &str,
+    params: Value,
+    cfg: &Arc<AppConfig>,
+    http: &reqwest::Client,
+) -> Result<Value, RpcError> {
+    match method {
+        "initialize" => Ok(json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {
+                "tools": {},
+                "prompts": {}
+            },
+            "serverInfo": {
+                "name": "aiui",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        })),
+        "tools/list" => Ok(json!({ "tools": tools_list() })),
+        "tools/call" => tools_call(params, cfg, http).await,
+        "prompts/list" => Ok(json!({ "prompts": prompts_list() })),
+        "prompts/get" => prompts_get(params),
+        _ => Err(RpcError {
+            code: -32601,
+            message: format!("method not found: {method}"),
+        }),
+    }
+}
+
+// ---------- tools ----------
+
+fn tools_list() -> Value {
+    json!([
+        {
+            "name": "confirm",
+            "description": "Hard yes/no decision as a native window, with optional destructive styling. Use when 'just proceed' would be unsafe (deletions, force-pushes, rollbacks). For pure information, reply in chat. For 3+ options, use `ask`. Returns {cancelled, confirmed}.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["title"],
+                "properties": {
+                    "title": { "type": "string", "description": "Decision as a question, ≤ 10 words." },
+                    "message": { "type": "string", "description": "One sentence stating the concrete consequence." },
+                    "header": { "type": "string", "description": "Short chip above the title (≤ 14 chars)." },
+                    "destructive": { "type": "boolean", "default": false, "description": "Red confirm button — for deletions/rollbacks only." },
+                    "confirm_label": { "type": "string" },
+                    "cancel_label": { "type": "string" }
+                }
+            }
+        },
+        {
+            "name": "ask",
+            "description": "Single- or multi-choice window with per-option descriptions. Use for 2-8 options; for a yes/no, use `confirm`; for ≥ 2 related inputs, use `form`. Returns {cancelled, answers, other?}.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["question", "options"],
+                "properties": {
+                    "question": { "type": "string", "description": "Full question, imperative or interrogative." },
+                    "options": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "label": { "type": "string" },
+                                "description": { "type": "string" },
+                                "value": { "type": "string" }
+                            },
+                            "required": ["label"]
+                        }
+                    },
+                    "header": { "type": "string" },
+                    "multi_select": { "type": "boolean", "default": false },
+                    "allow_other": { "type": "boolean", "default": false }
+                }
+            }
+        },
+        {
+            "name": "form",
+            "description": "Composite window with multiple typed fields and action buttons. Use for ≥ 2 related inputs, or one input plus context. Fields: text, password, number, select, checkbox, slider, date, date_range, color, static_text, list, tree. Actions support primary (blue), success (green), destructive (red). Returns {cancelled, action?, values}.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["title", "fields"],
+                "properties": {
+                    "title": { "type": "string" },
+                    "fields": { "type": "array", "items": { "type": "object" } },
+                    "description": { "type": "string" },
+                    "header": { "type": "string" },
+                    "actions": { "type": "array", "items": { "type": "object" } },
+                    "submit_label": { "type": "string" },
+                    "cancel_label": { "type": "string" }
+                }
+            }
+        },
+        {
+            "name": "aiui_health",
+            "description": "Reachability check against the local aiui companion. Returns version + ready flag if the companion is running and responding.",
+            "inputSchema": { "type": "object", "properties": {} }
+        },
+        {
+            "name": "version",
+            "description": "Report aiui companion version, build info, binary path, and the updater endpoint. Cheap; does not hit the network.",
+            "inputSchema": { "type": "object", "properties": {} }
+        },
+        {
+            "name": "update",
+            "description": "Check for an aiui update, download-and-install if one is available, then relaunch silently. Responds BEFORE the relaunch so the caller receives {updated, current, available, note}. Next agent call hits the new version.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }
+    ])
+}
+
+async fn tools_call(
+    params: Value,
+    cfg: &Arc<AppConfig>,
+    http: &reqwest::Client,
+) -> Result<Value, RpcError> {
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let args = params.get("arguments").cloned().unwrap_or(json!({}));
+
+    let outcome = match name.as_str() {
+        "confirm" => render_dialog(
+            json!({
+                "kind": "confirm",
+                "title": args.get("title"),
+                "message": args.get("message"),
+                "header": args.get("header"),
+                "destructive": args.get("destructive").and_then(|v| v.as_bool()).unwrap_or(false),
+                "confirmLabel": args.get("confirm_label"),
+                "cancelLabel": args.get("cancel_label")
+            }),
+            cfg,
+            http,
+        )
+        .await
+        .map(format_confirm_result),
+
+        "ask" => render_dialog(
+            json!({
+                "kind": "ask",
+                "question": args.get("question"),
+                "header": args.get("header"),
+                "options": args.get("options"),
+                "multiSelect": args.get("multi_select").and_then(|v| v.as_bool()).unwrap_or(false),
+                "allowOther": args.get("allow_other").and_then(|v| v.as_bool()).unwrap_or(false)
+            }),
+            cfg,
+            http,
+        )
+        .await
+        .map(format_dialog_result),
+
+        "form" => render_dialog(
+            json!({
+                "kind": "form",
+                "title": args.get("title"),
+                "description": args.get("description"),
+                "header": args.get("header"),
+                "fields": args.get("fields"),
+                "actions": args.get("actions"),
+                "submitLabel": args.get("submit_label"),
+                "cancelLabel": args.get("cancel_label")
+            }),
+            cfg,
+            http,
+        )
+        .await
+        .map(format_dialog_result),
+
+        "aiui_health" => get_json(http, cfg, "/health").await.map(value_to_tool_text),
+        "version" => get_json(http, cfg, "/version").await.map(value_to_tool_text),
+        "update" => post_empty(http, cfg, "/update")
+            .await
+            .map(value_to_tool_text),
+
+        _ => {
+            return Ok(json!({
+                "content": [{"type": "text", "text": format!("unknown tool: {name}")}],
+                "isError": true
+            }));
+        }
+    };
+
+    match outcome {
+        Ok(v) => Ok(v),
+        Err(e) => Ok(json!({
+            "content": [{"type": "text", "text": format!("aiui tool error: {e}")}],
+            "isError": true
+        })),
+    }
+}
+
+// ---------- dialog/http plumbing ----------
+
+fn load_token(cfg: &AppConfig) -> Result<String, String> {
+    std::fs::read_to_string(&cfg.token_path)
+        .map(|s| s.trim().to_string())
+        .map_err(|e| format!("reading token: {e}"))
+}
+
+fn base_url(cfg: &AppConfig) -> String {
+    format!("http://127.0.0.1:{}", cfg.http_port)
+}
+
+async fn render_dialog(
+    spec: Value,
+    cfg: &AppConfig,
+    http: &reqwest::Client,
+) -> Result<Value, String> {
+    let token = load_token(cfg)?;
+    let url = format!("{}/render", base_url(cfg));
+    let body = json!({ "spec": spec });
+    let resp = http
+        .post(&url)
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("POST /render: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("render http {}", resp.status()));
+    }
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("parse /render: {e}"))
+}
+
+async fn get_json(
+    http: &reqwest::Client,
+    cfg: &AppConfig,
+    path: &str,
+) -> Result<Value, String> {
+    let token = load_token(cfg)?;
+    let url = format!("{}{}", base_url(cfg), path);
+    let resp = http
+        .get(&url)
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|e| format!("GET {path}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("{path} http {}", resp.status()));
+    }
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("parse {path}: {e}"))
+}
+
+async fn post_empty(
+    http: &reqwest::Client,
+    cfg: &AppConfig,
+    path: &str,
+) -> Result<Value, String> {
+    let token = load_token(cfg)?;
+    let url = format!("{}{}", base_url(cfg), path);
+    let resp = http
+        .post(&url)
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|e| format!("POST {path}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("{path} http {}", resp.status()));
+    }
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("parse {path}: {e}"))
+}
+
+// MCP tool-result shape: { content: [...], structuredContent?: ..., isError? }
+fn value_to_tool_text(v: Value) -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string(&v).unwrap_or_else(|_| "{}".into())
+        }],
+        "structuredContent": v
+    })
+}
+
+fn format_confirm_result(render: Value) -> Value {
+    // /render returns { id, cancelled, result }; for confirm, result is
+    // { confirmed: bool } on submit, or null on cancel.
+    let cancelled = render
+        .get("cancelled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let confirmed = render
+        .get("result")
+        .and_then(|r| r.get("confirmed"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let payload = json!({ "cancelled": cancelled, "confirmed": confirmed });
+    value_to_tool_text(payload)
+}
+
+fn format_dialog_result(render: Value) -> Value {
+    // Passthrough: just return what the frontend delivered. The agent gets
+    // whatever shape the widget produced (values for form, answers for ask).
+    let cancelled = render
+        .get("cancelled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let mut payload = render
+        .get("result")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert("cancelled".into(), json!(cancelled));
+    } else {
+        payload = json!({ "cancelled": cancelled });
+    }
+    value_to_tool_text(payload)
+}
+
+// ---------- prompts ----------
+
+fn prompts_list() -> Value {
+    json!([
+        {
+            "name": "widgets",
+            "description": "Full widget catalog, rules, and patterns for building aiui dialogs. Load at the start of UI-heavy work.",
+            "arguments": []
+        },
+        {
+            "name": "update",
+            "description": "Check for an aiui update and install it silently, reporting the outcome.",
+            "arguments": []
+        },
+        {
+            "name": "version",
+            "description": "Report the currently installed aiui version.",
+            "arguments": []
+        }
+    ])
+}
+
+fn prompts_get(params: Value) -> Result<Value, RpcError> {
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let text = match name.as_str() {
+        "widgets" => SKILL_MD,
+        "update" => UPDATE_PROMPT,
+        "version" => VERSION_PROMPT,
+        _ => {
+            return Err(RpcError {
+                code: -32602,
+                message: format!("unknown prompt: {name}"),
+            });
+        }
+    };
+    Ok(json!({
+        "description": format!("aiui:{name}"),
+        "messages": [{
+            "role": "user",
+            "content": { "type": "text", "text": text }
+        }]
+    }))
 }

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -192,8 +192,15 @@ pub fn is_claude_config_current(app_binary_path: &str) -> bool {
 
 /// Patches `~/.claude.json` so Claude Code CLI sees `aiui` as a globally
 /// available MCP server — every session, every project, no per-project
-/// .mcp.json required. Uses the public uvx entrypoint on PyPI.
-pub fn patch_claude_code_config() -> StepResult {
+/// .mcp.json required.
+///
+/// Since v0.3.0 the entry points directly at the aiui.app binary with
+/// `--mcp-stdio`. That eliminates the `uv`/`uvx`/`pipx` dependency from
+/// the onboarding path — the app bundle already ships the MCP server as
+/// native code.
+///
+/// Auto-migrates legacy `uvx aiui-mcp` entries from ≤ v0.2.x installs.
+pub fn patch_claude_code_config(app_binary_path: &str) -> StepResult {
     let path = home().join(".claude.json");
     let existing: Value = if path.exists() {
         match fs::read_to_string(&path) {
@@ -218,11 +225,14 @@ pub fn patch_claude_code_config() -> StepResult {
         .unwrap_or_default();
 
     let entry = serde_json::json!({
-        "command": "uvx",
-        "args": ["aiui-mcp"]
+        "command": app_binary_path,
+        "args": ["--mcp-stdio"]
     });
-    let was_present = servers.contains_key("aiui");
-    let already_correct = was_present && servers.get("aiui") == Some(&entry);
+
+    let existing_entry = servers.get("aiui");
+    let previous_kind = classify_aiui_entry(existing_entry);
+    let was_present = existing_entry.is_some();
+    let already_correct = existing_entry == Some(&entry);
     if already_correct {
         return StepResult {
             ok: true,
@@ -242,20 +252,51 @@ pub fn patch_claude_code_config() -> StepResult {
     }
     let pretty = serde_json::to_string_pretty(&Value::Object(root)).unwrap();
     match fs::write(&path, pretty) {
-        Ok(_) => StepResult {
-            ok: true,
-            message: if was_present {
-                "Updated aiui entry in ~/.claude.json".into()
-            } else {
-                "Added aiui to ~/.claude.json — available in every Claude Code session".into()
-            },
-            details: None,
-        },
+        Ok(_) => {
+            let msg = match (was_present, previous_kind) {
+                (true, Some(AiuiEntryKind::LegacyUvx)) => {
+                    "Migrated aiui in ~/.claude.json from `uvx aiui-mcp` to the native app binary — no uv dependency required anymore".into()
+                }
+                (true, _) => "Updated aiui entry in ~/.claude.json".into(),
+                (false, _) => {
+                    "Added aiui to ~/.claude.json — available in every Claude Code session".into()
+                }
+            };
+            StepResult {
+                ok: true,
+                message: msg,
+                details: None,
+            }
+        }
         Err(e) => StepResult {
             ok: false,
             message: "Writing ~/.claude.json failed".into(),
             details: Some(e.to_string()),
         },
+    }
+}
+
+enum AiuiEntryKind {
+    LegacyUvx,
+    Other,
+}
+
+fn classify_aiui_entry(entry: Option<&Value>) -> Option<AiuiEntryKind> {
+    let entry = entry?;
+    let cmd = entry.get("command").and_then(|v| v.as_str()).unwrap_or("");
+    let args = entry
+        .get("args")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if cmd == "uvx" && args.first().map(String::as_str) == Some("aiui-mcp") {
+        Some(AiuiEntryKind::LegacyUvx)
+    } else {
+        Some(AiuiEntryKind::Other)
     }
 }
 
@@ -595,4 +636,75 @@ pub fn save_remotes(list: &[String]) -> std::io::Result<()> {
         fs::create_dir_all(parent)?;
     }
     fs::write(&p, serde_json::to_string_pretty(list).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_none() {
+        assert!(classify_aiui_entry(None).is_none());
+    }
+
+    #[test]
+    fn classify_legacy_uvx() {
+        let v = serde_json::json!({"command": "uvx", "args": ["aiui-mcp"]});
+        assert!(matches!(
+            classify_aiui_entry(Some(&v)),
+            Some(AiuiEntryKind::LegacyUvx)
+        ));
+    }
+
+    #[test]
+    fn classify_legacy_uvx_with_extra_args() {
+        // Extra args after "aiui-mcp" shouldn't disqualify the entry from
+        // being recognized as legacy — first arg is the package name.
+        let v = serde_json::json!({"command": "uvx", "args": ["aiui-mcp", "--verbose"]});
+        assert!(matches!(
+            classify_aiui_entry(Some(&v)),
+            Some(AiuiEntryKind::LegacyUvx)
+        ));
+    }
+
+    #[test]
+    fn classify_native_binary_is_other() {
+        // The native binary is considered "Other" here; callers compare
+        // to the current binary path and migrate only when it differs.
+        let v = serde_json::json!({
+            "command": "/Applications/aiui.app/Contents/MacOS/aiui",
+            "args": ["--mcp-stdio"]
+        });
+        assert!(matches!(
+            classify_aiui_entry(Some(&v)),
+            Some(AiuiEntryKind::Other)
+        ));
+    }
+
+    #[test]
+    fn classify_unrelated_command() {
+        let v = serde_json::json!({"command": "python", "args": ["-m", "something"]});
+        assert!(matches!(
+            classify_aiui_entry(Some(&v)),
+            Some(AiuiEntryKind::Other)
+        ));
+    }
+
+    #[test]
+    fn classify_uvx_but_wrong_package() {
+        let v = serde_json::json!({"command": "uvx", "args": ["some-other-package"]});
+        assert!(matches!(
+            classify_aiui_entry(Some(&v)),
+            Some(AiuiEntryKind::Other)
+        ));
+    }
+
+    #[test]
+    fn classify_malformed_entry() {
+        let v = serde_json::json!({});
+        assert!(matches!(
+            classify_aiui_entry(Some(&v)),
+            Some(AiuiEntryKind::Other)
+        ));
+    }
 }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Two substantive shifts bundled into v0.3.0:

### 1. Native MCP server — goodbye uv dependency

aiui.app now ships a full MCP server as native Rust code inside the bundle. Claude Code's `~/.claude.json` points directly at the app binary with `--mcp-stdio` — no `uv`, no `uvx`, no Python toolchain on the onboarding path.

- `companion/src-tauri/src/mcp.rs`: full rewrite, 80 LoC stub → ~400 LoC MCP 2025-06-18 server with tools `confirm`, `ask`, `form`, `aiui_health`, `version`, `update` and prompts `widgets`, `update`, `version`. Dialog rendering forwards over HTTP to the existing `/render` endpoint.
- `setup.rs`: `patch_claude_code_config` writes the native entry and transparently rewrites any legacy `uvx aiui-mcp` entry from ≤ v0.2.x installs. 7 unit tests cover the classification logic.
- The Python `aiui-mcp` package stays on PyPI unchanged — it's still the correct tool for remote SSH hosts without aiui.app. `patch_claude_code_config_remote` keeps using `uvx`.

### 2. `/aiui:update` and `/aiui:version` slash-commands

- `POST /update` — triggers the updater, responds `{updated, current, available, note}` **before** scheduling a 500 ms-deferred `app.restart()` so the agent always receives the version delta.
- `GET /version` — structured build metadata.
- Two new MCP prompts (`update`, `version`) instruct the agent how to call the tools and reply concisely.

Claude Code surfaces the MCP prompts as slash-commands: `/aiui:update`, `/aiui:version`, `/aiui:widgets`.

## Version bumps

- Cargo.toml, tauri.conf.json, package.json → 0.3.0

## Test plan

- [x] `cargo test` — 15 tests pass (8 housekeeping + 7 setup classification)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `npm run check` — 0 errors
- [ ] Manual: install 0.3.0 over a running 0.2.8, verify `~/.claude.json` migrated from `uvx` to native binary
- [ ] Manual: `/aiui:version` in a fresh Claude Code session returns a clean one-liner
- [ ] Manual: `/aiui:update` while on the latest version returns "already on latest"
- [ ] Manual: install 0.3.0 DMG on a brand-new Mac without `uv` or Homebrew; verify Claude Code session immediately has aiui tools