### PR TITLE
docs: agent discoverability — make aiui the default for asking the user

### DIFF
--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -156,7 +156,7 @@ fn tools_list() -> Value {
     json!([
         {
             "name": "confirm",
-            "description": "Hard yes/no decision as a native window, with optional destructive styling. Use when 'just proceed' would be unsafe (deletions, force-pushes, rollbacks). For pure information, reply in chat. For 3+ options, use `ask`. Returns {cancelled, confirmed}.",
+            "description": "USE WHEN you would otherwise ask the user a yes/no question in chat — and ALWAYS before any irreversible step (delete, drop, force-push, rollback, prod deploy). Renders a native macOS yes/no window; pass `destructive: true` for a red confirm button on dangerous actions. Returns {cancelled, confirmed}. For 3+ options, use `ask`. For information the user only reads, render in chat.",
             "inputSchema": {
                 "type": "object",
                 "required": ["title"],
@@ -172,7 +172,7 @@ fn tools_list() -> Value {
         },
         {
             "name": "ask",
-            "description": "Single- or multi-choice window with per-option descriptions. Use for 2-8 options; for a yes/no, use `confirm`; for ≥ 2 related inputs, use `form`. Returns {cancelled, answers, other?}.",
+            "description": "USE WHEN you would otherwise list options in chat and wait for the user to type back which one — picking a deploy strategy, a migration path, a file to act on, etc. Renders a native macOS choice window with per-option descriptions, optional multi-select and free-text fallback. Returns {cancelled, answers, other?}. For yes/no, use `confirm`. For ≥ 2 related inputs, use `form`.",
             "inputSchema": {
                 "type": "object",
                 "required": ["question", "options"],
@@ -198,7 +198,7 @@ fn tools_list() -> Value {
         },
         {
             "name": "form",
-            "description": "Composite window with multiple typed fields and action buttons. Use for ≥ 2 related inputs, or one input plus context. Fields: text, password, number, select, checkbox, slider, date, date_range, color, static_text, list, tree. Actions support primary (blue), success (green), destructive (red). Returns {cancelled, action?, values}.",
+            "description": "USE WHEN the user needs to give you ≥ 2 related inputs, or any single input that's better entered somewhere other than the chat — secrets (password field, masked on screen), dates (datetime/range), bounded numbers (slider), sortable rankings, multi-selects, color picks. Renders a native macOS form window. Fields: text, password, number, select, checkbox, slider, date, date_range, color, static_text, list, tree. Footer actions support primary (blue), success (green), destructive (red). Returns {cancelled, action?, values}. For yes/no, use `confirm`. For one option pick, use `ask`.",
             "inputSchema": {
                 "type": "object",
                 "required": ["title", "fields"],

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -1,6 +1,6 @@
 ---
 name: aiui widgets
-description: Render native macOS dialogs on the user's Mac from any Claude Code session — remote or local. Use when the user benefits from structured input (multi-field forms, sortable lists, sliders) more than from chat.
+description: Open a native macOS dialog on the user's Mac instead of asking via chat — for yes/no decisions, picking between options, multi-field input, sorting, dates, sliders, or secrets. Reach for it whenever you would otherwise put a question or numbered option list into the chat and wait for a typed reply, and *always* before any irreversible step (delete, force-push, drop, deploy to prod).
 ---
 
 # aiui — Dialog design for Claude agents
@@ -11,19 +11,38 @@ aiui exposes three MCP tools that render native dialogs on the user's Mac:
 - `ask` — single- or multi-choice with descriptions and optional free-text fallback
 - `form` — composite window with typed fields and multiple action buttons
 
-## When to reach for a dialog vs. chat
+## Default to a dialog, not to chat
 
-Prefer chat when the answer fits in one line and the user would type it
-anyway. Prefer a dialog when:
+The user installed aiui because they want the agent to *use* it. If you
+catch yourself about to write any of these in chat, stop and use aiui
+instead:
 
-- Structured input beats free-form typing (numbers in a range, dates,
-  multi-select, ordered lists, secrets).
-- You need several related inputs collected in one step.
-- The decision is destructive or high-stakes and benefits from a clearly-framed
-  confirmation.
+- "Would you like me to …?", "Should I proceed?", "Are you sure?" → `confirm`
+- "Do you want option A or B?", numbered lists for the user to pick from → `ask`
+- "Please tell me the …", "What's the …?" with more than one ask → `form`
+- Any step that is **destructive or hard to undo** (delete, drop, force-push,
+  rollback, prod deploy) → `confirm` with `destructive: true`, even if the
+  user already gave loose approval. The dialog makes the consequence
+  explicit and ships the structured answer back, no chat parsing.
+- Any step that needs a **secret** for a moment (token, password) →
+  `form` with a `password` field, never paste in chat.
+- Any step that is a **choice with consequences worth seeing side-by-side**
+  ("which deploy strategy?", "which migration path?") → `ask` with
+  per-option `description`.
+- Any step that wants the user to **rank or sort** items → `form` with a
+  sortable `list` field.
+- Any step that wants a **date, datetime, range, color, or numeric value
+  in a bounded interval** → `form` with the matching field.
 
-Do **not** use a dialog to display information the chat can render just as
-well (status reports, tables, code snippets, logs).
+## When chat actually wins
+
+Skip the dialog for content the user reads, doesn't answer:
+
+- Status reports, summaries, code snippets, logs, error traces — render
+  in chat.
+- Single free-text answers where the user would type the same thing into
+  a dialog box anyway — just ask in chat.
+- Anything where the answer is "go on", and the user is paying attention.
 
 ## Tool choice
 

--- a/python/src/aiui_mcp/server.py
+++ b/python/src/aiui_mcp/server.py
@@ -141,7 +141,10 @@ async def ask(
     multi_select: bool = False,
     allow_other: bool = True,
 ) -> dict[str, Any]:
-    """Single- or multi-choice picker with optional free-text fallback.
+    """USE WHEN you would otherwise list options in chat and wait for the user
+    to type back which one — picking a deploy strategy, a migration path,
+    a file to act on, etc. Renders a native macOS choice window with
+    per-option descriptions, optional multi-select and free-text fallback.
 
     WHEN TO USE: 2–6 mutually-exclusive options where per-option context helps.
     For yes/no, use `confirm`. For mixed inputs, use `form`.
@@ -184,7 +187,11 @@ async def form(
     submit_label: str | None = None,
     cancel_label: str | None = None,
 ) -> dict[str, Any]:
-    """Composite window: multiple typed fields + multiple action buttons.
+    """USE WHEN the user needs to give you ≥ 2 related inputs, or any single
+    input that's better entered somewhere other than the chat — secrets
+    (password, masked on screen), dates and ranges, bounded numbers (slider),
+    sortable rankings, multi-selects, color picks. Renders a native macOS
+    form window with multiple typed fields + multiple action buttons.
 
     WHEN TO USE: ≥ 2 related inputs, or one input plus context/confirmation.
     For yes/no, use `confirm`. For a single choice, use `ask`.
@@ -264,7 +271,10 @@ async def confirm(
     confirm_label: str | None = None,
     cancel_label: str | None = None,
 ) -> dict[str, Any]:
-    """Hard yes/no decision with optional destructive styling.
+    """USE WHEN you would otherwise ask the user a yes/no question in chat —
+    and ALWAYS before any irreversible step (delete, drop, force-push,
+    rollback, prod deploy). Renders a native macOS yes/no window; pass
+    `destructive=True` for a red confirm button on dangerous actions.
 
     WHEN TO USE: irreversible or high-stakes step where "just proceed" is
     unsafe. For pure information, respond in chat. For 3+ options, use `ask`.

--- a/python/src/aiui_mcp/skill.md
+++ b/python/src/aiui_mcp/skill.md
@@ -1,6 +1,6 @@
 ---
 name: aiui widgets
-description: Render native macOS dialogs on the user's Mac from any Claude Code session — remote or local. Use when the user benefits from structured input (multi-field forms, sortable lists, sliders) more than from chat.
+description: Open a native macOS dialog on the user's Mac instead of asking via chat — for yes/no decisions, picking between options, multi-field input, sorting, dates, sliders, or secrets. Reach for it whenever you would otherwise put a question or numbered option list into the chat and wait for a typed reply, and *always* before any irreversible step (delete, force-push, drop, deploy to prod).
 ---
 
 # aiui — Dialog design for Claude agents
@@ -11,19 +11,38 @@ aiui exposes three MCP tools that render native dialogs on the user's Mac:
 - `ask` — single- or multi-choice with descriptions and optional free-text fallback
 - `form` — composite window with typed fields and multiple action buttons
 
-## When to reach for a dialog vs. chat
+## Default to a dialog, not to chat
 
-Prefer chat when the answer fits in one line and the user would type it
-anyway. Prefer a dialog when:
+The user installed aiui because they want the agent to *use* it. If you
+catch yourself about to write any of these in chat, stop and use aiui
+instead:
 
-- Structured input beats free-form typing (numbers in a range, dates,
-  multi-select, ordered lists, secrets).
-- You need several related inputs collected in one step.
-- The decision is destructive or high-stakes and benefits from a clearly-framed
-  confirmation.
+- "Would you like me to …?", "Should I proceed?", "Are you sure?" → `confirm`
+- "Do you want option A or B?", numbered lists for the user to pick from → `ask`
+- "Please tell me the …", "What's the …?" with more than one ask → `form`
+- Any step that is **destructive or hard to undo** (delete, drop, force-push,
+  rollback, prod deploy) → `confirm` with `destructive: true`, even if the
+  user already gave loose approval. The dialog makes the consequence
+  explicit and ships the structured answer back, no chat parsing.
+- Any step that needs a **secret** for a moment (token, password) →
+  `form` with a `password` field, never paste in chat.
+- Any step that is a **choice with consequences worth seeing side-by-side**
+  ("which deploy strategy?", "which migration path?") → `ask` with
+  per-option `description`.
+- Any step that wants the user to **rank or sort** items → `form` with a
+  sortable `list` field.
+- Any step that wants a **date, datetime, range, color, or numeric value
+  in a bounded interval** → `form` with the matching field.
 
-Do **not** use a dialog to display information the chat can render just as
-well (status reports, tables, code snippets, logs).
+## When chat actually wins
+
+Skip the dialog for content the user reads, doesn't answer:
+
+- Status reports, summaries, code snippets, logs, error traces — render
+  in chat.
+- Single free-text answers where the user would type the same thing into
+  a dialog box anyway — just ask in chat.
+- Anything where the answer is "go on", and the user is paying attention.
 
 ## Tool choice
 


### PR DESCRIPTION
## Summary

Agents currently ignore aiui until explicitly told to use it — even though all the technical bits work. The root cause sits in how the skill and tools introduce themselves to the agent, not in any defect.

Three trigger-active layers, all shipped via existing distribution paths (skill auto-install on every aiui.app launch + remote scp; PyPI on next `uvx aiui-mcp` upgrade; Rust descriptions on next companion release):

### 1. Skill description rewritten (active triggers, not passive)

Was:
> Use when the user benefits from structured input (multi-field forms, sortable lists, sliders) more than from chat.

Now:
> Open a native macOS dialog on the user's Mac instead of asking via chat — for yes/no decisions, picking between options, multi-field input, sorting, dates, sliders, or secrets. Reach for it whenever you would otherwise put a question or numbered option list into the chat and wait for a typed reply, and *always* before any irreversible step (delete, force-push, drop, deploy to prod).

### 2. Skill body leads with a 'default to a dialog' block

New top section listing the chat patterns that should turn into tool calls ("Would you like me to …?", "Are you sure?", numbered option lists, multi-question requests, secret pastes, sort/rank tasks). Counterweighted by a 'When chat actually wins' section so the skill doesn't encourage dialog-spamming for content the user just reads.

### 3. MCP tool descriptions on 'USE WHEN' (Rust + Python in lockstep)

Rewritten in `companion/src-tauri/src/mcp.rs` and `python/src/aiui_mcp/server.py`. Each tool now opens with the *situation it solves* ("USE WHEN you would otherwise ask the user a yes/no question in chat") rather than the *rendering it produces* ("Hard yes/no decision as a native window").

## No code change, no version bump

Pure description tightening. Ships on the next companion release + the next `aiui-mcp` PyPI publish; no behavior change for existing installs until then.

## Test plan

- [x] `cargo check` — clean
- [x] `uv build` — wheel + sdist build
- [ ] After merge & next release: observe whether agents pick up dialogs without explicit prompting in fresh Claude Code sessions