### PR TITLE
fix: recurring update check, not just at startup (v0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented here.
 
+## [0.3.3] — 2026-04-24
+
+### Fixed
+
+- **Long-running installs now actually auto-update.** The updater only
+  ran at app startup (`onMount`), so an aiui instance that had been up
+  for hours or days silently stayed on its install version while new
+  releases shipped. Added a recurring silent check every 6 h on top of
+  the existing startup check. The call stays silent unless an update
+  is actually available.
+
 ## [0.3.2] — 2026-04-24
 
 ### Added

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "aiui companion \u2014 renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.3.2"
+version = "0.3.3"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -13,16 +13,28 @@
 
   let current = $state<DialogReq | null>(null);
 
+  // Re-check for updates every 6 h in long-running sessions. The initial
+  // startup check alone doesn't cut it: aiui lives for the whole Claude
+  // Desktop session (often multiple days), so without a periodic timer a
+  // user sitting on an outdated build never sees the prompt. Silent —
+  // `checkForUpdates` only surfaces UI when an update is actually available.
+  const UPDATE_POLL_MS = 6 * 60 * 60 * 1000;
+  let updateTimer: number | undefined;
+
   onMount(() => {
     const un = listen<DialogReq>("dialog:show", (e) => {
       current = e.payload;
     });
     window.addEventListener("keydown", onKey);
-    // Silent update check on startup — user sees nothing unless there's a new version.
+    // Startup check + recurring poll.
     void checkForUpdates({ silent: true });
+    updateTimer = window.setInterval(() => {
+      void checkForUpdates({ silent: true });
+    }, UPDATE_POLL_MS);
     return async () => {
       (await un)();
       window.removeEventListener("keydown", onKey);
+      if (updateTimer !== undefined) window.clearInterval(updateTimer);
     };
   });
 


### PR DESCRIPTION
## Summary

The updater only ran at `onMount`, so long-running aiui instances never saw newer releases. User sat on v0.3.0 while v0.3.1 and v0.3.2 shipped.

Adds a recurring silent `checkForUpdates` every 6 h. No UI unless an update is actually available. Timer cleared on unmount.

Bumps 0.3.2 → 0.3.3.

## Test plan

- [x] svelte-check: 0 errors
- [x] cargo check: clean
- [ ] Manual: install 0.3.3, wait past next scheduled interval with a newer release published, confirm prompt appears unbidden