### PR TITLE
feat: self-healing PR1 — ack contract, composite /health, registry sweep

### DIFF
--- a/companion/src-tauri/src/ack.rs
+++ b/companion/src-tauri/src/ack.rs
@@ -1,0 +1,75 @@
+//! Generic one-shot ack registry.
+//!
+//! Hands out a unique id paired with a `oneshot::Receiver`; the responder
+//! fulfils it via `ack(id)`. Used today for `ui:ping` round-trips from
+//! `/health` to verify that the WebView event loop is still alive.
+//!
+//! Event-driven: nothing runs unless someone explicitly registers a request.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+pub struct AckRegistry {
+    pending: Mutex<HashMap<String, oneshot::Sender<()>>>,
+}
+
+impl AckRegistry {
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a new ack slot. Returns the id that the caller emits to the
+    /// frontend, plus the receiver to await with a timeout.
+    pub fn register(&self) -> (String, oneshot::Receiver<()>) {
+        let id = Uuid::new_v4().to_string();
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().unwrap().insert(id.clone(), tx);
+        (id, rx)
+    }
+
+    /// Fulfil an outstanding ack. No-op if the id is unknown (e.g. timed
+    /// out and forgotten already).
+    pub fn ack(&self, id: &str) {
+        if let Some(tx) = self.pending.lock().unwrap().remove(id) {
+            let _ = tx.send(());
+        }
+    }
+
+    /// Drop an outstanding entry without firing it. Use after a timeout so
+    /// the map cannot grow without bound under repeated WebView failures.
+    pub fn forget(&self, id: &str) {
+        self.pending.lock().unwrap().remove(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ack_resolves_receiver() {
+        let r = AckRegistry::new();
+        let (id, rx) = r.register();
+        r.ack(&id);
+        rx.blocking_recv().expect("ack should arrive");
+    }
+
+    #[test]
+    fn ack_unknown_id_is_noop() {
+        let r = AckRegistry::new();
+        r.ack("no-such-id"); // must not panic
+    }
+
+    #[test]
+    fn forget_drops_entry() {
+        let r = AckRegistry::new();
+        let (id, rx) = r.register();
+        r.forget(&id);
+        // Sender was dropped without sending — recv() now sees `Err(RecvError)`.
+        assert!(rx.blocking_recv().is_err());
+    }
+}

--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
@@ -17,8 +18,34 @@ pub struct DialogResult {
     pub result: serde_json::Value,
 }
 
+/// How long an unresolved dialog may sit in the registry before opportunistic
+/// sweep cancels it. Bound for `cargo`-controlled tweaking later.
+pub const DIALOG_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// Hard cap on concurrently registered dialogs. When exceeded, the oldest
+/// entry is evicted so the map cannot grow without bound even under bursty
+/// load.
+pub const DIALOG_HARD_CAP: usize = 16;
+
+struct PendingEntry {
+    /// Resolves the `/render` waiter once the user submits or cancels.
+    result_tx: oneshot::Sender<DialogResult>,
+    /// Resolves the per-render ack waiter the first time the frontend
+    /// confirms it received `dialog:show`. Wrapped in `Option` so we can
+    /// take it out exactly once.
+    ack_tx: Option<oneshot::Sender<()>>,
+    created_at: Instant,
+}
+
 pub struct DialogState {
-    pending: Mutex<HashMap<String, oneshot::Sender<DialogResult>>>,
+    pending: Mutex<HashMap<String, PendingEntry>>,
+}
+
+/// Live counters for `/health` and diagnostics.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DialogStats {
+    pub orphan_count: usize,
+    pub oldest_age_secs: Option<u64>,
 }
 
 impl DialogState {
@@ -28,19 +55,88 @@ impl DialogState {
         }
     }
 
-    /// Registers a new dialog and returns (id, future). The caller is
-    /// responsible for surfacing the window + emitting the dialog-show event.
-    pub fn register(&self) -> (String, oneshot::Receiver<DialogResult>) {
+    /// Registers a new dialog and returns `(id, result_rx, ack_rx)`. The
+    /// caller is responsible for surfacing the window + emitting the
+    /// `dialog:show` event.
+    ///
+    /// Performs an opportunistic sweep before insert: TTL-expired entries
+    /// are cancelled and removed, and if the hard cap would be exceeded
+    /// the oldest entry is evicted. No background reaper is needed.
+    pub fn register(
+        &self,
+    ) -> (
+        String,
+        oneshot::Receiver<DialogResult>,
+        oneshot::Receiver<()>,
+    ) {
         let id = Uuid::new_v4().to_string();
-        let (tx, rx) = oneshot::channel();
-        self.pending.lock().unwrap().insert(id.clone(), tx);
-        (id, rx)
+        let (result_tx, result_rx) = oneshot::channel();
+        let (ack_tx, ack_rx) = oneshot::channel();
+
+        let mut map = self.pending.lock().unwrap();
+
+        // Sweep TTL-expired entries.
+        let now = Instant::now();
+        let expired: Vec<String> = map
+            .iter()
+            .filter(|(_, e)| now.duration_since(e.created_at) > DIALOG_TTL)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for stale_id in expired {
+            if let Some(entry) = map.remove(&stale_id) {
+                // Cancel the waiter with the same shape `cancel()` would use.
+                let _ = entry.result_tx.send(DialogResult {
+                    id: stale_id,
+                    cancelled: true,
+                    result: serde_json::Value::Null,
+                });
+            }
+        }
+
+        // Enforce hard cap: if at-or-above limit, evict the single oldest.
+        if map.len() >= DIALOG_HARD_CAP {
+            if let Some(oldest_id) = map
+                .iter()
+                .min_by_key(|(_, e)| e.created_at)
+                .map(|(k, _)| k.clone())
+            {
+                if let Some(entry) = map.remove(&oldest_id) {
+                    let _ = entry.result_tx.send(DialogResult {
+                        id: oldest_id,
+                        cancelled: true,
+                        result: serde_json::Value::Null,
+                    });
+                }
+            }
+        }
+
+        map.insert(
+            id.clone(),
+            PendingEntry {
+                result_tx,
+                ack_tx: Some(ack_tx),
+                created_at: now,
+            },
+        );
+
+        (id, result_rx, ack_rx)
+    }
+
+    /// Marks the dialog with `id` as having been received by the frontend.
+    /// Idempotent: the second call is a silent no-op (oneshot already sent).
+    pub fn ack(&self, id: &str) {
+        let mut map = self.pending.lock().unwrap();
+        if let Some(entry) = map.get_mut(id) {
+            if let Some(tx) = entry.ack_tx.take() {
+                let _ = tx.send(());
+            }
+        }
     }
 
     pub fn complete(&self, id: &str, result: serde_json::Value) {
-        let sender = self.pending.lock().unwrap().remove(id);
-        if let Some(sender) = sender {
-            let _ = sender.send(DialogResult {
+        let entry = self.pending.lock().unwrap().remove(id);
+        if let Some(entry) = entry {
+            let _ = entry.result_tx.send(DialogResult {
                 id: id.to_string(),
                 cancelled: false,
                 result,
@@ -49,13 +145,93 @@ impl DialogState {
     }
 
     pub fn cancel(&self, id: &str) {
-        let sender = self.pending.lock().unwrap().remove(id);
-        if let Some(sender) = sender {
-            let _ = sender.send(DialogResult {
+        let entry = self.pending.lock().unwrap().remove(id);
+        if let Some(entry) = entry {
+            let _ = entry.result_tx.send(DialogResult {
                 id: id.to_string(),
                 cancelled: true,
                 result: serde_json::Value::Null,
             });
         }
+    }
+
+    /// Snapshot for `/health` / diagnostics. Cheap: one mutex acquire.
+    pub fn stats(&self) -> DialogStats {
+        let map = self.pending.lock().unwrap();
+        if map.is_empty() {
+            return DialogStats::default();
+        }
+        let now = Instant::now();
+        let oldest = map
+            .values()
+            .map(|e| now.duration_since(e.created_at))
+            .max()
+            .map(|d| d.as_secs());
+        DialogStats {
+            orphan_count: map.len(),
+            oldest_age_secs: oldest,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_inserts_entry() {
+        let s = DialogState::new();
+        let (id, _rx, _ack) = s.register();
+        assert!(!id.is_empty());
+        assert_eq!(s.stats().orphan_count, 1);
+    }
+
+    #[test]
+    fn complete_resolves_and_removes() {
+        let s = DialogState::new();
+        let (id, rx, _ack) = s.register();
+        s.complete(&id, serde_json::json!({"ok": true}));
+        let r = rx.blocking_recv().unwrap();
+        assert!(!r.cancelled);
+        assert_eq!(s.stats().orphan_count, 0);
+    }
+
+    #[test]
+    fn cancel_resolves_and_removes() {
+        let s = DialogState::new();
+        let (id, rx, _ack) = s.register();
+        s.cancel(&id);
+        let r = rx.blocking_recv().unwrap();
+        assert!(r.cancelled);
+        assert_eq!(s.stats().orphan_count, 0);
+    }
+
+    #[test]
+    fn ack_fires_once() {
+        let s = DialogState::new();
+        let (id, _rx, ack) = s.register();
+        s.ack(&id);
+        let _ = ack.blocking_recv().expect("first ack must arrive");
+        // Second ack on the same id is a silent no-op.
+        s.ack(&id);
+    }
+
+    #[test]
+    fn hard_cap_evicts_oldest() {
+        let s = DialogState::new();
+        let mut rxs = Vec::new();
+        for _ in 0..DIALOG_HARD_CAP {
+            let (_id, rx, _ack) = s.register();
+            rxs.push(rx);
+        }
+        assert_eq!(s.stats().orphan_count, DIALOG_HARD_CAP);
+
+        // One more — should evict the oldest.
+        let (_id, _rx, _ack) = s.register();
+        assert_eq!(s.stats().orphan_count, DIALOG_HARD_CAP);
+
+        // The first registered receiver should now resolve as cancelled.
+        let first = rxs.remove(0).blocking_recv().unwrap();
+        assert!(first.cancelled);
     }
 }

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -1,5 +1,7 @@
+use crate::ack::AckRegistry;
 use crate::config::AppConfig;
 use crate::dialog::{DialogRequest, DialogState};
+use crate::lifetime::LifetimeStats;
 use axum::{
     extract::State,
     http::{HeaderMap, StatusCode},
@@ -15,10 +17,25 @@ use crate::logging::trace;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::UpdaterExt;
 
+/// How long the `/render` handler waits for the frontend to acknowledge
+/// receipt of `dialog:show` before concluding the WebView event loop is
+/// dead and triggering a reload.
+const DIALOG_ACK_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Pause after `webview.reload()` before re-emitting `dialog:show`. Gives
+/// the freshly-loaded Svelte app time to mount and register its listener.
+const RELOAD_SETTLE: Duration = Duration::from_millis(300);
+
+/// How long `/health` waits for a `ui:ping` round-trip from the frontend
+/// before concluding the WebView is unresponsive.
+const UI_PING_TIMEOUT: Duration = Duration::from_millis(100);
+
 #[derive(Clone)]
 struct AppState {
     cfg: Arc<AppConfig>,
     dialog: Arc<DialogState>,
+    ui_acks: Arc<AckRegistry>,
+    lifetime: Arc<LifetimeStats>,
     app: AppHandle,
 }
 
@@ -36,10 +53,39 @@ struct RenderResponse {
     result: serde_json::Value,
 }
 
+/// Composite health response. `ready` is true only when every sub-check is
+/// healthy; otherwise the response gives the caller enough detail to act on
+/// the specific failure (WebView frozen vs. registry overloaded vs. too many
+/// child processes, etc.).
 #[derive(Serialize)]
 struct HealthResponse {
     version: String,
     ready: bool,
+    webview: WebviewHealth,
+    dialogs: DialogHealth,
+    children: ChildrenHealth,
+}
+
+#[derive(Serialize)]
+struct WebviewHealth {
+    /// `true` if the Svelte app answered a `ui:ping` within the timeout.
+    responsive: bool,
+    /// Round-trip duration in milliseconds; `None` if the ping timed out.
+    rtt_ms: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct DialogHealth {
+    /// Currently-pending dialogs in the registry.
+    pending: usize,
+    /// Age of the oldest pending dialog in seconds; `None` if registry empty.
+    oldest_age_secs: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct ChildrenHealth {
+    /// MCP-stdio children currently attached to the lifetime socket.
+    attached: usize,
 }
 
 #[derive(Serialize)]
@@ -62,10 +108,18 @@ struct UpdateResponse {
 pub async fn serve(
     cfg: Arc<AppConfig>,
     dialog: Arc<DialogState>,
+    ui_acks: Arc<AckRegistry>,
+    lifetime: Arc<LifetimeStats>,
     app: AppHandle,
 ) -> std::io::Result<()> {
     let port = cfg.http_port;
-    let state = AppState { cfg, dialog, app };
+    let state = AppState {
+        cfg,
+        dialog,
+        ui_acks,
+        lifetime,
+        app,
+    };
 
     let router = Router::new()
         .route("/health", get(health))
@@ -99,17 +153,80 @@ fn auth_ok(headers: &HeaderMap, token: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Composite health check. Probes the WebView event loop with a `ui:ping`
+/// round-trip, reads live counters from the dialog registry and lifetime
+/// tracker, and reports `ready` only when all three are healthy. Computed
+/// on-demand — there is no background task maintaining a "current health"
+/// state, so an idle companion does no liveness work whatsoever.
 async fn health(
     State(state): State<AppState>,
     headers: HeaderMap,
-) -> Result<Json<HealthResponse>, StatusCode> {
+) -> impl IntoResponse {
     if !auth_ok(&headers, &state.cfg.token) {
-        return Err(StatusCode::UNAUTHORIZED);
+        return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({"error":"unauthorized"})))
+            .into_response();
     }
-    Ok(Json(HealthResponse {
+
+    let webview = probe_webview(&state).await;
+    let dialog_stats = state.dialog.stats();
+    let attached = state.lifetime.child_count();
+
+    let dialogs = DialogHealth {
+        pending: dialog_stats.orphan_count,
+        oldest_age_secs: dialog_stats.oldest_age_secs,
+    };
+    let children = ChildrenHealth { attached };
+
+    // Ready criterion: WebView answers, no orphan-dialog backlog, and we
+    // aren't drowning in attached children. Thresholds are intentionally
+    // loose — anything tighter belongs in a separate metric, not in the
+    // ready/not-ready gate.
+    let ready = webview.responsive
+        && dialog_stats.orphan_count <= crate::dialog::DIALOG_HARD_CAP
+        && attached < 32;
+
+    let body = HealthResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
-        ready: true,
-    }))
+        ready,
+        webview,
+        dialogs,
+        children,
+    };
+
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, Json(body)).into_response()
+}
+
+/// Round-trip a `ui:ping` event through the frontend and back via the
+/// `ui_pong` Tauri command. Returns the observed RTT, or `None` on timeout.
+async fn probe_webview(state: &AppState) -> WebviewHealth {
+    let (id, rx) = state.ui_acks.register();
+    let started = std::time::Instant::now();
+    if let Err(e) = state.app.emit("ui:ping", &id) {
+        trace(&format!("health: emit ui:ping failed: {e}"));
+        state.ui_acks.forget(&id);
+        return WebviewHealth {
+            responsive: false,
+            rtt_ms: None,
+        };
+    }
+    match tokio::time::timeout(UI_PING_TIMEOUT, rx).await {
+        Ok(Ok(())) => WebviewHealth {
+            responsive: true,
+            rtt_ms: Some(started.elapsed().as_millis() as u64),
+        },
+        _ => {
+            state.ui_acks.forget(&id);
+            WebviewHealth {
+                responsive: false,
+                rtt_ms: None,
+            }
+        }
+    }
 }
 
 async fn version(
@@ -243,39 +360,83 @@ async fn render(
     };
     trace(&format!("render: auth ok, spec={}", req.spec));
 
-    let (id, rx) = state.dialog.register();
+    let (id, result_rx, ack_rx) = state.dialog.register();
     trace(&format!("render: registered id={}", id));
     let dr = DialogRequest {
         id: id.clone(),
         spec: req.spec,
     };
 
-    // Surface the window from the main thread
-    let app_for_show = state.app.clone();
-    let id_for_log = id.clone();
-    let rc = app_for_show.clone().run_on_main_thread(move || {
-        trace(&format!("render: main-thread callback id={}", id_for_log));
-        if let Some(win) = app_for_show.get_webview_window("main") {
-            trace("render: main-thread got window, calling show()");
-            let _ = win.show();
-            let _ = win.set_focus();
-            let _ = win.unminimize();
-            trace("render: main-thread show() returned");
-        } else {
-            trace("render: main-thread window MISSING");
-        }
-    });
-    trace(&format!("render: run_on_main_thread returned {:?}", rc.is_ok()));
+    // Surface the window from the main thread.
+    surface_main_window(&state.app, &id);
 
-    // Emit the dialog to the frontend
-    match state.app.emit("dialog:show", &dr) {
-        Ok(_) => trace(&format!("render: emitted dialog:show id={}", id)),
-        Err(e) => trace(&format!("render: emit FAILED: {e}")),
+    // Emit the dialog to the frontend.
+    if let Err(e) = state.app.emit("dialog:show", &dr) {
+        trace(&format!("render: emit FAILED: {e}"));
+    } else {
+        trace(&format!("render: emitted dialog:show id={}", id));
     }
 
+    // ── Ack-Contract ────────────────────────────────────────────────────
+    // Wait briefly for the frontend to confirm receipt. If no ack arrives,
+    // the WebView event loop is most likely dead — try to revive it by
+    // reloading the webview, then re-emitting once. If the second ack also
+    // fails, give up and surface a structured error to the caller instead
+    // of blocking indefinitely on a dialog the user will never see.
+    match tokio::time::timeout(DIALOG_ACK_TIMEOUT, ack_rx).await {
+        Ok(Ok(())) => {
+            trace(&format!("render: ack ok id={}", id));
+        }
+        _ => {
+            trace(&format!(
+                "render: no ack within {:?}; reloading webview and retrying",
+                DIALOG_ACK_TIMEOUT
+            ));
+            reload_main_webview(&state.app);
+            tokio::time::sleep(RELOAD_SETTLE).await;
+
+            // After reload the previous ack receiver was consumed. We need a
+            // fresh handshake on the same dialog id — register a new ack
+            // slot tied to the same id is overkill; instead we just re-emit
+            // and wait on the same (already-armed) ack registry by treating
+            // the second emit's resolution as the ack we care about.
+            //
+            // Since `register()` only created one ack channel and we just
+            // consumed its receiver via the timeout, we have to fall back
+            // to a small generic ack via the AckRegistry for the second
+            // round. That keeps DialogState simple.
+            let (probe_id, probe_rx) = state.ui_acks.register();
+            if let Err(e) = state.app.emit("ui:ping", &probe_id) {
+                trace(&format!("render: post-reload ui:ping emit failed: {e}"));
+                state.ui_acks.forget(&probe_id);
+            }
+            match tokio::time::timeout(DIALOG_ACK_TIMEOUT, probe_rx).await {
+                Ok(Ok(())) => {
+                    trace("render: post-reload webview is responsive, re-emitting dialog:show");
+                    if let Err(e) = state.app.emit("dialog:show", &dr) {
+                        trace(&format!("render: re-emit FAILED: {e}"));
+                    }
+                }
+                _ => {
+                    state.ui_acks.forget(&probe_id);
+                    trace("render: webview still unreachable after reload — giving up");
+                    state.dialog.cancel(&id);
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Json(serde_json::json!({
+                            "error": "ui_unreachable",
+                            "detail": "webview did not acknowledge dialog:show after reload",
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+    }
+
+    // ── Normal path ─────────────────────────────────────────────────────
     trace(&format!("render: awaiting user response id={}", id));
-    // Wait for user to submit or cancel
-    let result = match rx.await {
+    let result = match result_rx.await {
         Ok(r) => r,
         Err(_) => crate::dialog::DialogResult {
             id: id.clone(),
@@ -294,4 +455,45 @@ async fn render(
         result: result.result,
     })
     .into_response()
+}
+
+/// Bring the main webview window to the front from any thread. All Tauri
+/// window operations have to run on the main thread, so we hop there via
+/// `run_on_main_thread`.
+fn surface_main_window(app: &AppHandle, id: &str) {
+    let app_for_show = app.clone();
+    let id_for_log = id.to_string();
+    let rc = app.clone().run_on_main_thread(move || {
+        trace(&format!("render: main-thread callback id={}", id_for_log));
+        if let Some(win) = app_for_show.get_webview_window("main") {
+            trace("render: main-thread got window, calling show()");
+            let _ = win.show();
+            let _ = win.set_focus();
+            let _ = win.unminimize();
+            trace("render: main-thread show() returned");
+        } else {
+            trace("render: main-thread window MISSING");
+        }
+    });
+    trace(&format!("render: run_on_main_thread returned {:?}", rc.is_ok()));
+}
+
+/// Reload the main webview to recover from a stuck JS event loop. Tears
+/// down the JS side (DOM, listeners, setIntervals) and re-runs the Svelte
+/// app from scratch — Tauri's `webview.reload()` is exactly this. We use
+/// it as the recreate path because it's lighter than destroying and
+/// rebuilding the window via `WebviewWindowBuilder` and recovers from the
+/// same class of failure.
+fn reload_main_webview(app: &AppHandle) {
+    let app_for_reload = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        if let Some(win) = app_for_reload.get_webview_window("main") {
+            trace("render: reloading main webview");
+            if let Err(e) = win.eval("location.reload()") {
+                trace(&format!("render: reload eval failed: {e}"));
+            }
+        } else {
+            trace("render: reload requested but main window is MISSING");
+        }
+    });
 }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod ack;
 mod config;
 mod dialog;
 mod housekeeping;
@@ -28,6 +29,29 @@ fn dialog_cancel(
     id: String,
 ) -> Result<(), String> {
     state.cancel(&id);
+    Ok(())
+}
+
+/// Frontend confirms it received the matching `dialog:show` event. The
+/// `/render` handler waits up to 500 ms for this before assuming the WebView
+/// event loop is dead and triggering a recreate.
+#[tauri::command]
+fn dialog_received(
+    state: tauri::State<'_, Arc<dialog::DialogState>>,
+    id: String,
+) -> Result<(), String> {
+    state.ack(&id);
+    Ok(())
+}
+
+/// Frontend response to a `ui:ping` event from `/health`. Same shape as
+/// `dialog_received` but routed to the generic ack registry.
+#[tauri::command]
+fn ui_pong(
+    state: tauri::State<'_, Arc<ack::AckRegistry>>,
+    id: String,
+) -> Result<(), String> {
+    state.ack(&id);
     Ok(())
 }
 
@@ -224,6 +248,8 @@ pub fn run_mcp_stdio_only() {
 pub fn run() {
     let cfg = Arc::new(config::AppConfig::load_or_init().expect("config init"));
     let dialog_state = Arc::new(dialog::DialogState::new());
+    let ui_acks = Arc::new(ack::AckRegistry::new());
+    let lifetime_stats = Arc::new(lifetime::LifetimeStats::new());
     let tunnel_mgr = tunnel::TunnelManager::new(cfg.http_port);
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -251,10 +277,14 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .manage(cfg.clone())
         .manage(dialog_state.clone())
+        .manage(ui_acks.clone())
+        .manage(lifetime_stats.clone())
         .manage(tunnel_mgr.clone())
         .invoke_handler(tauri::generate_handler![
             dialog_submit,
             dialog_cancel,
+            dialog_received,
+            ui_pong,
             close_window,
             surface_for_dialog,
             status,
@@ -268,6 +298,9 @@ pub fn run() {
             let cfg_http = cfg.clone();
             let cfg_lt = cfg.clone();
             let ds_http = dialog_state.clone();
+            let ui_acks_http = ui_acks.clone();
+            let lifetime_http = lifetime_stats.clone();
+            let lifetime_lt = lifetime_stats.clone();
             let app_handle_http = app_handle.clone();
             let app_handle_lt = app_handle.clone();
 
@@ -308,15 +341,24 @@ pub fn run() {
 
             // HTTP server on localhost:7777.
             rt.spawn(async move {
-                if let Err(e) = http::serve(cfg_http, ds_http, app_handle_http).await {
+                if let Err(e) = http::serve(
+                    cfg_http,
+                    ds_http,
+                    ui_acks_http,
+                    lifetime_http,
+                    app_handle_http,
+                )
+                .await
+                {
                     log::error!("[aiui] http server error: {e}");
                 }
             });
 
             // Lifetime socket — couples GUI lifetime to MCP-stdio children.
+            // Counter is shared with `/health` via `LifetimeStats`.
             rt.spawn(async move {
                 let sock = lifetime::socket_path(&cfg_lt.config_dir);
-                lifetime::gui_serve(sock, app_handle_lt).await;
+                lifetime::gui_serve(sock, app_handle_lt, lifetime_lt.conns.clone()).await;
             });
 
             // Auto-start reverse tunnels for every registered remote.

--- a/companion/src-tauri/src/lifetime.rs
+++ b/companion/src-tauri/src/lifetime.rs
@@ -24,9 +24,30 @@ pub fn socket_path(config_dir: &std::path::Path) -> PathBuf {
     config_dir.join("gui.sock")
 }
 
+/// Live counter of currently-attached MCP-stdio children. Owned by the Tauri
+/// app via `manage()` and read by `/health` to surface child count in the
+/// composite-health response.
+pub struct LifetimeStats {
+    pub conns: Arc<AtomicUsize>,
+}
+
+impl LifetimeStats {
+    pub fn new() -> Self {
+        Self {
+            conns: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn child_count(&self) -> usize {
+        self.conns.load(Ordering::SeqCst)
+    }
+}
+
 /// GUI-side: bind the socket, accept connections, and self-terminate after a
-/// grace period once all clients are gone.
-pub async fn gui_serve(sock: PathBuf, app: AppHandle) {
+/// grace period once all clients are gone. Increments/decrements the shared
+/// `conns` counter on every connect/disconnect so `/health` can report the
+/// live child count without polling.
+pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
     let _ = std::fs::remove_file(&sock);
     let listener = match UnixListener::bind(&sock) {
         Ok(l) => l,
@@ -37,7 +58,6 @@ pub async fn gui_serve(sock: PathBuf, app: AppHandle) {
     };
     trace(&format!("lifetime: listening on {}", sock.display()));
 
-    let conns = Arc::new(AtomicUsize::new(0));
     let wake = Arc::new(Notify::new());
 
     // Shutdown watcher — armed every time conns hits 0.

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -18,13 +18,28 @@
   // Desktop session (often multiple days), so without a periodic timer a
   // user sitting on an outdated build never sees the prompt. Silent —
   // `checkForUpdates` only surfaces UI when an update is actually available.
+  // (Issue #42 will replace this with lifecycle-driven checks; kept here
+  // for now so behavior doesn't regress before that PR lands.)
   const UPDATE_POLL_MS = 6 * 60 * 60 * 1000;
   let updateTimer: number | undefined;
 
   onMount(() => {
-    const un = listen<DialogReq>("dialog:show", (e) => {
+    // Dialog event from Rust. We acknowledge receipt back to the Rust side
+    // immediately so the `/render` handler knows the WebView event loop is
+    // alive — this is the per-request liveness check that replaces the
+    // need for any background UI heartbeat.
+    const unDialog = listen<DialogReq>("dialog:show", (e) => {
       current = e.payload;
+      void invoke("dialog_received", { id: e.payload.id });
     });
+
+    // UI ping from Rust (used by /health to verify the event loop). We
+    // pong back synchronously — the Rust side has a 100 ms timeout and a
+    // missed pong is what flips /health to `degraded`.
+    const unPing = listen<string>("ui:ping", (e) => {
+      void invoke("ui_pong", { id: e.payload });
+    });
+
     window.addEventListener("keydown", onKey);
     // Startup check + recurring poll.
     void checkForUpdates({ silent: true });
@@ -32,7 +47,8 @@
       void checkForUpdates({ silent: true });
     }, UPDATE_POLL_MS);
     return async () => {
-      (await un)();
+      (await unDialog)();
+      (await unPing)();
       window.removeEventListener("keydown", onKey);
       if (updateTimer !== undefined) window.clearInterval(updateTimer);
     };


### PR DESCRIPTION
## Summary
Closes the class of failure observed on 2026-04-25 where the GUI process stayed alive 15h+ but the WebView event loop went silent: every /render call blocked indefinitely while /health kept returning \`ready\`. None of the changes introduce idle background work — every check fires on a real cause.

Implements #37, #38, #39. Tracked under #43. RFC: \`docs/architecture/self-healing.md\` (PR #44).

### #39 — Opportunistic Dialog-Registry-Sweep
- \`DialogState\` trägt jetzt \`created_at: Instant\` pro Eintrag.
- \`register()\` macht vor Insert einen Sweep über TTL-Expired (5min) und enforced ein Hard-Cap (16).
- Kein Reaper-Task. Cleanup als Side-Effect jeder neuen Aktion.
- Neue \`stats()\`-Methode für \`/health\`.

### #37 — Per-Render Ack-Contract + WebView-Reload
- Nach \`emit(\"dialog:show\")\` wartet der Handler 500ms auf \`dialog_received(id)\` vom Frontend.
- Kein Ack ⇒ \`location.reload()\` via Tauri-eval auf der Main-Thread, dann generisches \`ui:ping\` als Probe.
- Zweites Ack-Failure ⇒ strukturierter \`ui_unreachable\`-503-Fehler statt Hang.
- Steady-State-Last: null. Check läuft nur bei echtem Render.

### #38 — Composite /health, Lazy Compute
- \`/health\` ist jetzt eine Frage, nicht ein gehaltener State.
- Beim Call: \`ui:ping\`-Roundtrip (100ms Timeout), Dialog-Registry-Stats, Lifetime-Child-Count.
- \`ready=true\` nur wenn alle drei sane. Sonst 503 mit Sub-Feldern (\`webview\`, \`dialogs\`, \`children\`).
- \"Health grün, App tot\" ist damit strukturell unmöglich.

## Architectural Bits Added
- \`ack::AckRegistry\` — generisches one-shot ack primitive, backs \`ui:ping\` und Post-Reload-Probe.
- \`lifetime::LifetimeStats\` — exposeed conns-Counter so \`/health\` ihn lesen kann.
- Tauri-Commands: \`dialog_received\`, \`ui_pong\`.
- Frontend (\`App.svelte\`): listener für \`ui:ping\`, \`dialog_received\`-Invoke nach jedem \`dialog:show\`.

## Out of Scope (für PR2)
- Async \`/render\` mit TTL (#36) — bleibt synchron in dieser PR.
- Edge-driven mcp-stdio child tracking (#40).
- Idle-Restart on natural occasion (#41).
- Lifecycle-getriggerter Update-Check (#42) — der 6h-\`setInterval\` bleibt vorerst.

## Test Plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo test\` — 23 passing (inkl. neue \`DialogState\`- und \`AckRegistry\`-Tests)
- [x] \`npm run build\` — Svelte-Frontend baut
- [ ] Manuell: aiui-App neu bauen, einen Render auslösen, Ack-Pfad im Trace verifizieren
- [ ] Manuell: \`/health\`-Roundtrip mit gesundem WebView (\`ready=true\`)
- [ ] Manuell: WebView via DevTools-Pause \"einfrieren\", Render erneut auslösen, Reload-Pfad triggert

🤖 Generated with [Claude Code](https://claude.com/claude-code)