### PR TITLE
fix(ux): updater uses message() for info dialogs instead of ask() Yes/No

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented here.
 
+## [0.3.1] — 2026-04-24
+
+### Fixed
+
+- **Update-Dialog UX.** The "you're on the latest version" info and the
+  "update check failed" warning both used `ask()` (Yes/No), producing a
+  nonsensical two-button dialog where the user had nothing to answer.
+  Switched to `message()` (single OK button) for pure-info outcomes;
+  `ask()` stays on the actual "install update?" prompt where a decision
+  is needed.
+
 ## [0.3.0] — 2026-04-24
 
 ### Added

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "aiui companion \u2014 renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.3.0"
+version = "0.3.1"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/lib/updater.ts
+++ b/companion/src/lib/updater.ts
@@ -1,6 +1,6 @@
 import { check, Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { ask } from "@tauri-apps/plugin-dialog";
+import { ask, message } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 
 /**
@@ -8,6 +8,11 @@ import { invoke } from "@tauri-apps/api/core";
  * user via a native dialog. On confirm: downloads, verifies signature, swaps,
  * relaunches. Silent if already on latest. Call from onMount of the settings
  * window, or wire to a "Check for updates" button.
+ *
+ * UX note: use `message()` (single OK button) for pure-info outcomes, and
+ * `ask()` (Yes/No) only when the user actually has a decision to make. Using
+ * `ask()` for "you're on the latest version" produces a nonsensical two-
+ * button dialog.
  */
 export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<void> {
   let update: Update | null;
@@ -15,7 +20,7 @@ export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<
     update = await check();
   } catch (e) {
     if (!opts.silent) {
-      await ask(`Update-Check fehlgeschlagen:\n${e}`, {
+      await message(`Update-Check fehlgeschlagen:\n${e}`, {
         title: "aiui",
         kind: "warning",
       });
@@ -24,7 +29,7 @@ export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<
   }
   if (!update) {
     if (!opts.silent) {
-      await ask("Du bist auf der aktuellen Version.", {
+      await message("Du bist auf der aktuellen Version.", {
         title: "aiui",
         kind: "info",
       });


### PR DESCRIPTION
## Summary

The updater's "you're on the latest version" info and the "update check failed" warning used `ask()` — a Yes/No dialog — where there's nothing to answer. User hit the nonsensical two-button prompt and called it out.

Switched to `message()` (single OK button) for pure-info outcomes. `ask()` stays on the real "install update?" prompt.

Bumps 0.3.0 → 0.3.1.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `cargo check` — clean
- [ ] Manual: click "Nach Updates suchen" while on latest version → see single-OK dialog, not Yes/No