### PR TITLE
v0.4.1: first-run welcome banner (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.1] — 2026-04-25
+
+### Added
+
+- **Welcome banner on first run.** The Settings window now shows an
+  onboarding card on the first launch (and on every subsequent launch
+  until the user clicks "Got it"). Tells the user aiui is set up,
+  points at `/aiui:test-dialog` and `/aiui:widgets` for a 30-second
+  smoke test, and prompts SSH users to add their dev host. Replaces
+  the previous behaviour where first-run state was marked done as
+  soon as the window opened — users who closed the window without
+  reading anything had no second chance.
+
+### Changed
+
+- `status` Tauri command returns a new `welcome_pending` boolean.
+- New `dismiss_welcome` command marks the banner dismissed (writes
+  `~/.config/aiui/first_run_done`).
+- The auto-mark-done call moved out of `setup` into the
+  user-controlled dismiss path.
+
 ## [0.4.0] — 2026-04-25
 
 ### Added — new form fields

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "aiui companion — renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.0"
+version = "0.4.1"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -87,6 +87,11 @@ struct StatusReport {
     remotes: Vec<String>,
     tunnels: std::collections::HashMap<String, tunnel::TunnelStatus>,
     build_info: &'static str,
+    /// True until the user dismisses the welcome section. Drives the
+    /// onboarding banner in the Settings UI — they see it on the very
+    /// first launch and on every subsequent launch where they haven't
+    /// clicked "Got it" yet.
+    welcome_pending: bool,
 }
 
 #[tauri::command]
@@ -103,7 +108,17 @@ async fn status(
         remotes: setup::load_remotes(),
         tunnels: tm.snapshot().await,
         build_info: logging::BUILD_INFO,
+        welcome_pending: is_first_run(&cfg),
     })
+}
+
+/// Marks the welcome banner as dismissed so it doesn't reappear on the
+/// next launch. Frontend calls this when the user clicks "Got it" on the
+/// first-run welcome section.
+#[tauri::command]
+fn dismiss_welcome(cfg: tauri::State<'_, Arc<config::AppConfig>>) -> Result<(), String> {
+    mark_first_run_done(&cfg);
+    Ok(())
 }
 
 #[tauri::command]
@@ -291,7 +306,8 @@ pub fn run() {
             add_remote,
             remove_remote,
             reinstall_skill,
-            uninstall_all
+            uninstall_all,
+            dismiss_welcome
         ])
         .setup(move |app| {
             let app_handle = app.handle().clone();
@@ -375,8 +391,14 @@ pub fn run() {
             });
 
             if is_first_run(&cfg) {
+                // First-ever launch: surface the settings window so the user
+                // sees the welcome / pairing instructions. We deliberately
+                // *don't* call `mark_first_run_done` here — that flag stays
+                // true until the user explicitly dismisses the welcome
+                // section in the UI (via `dismiss_welcome` command). If the
+                // user closes the window without dismissing, they'll see
+                // the welcome again next launch — better than missing it.
                 show_settings_window(&app_handle);
-                mark_first_run_done(&cfg);
             } else if !is_auto_launch() {
                 // Manual launch by user (Finder double-click) → show settings,
                 // Dock icon appears. Auto-launch from MCP-stdio stays silent.

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -5,6 +5,13 @@
     "status.not_connected": "Claude Desktop Config wird beim nächsten Start automatisch gesetzt"
   },
   "settings": {
+    "welcome.title": "aiui ist eingerichtet",
+    "welcome.body": "Claude Code kann jetzt native Fenster auf diesem Mac öffnen, statt Dich im Chat zu fragen. Probier in einer Claude-Code-Session:",
+    "welcome.point.test": "/aiui:test-dialog — kurzer Demo-Dialog zum Verifizieren.",
+    "welcome.point.skill": "/aiui:widgets — lädt das Agent-Skill, damit künftige Agents von alleine Fenster nutzen.",
+    "welcome.point.remote": "Arbeitest Du via SSH auf einem Dev-Host? Trag ihn unten ein, aiui tunnelt die Dialoge zurück.",
+    "welcome.cta": "Verstanden",
+    "welcome.dismiss": "Schließen",
     "remotes.title": "Eingerichtete Remote-Hosts",
     "remotes.empty.hint": "Nur nötig, wenn Du Claude Code auf einem Remote-Host fährst. Für lokale Projekte leer lassen.",
     "remotes.add.title": "Neuen Remote hinzufügen",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -5,6 +5,13 @@
     "status.not_connected": "Claude Desktop config will be set automatically on next launch"
   },
   "settings": {
+    "welcome.title": "aiui is set up",
+    "welcome.body": "Claude Code can now open native dialogs on this Mac instead of asking you in chat. Try one of these in any Claude Code session:",
+    "welcome.point.test": "Type /aiui:test-dialog — pops a small demo window so you can verify the wiring.",
+    "welcome.point.skill": "Type /aiui:widgets — loads the agent skill so the next agent uses dialogs without prompting.",
+    "welcome.point.remote": "Working over SSH? Add the dev host below and aiui tunnels dialogs back to your Mac.",
+    "welcome.cta": "Got it",
+    "welcome.dismiss": "Dismiss",
     "remotes.title": "Registered remote hosts",
     "remotes.empty.hint": "Only needed if you run Claude Code on a remote host. Leave empty for local projects.",
     "remotes.add.title": "Add a new remote",

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -20,6 +20,7 @@
     remotes: string[];
     tunnels: Record<string, TunnelStatus>;
     build_info: string;
+    welcome_pending: boolean;
   };
 
   let status = $state<Status | null>(null);
@@ -86,6 +87,15 @@
     }
   }
 
+  async function dismissWelcome() {
+    try {
+      await invoke("dismiss_welcome");
+    } finally {
+      // Either way, hide locally — server-side state will catch up on next refresh.
+      if (status) status = { ...status, welcome_pending: false };
+    }
+  }
+
   function openIssue() {
     const body = encodeURIComponent(
       `**Version:** ${status?.build_info ?? "unknown"}\n\n` +
@@ -135,6 +145,24 @@
       </div>
       <div class="build-info" title={status.build_info}>{status.build_info.split(" ")[1]}</div>
     </header>
+
+    {#if status.welcome_pending}
+      <section class="welcome">
+        <div class="welcome-head">
+          <strong>{$_("settings.welcome.title")}</strong>
+          <button class="welcome-dismiss" onclick={dismissWelcome} aria-label={$_("settings.welcome.dismiss")}>×</button>
+        </div>
+        <p class="welcome-body">{$_("settings.welcome.body")}</p>
+        <ul class="welcome-list">
+          <li>{$_("settings.welcome.point.test")}</li>
+          <li>{$_("settings.welcome.point.skill")}</li>
+          <li>{$_("settings.welcome.point.remote")}</li>
+        </ul>
+        <div class="welcome-foot">
+          <button class="primary" onclick={dismissWelcome}>{$_("settings.welcome.cta")}</button>
+        </div>
+      </section>
+    {/if}
 
     <section>
       <label>{$_("settings.remotes.title")}</label>
@@ -323,4 +351,60 @@
     flex-shrink: 0;
   }
   .dot-small.err { background: var(--danger); }
+
+  /* --- first-run welcome --- */
+  .welcome {
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+    border-radius: 10px;
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .welcome-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+  .welcome-head strong {
+    font-size: 14px;
+    color: var(--fg);
+  }
+  .welcome-dismiss {
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    font-size: 18px;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+    box-shadow: none;
+    border-radius: 4px;
+  }
+  .welcome-dismiss:hover { color: var(--fg); background: color-mix(in srgb, var(--fg) 6%, transparent); }
+  .welcome-body {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+  .welcome-list {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 12.5px;
+    color: var(--fg);
+    line-height: 1.55;
+  }
+  .welcome-list li :global(code) {
+    background: color-mix(in srgb, var(--fg) 8%, transparent);
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+  .welcome-foot {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 2px;
+  }
 </style>


### PR DESCRIPTION
Closes #31.

Replaces the silent first-run behaviour where the welcome state got marked done the moment the window opened. The card now persists across launches until the user clicks "Got it".

Card pointers:
- `/aiui:test-dialog` — verify the wiring with a tiny demo
- `/aiui:widgets` — load the agent skill so future agents reach for dialogs without prompting
- Add SSH dev host below if you work remote

Bumps 0.4.0 → 0.4.1.

## Test plan
- [x] cargo check + svelte-check clean
- [ ] Manual: fresh install, see welcome card, dismiss → doesn't return on next launch