### PR TITLE
feat: self-healing PR2 — render TTL, idle-restart, lifecycle update-check

### DIFF
--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -211,7 +211,7 @@ mod tests {
         let s = DialogState::new();
         let (id, _rx, ack) = s.register();
         s.ack(&id);
-        let _ = ack.blocking_recv().expect("first ack must arrive");
+        ack.blocking_recv().expect("first ack must arrive");
         // Second ack on the same id is a silent no-op.
         s.ack(&id);
     }

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -1,6 +1,6 @@
 use crate::ack::AckRegistry;
 use crate::config::AppConfig;
-use crate::dialog::{DialogRequest, DialogState};
+use crate::dialog::{DialogRequest, DialogState, DIALOG_TTL};
 use crate::lifetime::LifetimeStats;
 use axum::{
     extract::State,
@@ -11,8 +11,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use crate::logging::trace;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_updater::UpdaterExt;
@@ -30,6 +30,16 @@ const RELOAD_SETTLE: Duration = Duration::from_millis(300);
 /// before concluding the WebView is unresponsive.
 const UI_PING_TIMEOUT: Duration = Duration::from_millis(100);
 
+/// Idle-restart trigger: if the GUI has been alive longer than this AND
+/// hasn't served a render recently (see `IDLE_RESTART_QUIET`), the next
+/// render reloads the WebView before showing — flushes any drift that
+/// accumulated while nobody was watching.
+const IDLE_RESTART_UPTIME: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Minimum time between renders for the long-uptime reload to trigger.
+/// Prevents reloading mid-burst when many renders fire close together.
+const IDLE_RESTART_QUIET: Duration = Duration::from_secs(10 * 60);
+
 #[derive(Clone)]
 struct AppState {
     cfg: Arc<AppConfig>,
@@ -37,6 +47,13 @@ struct AppState {
     ui_acks: Arc<AckRegistry>,
     lifetime: Arc<LifetimeStats>,
     app: AppHandle,
+    /// Process-start timestamp for the GUI. Used to evaluate the
+    /// idle-restart condition without requiring an OS sleep/wake hook.
+    started_at: Instant,
+    /// Last time `/render` produced (or attempted to produce) a dialog.
+    /// Mutex<Instant> is fine here — contention is bounded by the rate of
+    /// /render calls.
+    last_render_at: Arc<Mutex<Instant>>,
 }
 
 #[derive(Deserialize)]
@@ -113,12 +130,15 @@ pub async fn serve(
     app: AppHandle,
 ) -> std::io::Result<()> {
     let port = cfg.http_port;
+    let now = Instant::now();
     let state = AppState {
         cfg,
         dialog,
         ui_acks,
         lifetime,
         app,
+        started_at: now,
+        last_render_at: Arc::new(Mutex::new(now)),
     };
 
     let router = Router::new()
@@ -367,6 +387,30 @@ async fn render(
         spec: req.spec,
     };
 
+    // ── Idle-restart check (#41) ────────────────────────────────────────
+    // If the GUI has been up for a long time and the last render was a
+    // while ago, reload the WebView before serving this one. Catches
+    // accumulated drift (sleep/wake artefacts, stuck event listeners)
+    // *exactly* when it would matter — not on a wall-clock timer.
+    {
+        let last = *state.last_render_at.lock().unwrap();
+        if state.started_at.elapsed() > IDLE_RESTART_UPTIME
+            && last.elapsed() > IDLE_RESTART_QUIET
+        {
+            trace(&format!(
+                "render: idle-restart trigger (uptime {:?}, last_render {:?} ago)",
+                state.started_at.elapsed(),
+                last.elapsed()
+            ));
+            reload_main_webview(&state.app);
+            tokio::time::sleep(RELOAD_SETTLE).await;
+        }
+    }
+
+    // Mark this render attempt — done early so the ack/recreate path
+    // still resets the idle clock even if the user closes the dialog.
+    *state.last_render_at.lock().unwrap() = Instant::now();
+
     // Surface the window from the main thread.
     surface_main_window(&state.app, &id);
 
@@ -435,19 +479,49 @@ async fn render(
     }
 
     // ── Normal path ─────────────────────────────────────────────────────
+    // Wait for the user's submit/cancel — but bounded by `DIALOG_TTL`. A
+    // dialog that nobody answers eventually returns a structured timeout
+    // instead of blocking the caller indefinitely (#36). The same TTL is
+    // used by the registry's opportunistic sweep, so a timed-out entry
+    // gets cancelled regardless of whether this awaiter or the next
+    // `register()` call notices first.
     trace(&format!("render: awaiting user response id={}", id));
-    let result = match result_rx.await {
-        Ok(r) => r,
-        Err(_) => crate::dialog::DialogResult {
+    let result = match tokio::time::timeout(DIALOG_TTL, result_rx).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(_)) => crate::dialog::DialogResult {
             id: id.clone(),
             cancelled: true,
             result: serde_json::Value::Null,
         },
+        Err(_) => {
+            // TTL expired without user response. Cancel the registry
+            // entry (also frees its slot) and return a structured timeout.
+            trace(&format!("render: TTL expired id={}", id));
+            state.dialog.cancel(&id);
+            return (
+                StatusCode::REQUEST_TIMEOUT,
+                Json(serde_json::json!({
+                    "id": id,
+                    "cancelled": true,
+                    "error": "timeout",
+                    "detail": format!("no user response within {:?}", DIALOG_TTL),
+                })),
+            )
+                .into_response();
+        }
     };
     trace(&format!(
         "render: got response id={} cancelled={}",
         result.id, result.cancelled
     ));
+
+    // Lifecycle-driven update check (#42): fire once after every
+    // successful render. Frontend gates with a 30-min cooldown so this is
+    // never noisier than the old 6h timer in active use, and zero load
+    // when nobody is talking to aiui.
+    if let Err(e) = state.app.emit("update:check", "post-render") {
+        trace(&format!("render: emit update:check failed: {e}"));
+    }
 
     Json(RenderResponse {
         id: result.id,

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -43,8 +43,18 @@ parsed from `build_info` (format \"v{ver} (commit, yyyy-mm-dd)\"). If the \
 user asked for more, include the binary path and updater endpoint.
 ";
 
+/// How long mcp-stdio waits for *any* incoming line before assuming the
+/// parent process has gone silent and exiting. This is an event-driven
+/// deadline that resets on activity — equivalent to "no input for 6 h ⇒
+/// exit", with zero idle cost. Catches the failure mode where Claude
+/// Desktop forgets to close our stdin pipe but also never sends another
+/// request, which is how stale mcp-stdio children accumulated in the
+/// 2026-04-25 incident.
+const STDIN_IDLE_LIMIT: std::time::Duration = std::time::Duration::from_secs(6 * 60 * 60);
+
 /// Top-level entry: read JSON-RPC messages from stdin, dispatch to handlers,
-/// write responses to stdout. Runs until stdin closes.
+/// write responses to stdout. Runs until stdin closes or the idle deadline
+/// expires.
 pub async fn run_stdio(cfg: Arc<AppConfig>) {
     let stdin = tokio::io::stdin();
     let mut reader = BufReader::new(stdin).lines();
@@ -56,7 +66,28 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
 
     trace("mcp-stdio: run_stdio entered");
 
-    while let Ok(Some(line)) = reader.next_line().await {
+    loop {
+        let line = tokio::select! {
+            res = reader.next_line() => match res {
+                Ok(Some(l)) => l,
+                Ok(None) => {
+                    trace("mcp-stdio: stdin closed, exiting");
+                    return;
+                }
+                Err(e) => {
+                    trace(&format!("mcp-stdio: stdin error: {e}, exiting"));
+                    return;
+                }
+            },
+            _ = tokio::time::sleep(STDIN_IDLE_LIMIT) => {
+                trace(&format!(
+                    "mcp-stdio: no input for {:?}, parent likely gone, exiting",
+                    STDIN_IDLE_LIMIT
+                ));
+                return;
+            }
+        };
+
         let Ok(msg) = serde_json::from_str::<Value>(&line) else {
             continue;
         };
@@ -83,8 +114,6 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
             .await;
         let _ = stdout.flush().await;
     }
-
-    trace("mcp-stdio: stdin closed, exiting");
 }
 
 struct RpcError {

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -13,15 +13,28 @@
 
   let current = $state<DialogReq | null>(null);
 
-  // Re-check for updates every 6 h in long-running sessions. The initial
-  // startup check alone doesn't cut it: aiui lives for the whole Claude
-  // Desktop session (often multiple days), so without a periodic timer a
-  // user sitting on an outdated build never sees the prompt. Silent —
-  // `checkForUpdates` only surfaces UI when an update is actually available.
-  // (Issue #42 will replace this with lifecycle-driven checks; kept here
-  // for now so behavior doesn't regress before that PR lands.)
-  const UPDATE_POLL_MS = 6 * 60 * 60 * 1000;
-  let updateTimer: number | undefined;
+  // Update checks are lifecycle-driven, not interval-driven. Triggers:
+  //  • on mount (initial check at GUI start),
+  //  • on `update:check` event from Rust (fired after each successful
+  //    render — clusters around real user activity),
+  //  • on window focus (covers wake-from-sleep and "user came back to the
+  //    Mac" without needing an OS-level event hook).
+  // A 30-minute cooldown debounces bursts so a chatty session doesn't
+  // hammer the GitHub release endpoint.
+  const UPDATE_COOLDOWN_MS = 30 * 60 * 1000;
+  let lastUpdateCheck = 0;
+
+  function maybeCheckForUpdates(reason: string) {
+    const now = Date.now();
+    if (now - lastUpdateCheck < UPDATE_COOLDOWN_MS) return;
+    lastUpdateCheck = now;
+    console.debug(`[aiui] update check (${reason})`);
+    void checkForUpdates({ silent: true });
+  }
+
+  function onFocus() {
+    maybeCheckForUpdates("window-focus");
+  }
 
   onMount(() => {
     // Dialog event from Rust. We acknowledge receipt back to the Rust side
@@ -40,17 +53,25 @@
       void invoke("ui_pong", { id: e.payload });
     });
 
+    // Update-check trigger from Rust — fired after each successful render.
+    // Frontend gates with the cooldown so we don't actually hit GitHub on
+    // every render.
+    const unUpdate = listen<string>("update:check", (e) => {
+      maybeCheckForUpdates(`rust:${e.payload}`);
+    });
+
     window.addEventListener("keydown", onKey);
-    // Startup check + recurring poll.
-    void checkForUpdates({ silent: true });
-    updateTimer = window.setInterval(() => {
-      void checkForUpdates({ silent: true });
-    }, UPDATE_POLL_MS);
+    window.addEventListener("focus", onFocus);
+
+    // Initial check on mount.
+    maybeCheckForUpdates("startup");
+
     return async () => {
       (await unDialog)();
       (await unPing)();
+      (await unUpdate)();
       window.removeEventListener("keydown", onKey);
-      if (updateTimer !== undefined) window.clearInterval(updateTimer);
+      window.removeEventListener("focus", onFocus);
     };
   });
 


### PR DESCRIPTION
## Summary
Builds on PR #45 (ack contract + composite /health + opportunistic sweep) to remove the remaining timer-based architecture from the companion. No new background tasks, no \`setInterval\` anywhere — every check fires on a real cause (incoming request, frontend focus, OS pipe EOF) or as an event-driven deadline that resets on activity.

Implements #36, #40, #41, #42. Tracked under #43.

> **Base branch is \`feat/self-healing-pr1\`.** GitHub will auto-retarget to \`main\` once PR #45 merges.

### #36 — Render TTL (no wire-format change)
- \`/render\` wraps result-await in \`tokio::timeout(DIALOG_TTL)\` (5 min).
- Expired calls cancel the registry entry, return HTTP 408 with \`{error: \"timeout\"}\`.
- Existing Python MCP wrapper keeps working — the wire still looks synchronous to clients, just bounded.

### #41 — Idle-Restart on Render
- \`AppState\` gains \`started_at\` und \`last_render_at\`.
- Vor jedem \`/render\`: \`gui_uptime > 24h && last_render_age > 10min\` ⇒ WebView-Reload (gleicher Pfad wie PR1 für Ack-Failures).
- Drift wird genau dann gespült, wenn sie Probleme machen würde — kein Idle-Polling, kein OS-Hook.

### #42 — Lifecycle Update-Check
- 6h-\`setInterval\` ist raus.
- Trigger jetzt: GUI-Mount, \`update:check\`-Event vom Rust nach jedem erfolgreichen Render, \`window.focus\`-Handler (deckt wake-from-sleep ab).
- 30-min Cooldown debounced Bursts.

### #40 — mcp-stdio Idle-Deadline
- \`tokio::select!\` zwischen \`reader.next_line()\` und 6h-Sleep.
- Sleep resettet bei jeder neuen Zeile — keine Polling-Schleife.
- Schließt den Fall „Parent vergisst stdin zu schließen, schickt aber auch nichts mehr" (Quelle der 11+ stale Childs am 2026-04-25).

## Architecture Compliance
Kein \`setInterval\` und kein wiederkehrender \`tokio::time::sleep\`-Loop mehr. Drei legitime Trigger-Klassen aus dem RFC:
- **Incoming request** — Render-Handler-Logik (#36, #41)
- **OS lifecycle edges** — stdin-EOF (vorhanden), focus-event (#42)
- **Activity-reset deadlines** — mcp-stdio (#40), MCP-Render-TTL (#36)

## Out of Scope
- macOS-natives Sleep/Wake-Hook — Window-Focus deckt den praktisch wichtigen Fall ab; ein eigener Obj-C-Bridge ist als Open Question im RFC notiert.
- Echtes async \`/render\` mit Long-Poll — Wire-Format-Change wäre größer, der TTL-Bound deckt das Hauptproblem (unendliches Hängen) ohne Client-Anpassung ab.

## Test Plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy --tests -- -D warnings\` clean
- [x] \`cargo test\` — 23/23
- [x] \`npm run build\` — Svelte clean
- [ ] Manuell: aiui-DMG bauen, Render mit künstlich blockiertem Frontend ⇒ TTL-408 nach 5min
- [ ] Manuell: Update-Check feuert nach Render (Console-Log: \`[aiui] update check (rust:post-render)\`)
- [ ] Manuell: GUI 24h+ uptime simulieren (\`IDLE_RESTART_UPTIME\` testweise auf 30s setzen) ⇒ Reload triggert sichtbar im Trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)