### PR TITLE
chore: remove project-local .mcp.json (overrides users' real config)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "aiui": {
-      "command": "uvx",
-      "args": ["aiui-mcp"]
-    }
-  }
-}


### PR DESCRIPTION
Removes `.mcp.json` from the aiui repo. The file was a leftover from before aiui.app shipped publicly — back then there was no global registration and the project-scoped config helped contributors test inside the repo.

Today it actively hurts: when a user clones aiui (or works on it locally), Claude Code prefers the project's `.mcp.json` over their global `~/.claude.json`. The project file pinned `uvx aiui-mcp`, which means:

- The native Rust MCP from `/Applications/aiui.app` (with `/aiui:version`, `/aiui:update`) is never reached
- uvx happily uses whatever stale version it has cached (we just found a v0.2.0 cache hanging around — months out of date)

Anyone hacking on aiui has aiui.app installed and can rely on the global config. Anyone who needs per-project overrides can add an unstaged `.mcp.json` locally.