### PR TITLE
feat(tunnel): detect shared port-7777 forwards instead of red-flagging them

### DIFF
--- a/companion/src-tauri/src/tunnel.rs
+++ b/companion/src-tauri/src/tunnel.rs
@@ -1,6 +1,17 @@
 //! SSH reverse-tunnel manager. Owns one tokio task per remote host, respawns
 //! on exit with exponential backoff, and can be cancelled per-host or
 //! globally. Status snapshot is exposed to the frontend.
+//!
+//! **Shared-forward detection.** If our `ssh -NTR` fails with
+//! `ExitOnForwardFailure`, port 7777 on the remote is already taken.
+//! Historically we flagged this as a hard failure (red dot, "ssh exit 255"),
+//! which was misleading when the occupier was a still-living sshd-sess from
+//! an earlier aiui session. In that case, the forward works — we just don't
+//! own it. We now probe the remote after a failure: if a plain
+//! `curl -sS -f -m 3 http://localhost:<port>/ping` over ssh returns `pong`,
+//! we mark the tunnel as `ConnectedShared` and poll periodically instead of
+//! retrying `-NTR` aggressively. When the probe starts failing (external
+//! session died) we drop back into the normal `ssh -NTR` retry loop.
 
 use crate::logging::trace;
 use serde::Serialize;
@@ -15,7 +26,14 @@ use tokio::sync::{oneshot, Mutex};
 pub enum TunnelStatus {
     Connecting,
     Connected,
-    Failed { reason: String },
+    /// Port 7777 on the remote is forwarded by a different process (an
+    /// earlier aiui session's sshd-sess that outlived its parent, or a
+    /// parallel tool doing the same forward). Our own `-NTR` can't bind,
+    /// but dialogs reach the Mac anyway. Periodically re-probed.
+    ConnectedShared,
+    Failed {
+        reason: String,
+    },
     Stopped,
 }
 
@@ -84,6 +102,51 @@ impl TunnelManager {
             out.insert(k.clone(), v.status.lock().await.clone());
         }
         out
+    }
+}
+
+/// Interval at which we re-probe a shared-forward remote to notice when the
+/// external occupier dies. Chosen to be fast enough that users don't stare
+/// at a stale "connected (shared)" label for long, but slow enough that we
+/// aren't ssh-ing per second.
+const SHARED_FORWARD_POLL_SECS: u64 = 30;
+
+/// Ask the remote whether localhost:`port` is already answering `/ping` from
+/// aiui. Uses ssh in batch mode + curl; no-op if either ssh or curl aren't
+/// available. Returns Some(true) on a clean `pong`, Some(false) on a clean
+/// "port is empty", None on inconclusive errors (ssh failed to connect at
+/// all — different failure mode than "port unreachable").
+async fn probe_remote_shared_forward(host: &str, port: u16) -> Option<bool> {
+    let url = format!("http://localhost:{port}/ping");
+    // -f makes curl return non-zero on 4xx/5xx; -m 3 caps the total time.
+    // We do NOT need the auth token for /ping; it's public on the companion.
+    let cmd = format!("curl -sS -f -m 3 {url} 2>/dev/null");
+    let out = Command::new("ssh")
+        .args([
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=5",
+            host,
+            &cmd,
+        ])
+        .output()
+        .await;
+    match out {
+        Ok(o) if o.status.success() => {
+            let body = String::from_utf8_lossy(&o.stdout);
+            Some(body.trim() == "pong")
+        }
+        Ok(o) => {
+            // ssh ran, curl returned non-zero (port not answering → not shared).
+            // exit 255 from ssh itself means "connection error" — distinguish.
+            if o.status.code() == Some(255) {
+                None
+            } else {
+                Some(false)
+            }
+        }
+        Err(_) => None,
     }
 }
 
@@ -162,6 +225,31 @@ async fn run_tunnel(
                     Err(e) => format!("wait error: {e}"),
                 };
                 trace(&format!("tunnel[{host}]: ssh died: {msg}"));
+
+                // Before falling into the backoff loop, check if the remote
+                // actually has our port forwarded by somebody else. If so,
+                // degrade gracefully to shared-forward polling instead of
+                // spamming `ssh -NTR` that's guaranteed to keep failing
+                // while the zombie session holds the port.
+                if let Some(true) = probe_remote_shared_forward(&host, port).await {
+                    trace(&format!(
+                        "tunnel[{host}]: shared forward detected — switching to poll mode"
+                    ));
+                    *status.lock().await = TunnelStatus::ConnectedShared;
+                    match shared_forward_poll_loop(&host, port, &status, &mut cancel_pin).await {
+                        PollOutcome::LostShare => {
+                            // External forward disappeared; drop back to the
+                            // normal `-NTR` retry path with a short backoff.
+                            backoff_secs = 1;
+                            continue;
+                        }
+                        PollOutcome::Cancelled => {
+                            *status.lock().await = TunnelStatus::Stopped;
+                            return;
+                        }
+                    }
+                }
+
                 *status.lock().await = TunnelStatus::Failed { reason: msg };
                 tokio::select! {
                     _ = tokio::time::sleep(Duration::from_secs(backoff_secs)) => {}
@@ -178,6 +266,52 @@ async fn run_tunnel(
                 let _ = child.kill().await;
                 *status.lock().await = TunnelStatus::Stopped;
                 return;
+            }
+        }
+    }
+}
+
+enum PollOutcome {
+    /// External forward is no longer answering — caller should resume the
+    /// normal `ssh -NTR` retry loop.
+    LostShare,
+    /// User asked for teardown.
+    Cancelled,
+}
+
+/// While a shared forward is active, periodically re-probe the remote to
+/// confirm it still answers. Stays in `ConnectedShared` as long as the probe
+/// succeeds. Returns on first probe failure (`LostShare`) or on cancellation.
+async fn shared_forward_poll_loop(
+    host: &str,
+    port: u16,
+    status: &Arc<Mutex<TunnelStatus>>,
+    cancel_pin: &mut std::pin::Pin<Box<oneshot::Receiver<()>>>,
+) -> PollOutcome {
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(SHARED_FORWARD_POLL_SECS)) => {
+                match probe_remote_shared_forward(host, port).await {
+                    Some(true) => continue,
+                    Some(false) => {
+                        trace(&format!(
+                            "tunnel[{host}]: shared forward gone — will re-attempt ssh -NTR"
+                        ));
+                        return PollOutcome::LostShare;
+                    }
+                    None => {
+                        // Inconclusive (ssh itself failed). Keep the label
+                        // as shared; next poll will retry. If it's really
+                        // gone, the probe will eventually return Some(false).
+                        trace(&format!(
+                            "tunnel[{host}]: shared-forward probe inconclusive, keeping state"
+                        ));
+                        let _ = status;
+                    }
+                }
+            }
+            _ = &mut *cancel_pin => {
+                return PollOutcome::Cancelled;
             }
         }
     }

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -14,6 +14,7 @@
     "remotes.remove": "Entfernen",
     "log.title": "Zuletzt",
     "tunnel.connected": "verbunden",
+    "tunnel.connected_shared": "verbunden (geteilter Forward)",
     "tunnel.connecting": "verbinde…",
     "tunnel.stopped": "gestoppt",
     "tunnel.failed": "Fehler: {reason}",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -14,6 +14,7 @@
     "remotes.remove": "Remove",
     "log.title": "Recent",
     "tunnel.connected": "connected",
+    "tunnel.connected_shared": "connected (shared forward)",
     "tunnel.connecting": "connecting…",
     "tunnel.stopped": "stopped",
     "tunnel.failed": "Failed: {reason}",

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -9,6 +9,7 @@
   type TunnelStatus =
     | { state: "connecting" }
     | { state: "connected" }
+    | { state: "connected_shared" }
     | { state: "failed"; reason: string }
     | { state: "stopped" };
   type Status = {
@@ -100,6 +101,8 @@
     switch (t.state) {
       case "connected":
         return { text: $_("settings.tunnel.connected"), tone: "ok" };
+      case "connected_shared":
+        return { text: $_("settings.tunnel.connected_shared"), tone: "ok" };
       case "connecting":
         return { text: $_("settings.tunnel.connecting"), tone: "warn" };
       case "stopped":


### PR DESCRIPTION
## Summary

Fixes the UX pain where a zombie sshd-sess (typically an earlier aiui session whose parent died but whose child forward kept running) holding port 7777 caused aiui to show a hard red "Failed: ssh exit code 255" — even though the forward actually worked, we just didn't own it.

Now: after every `ssh -NTR` exit, we probe the remote via `ssh host curl -sS -f -m 3 http://localhost:<port>/ping`. If it answers `pong`, we flip the tunnel to a new `ConnectedShared` state (green "connected (shared forward)") and poll every 30 s instead of spamming `-NTR`. When the external owner dies, we fall back to the normal retry loop.

### Changes

- `TunnelStatus::ConnectedShared` variant (Rust + TS + i18n en/de).
- Probe helper `probe_remote_shared_forward()` — ssh + curl, returns tri-state (shared / not-shared / inconclusive).
- New `shared_forward_poll_loop()` replaces the aggressive backoff loop while a share is active.
- Inconclusive probes keep the shared state (no oscillation).

### Context

The user hit this today: `customer@macmini` tunnel was red, but a stale sshd-sess from hours earlier was holding :7777. Dialogs would have rendered fine. Post-fix the label would have been green.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `npm run check` — 0 errors (8 pre-existing a11y warnings unchanged)
- [ ] Manual: start aiui while a zombie ssh -R to the remote is still holding :7777; verify label turns green "connected (shared forward)" instead of red "ssh exit code 255"
- [ ] Manual: kill the zombie ssh; verify label drops back to yellow "connecting…" then green "connected" within ~60 s

## Not released

Per user direction, PRs collect and releases are batched later.