### PR TITLE
v0.4.2: hardening pass (Codex review) — closes #51 #52 #53 #54 #55 #56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.2] — 2026-04-25
+
+Pre-launch hardening pass: external code review surfaced six substantive
+defects in the SSH-tunnel and remote-setup paths. All fixed.
+
+### Fixed
+
+- **Remote `~/.claude.json` patching/removal silently no-op'd** (#51,
+  blocker). The previous implementation tried to ship the python script
+  through `python3 -c "$1"` over ssh; the remote login shell expanded
+  `$1` to empty *before* python ran, producing a no-op + `print("ok")`
+  the Rust side trusted. `add_remote` claimed success while the remote
+  config was untouched. New implementation pipes the script through
+  ssh's stdin to `python3 -`, and verifies the `"ok"` marker before
+  reporting success.
+- **SSH option injection via `host_alias`** (#52, security/high). User
+  input from "Add Remote" flowed unvalidated into `ssh`/`scp` argv;
+  values starting with `-` were interpreted as ssh options
+  (e.g. `-oProxyCommand=…`). Now validated at the API boundary
+  (`is_valid_host_alias`), with defense-in-depth `--` end-of-options
+  markers everywhere ssh/scp invokes a host. 15 unit tests cover the
+  validator.
+- **Shared-forward detection trusted unauthenticated `/ping`** (#53,
+  security/high). A squatter on remote port 7777 could mask a
+  port-takeover by answering "pong", flipping the tunnel to
+  `ConnectedShared` (green). Replaced with a token-authenticated
+  `/probe` endpoint; the remote-side curl reads
+  `~/.config/aiui/token` and sends it as `Authorization: Bearer …`.
+  Only an aiui that authenticates against the same token is accepted
+  as a shared owner.
+- **`add_remote` was not transactional** (#54). Half-failed setup
+  steps still appended the host to `remotes.json` and started the
+  tunnel manager retrying forever. Now: token-push and config-patch
+  are blocking (must succeed before persistence + tunnel start). Skill
+  install stays non-blocking (warn-only). The user sees per-step
+  results either way.
+- **HTTP bind failure was logged-and-swallowed** (#55). If port 7777
+  was already held when aiui started, the GUI looked alive but every
+  request failed silently. New `http_error` field in the `status`
+  payload + a red banner in Settings ("aiui can't accept requests")
+  that points at the squatter and tells the user how to find it
+  (`lsof -nP -iTCP:7777`).
+- **`/health` reported ready exactly at the dialog hard-cap** (#56).
+  At `len() == HARD_CAP` the next `register()` evicts an in-flight
+  dialog while `/health` still claims ready. Tightened the gate to
+  `< HARD_CAP` so readiness leads eviction.
+
+### Notes
+
+- `aiui-mcp` PyPI version unchanged (no Python-side changes in this
+  release).
+- The Codex review's Windows-port readiness finding (low severity, #57)
+  is tracked but not addressed here.
+
 ## [0.4.1] — 2026-04-25
 
 ### Added

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "aiui companion — renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.1"
+version = "0.4.2"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -147,6 +147,7 @@ pub async fn serve(
         .route("/version", get(version))
         .route("/update", post(update))
         .route("/ping", get(ping))
+        .route("/probe", get(probe))
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -162,6 +163,30 @@ pub async fn serve(
 async fn ping() -> &'static str {
     trace("ping: hit");
     "pong"
+}
+
+/// Authenticated probe used by the tunnel-manager's shared-forward
+/// detection. Unlike /ping, this requires the bearer token, so it
+/// distinguishes "another aiui with our token is forwarding the port"
+/// from "some random process on :7777 is answering". Without this
+/// distinction a malicious squatter could mask a port-takeover by
+/// answering "pong" and aiui would keep showing connected-shared.
+async fn probe(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if !auth_ok(&headers, &state.cfg.token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "unauthorized"})),
+        )
+            .into_response();
+    }
+    Json(serde_json::json!({
+        "aiui": true,
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+    .into_response()
 }
 
 fn auth_ok(headers: &HeaderMap, token: &str) -> bool {
@@ -197,12 +222,17 @@ async fn health(
     };
     let children = ChildrenHealth { attached };
 
-    // Ready criterion: WebView answers, no orphan-dialog backlog, and we
-    // aren't drowning in attached children. Thresholds are intentionally
-    // loose — anything tighter belongs in a separate metric, not in the
-    // ready/not-ready gate.
+    // Ready criterion: WebView answers, room left in the dialog
+    // registry, and we aren't drowning in attached children.
+    //
+    // The dialog check uses *strict* less-than because `register()`
+    // evicts an existing pending dialog when `len() >= HARD_CAP`. If we
+    // reported ready at exactly the cap, the very next /render would
+    // silently cancel an in-flight dialog while /health still claimed
+    // healthy — readiness must lead the eviction signal, not coincide
+    // with it.
     let ready = webview.responsive
-        && dialog_stats.orphan_count <= crate::dialog::DIALOG_HARD_CAP
+        && dialog_stats.orphan_count < crate::dialog::DIALOG_HARD_CAP
         && attached < 32;
 
     let body = HealthResponse {

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -92,12 +92,17 @@ struct StatusReport {
     /// first launch and on every subsequent launch where they haven't
     /// clicked "Got it" yet.
     welcome_pending: bool,
+    /// `Some(message)` if the HTTP server failed to bind/serve. Drives a
+    /// red banner in Settings so the user knows why dialogs aren't
+    /// landing.
+    http_error: Option<String>,
 }
 
 #[tauri::command]
 async fn status(
     cfg: tauri::State<'_, Arc<config::AppConfig>>,
     tm: tauri::State<'_, Arc<tunnel::TunnelManager>>,
+    http_err: tauri::State<'_, Arc<std::sync::Mutex<Option<String>>>>,
 ) -> Result<StatusReport, String> {
     let bin = setup::app_binary_path();
     Ok(StatusReport {
@@ -109,6 +114,7 @@ async fn status(
         tunnels: tm.snapshot().await,
         build_info: logging::BUILD_INFO,
         welcome_pending: is_first_run(&cfg),
+        http_error: http_err.lock().ok().and_then(|s| s.clone()),
     })
 }
 
@@ -127,6 +133,23 @@ async fn add_remote(
     cfg: tauri::State<'_, Arc<config::AppConfig>>,
     tm: tauri::State<'_, Arc<tunnel::TunnelManager>>,
 ) -> Result<Vec<setup::StepResult>, String> {
+    // Validate at the API boundary: anything that doesn't pass
+    // `is_valid_host_alias` is rejected here, before we spawn ssh or
+    // touch persistent state. This is the primary defense against
+    // option-injection via `host_alias`. Per-helper validators below
+    // are defense-in-depth for callers that bypass this entry.
+    if !setup::is_valid_host_alias(&host_alias) {
+        return Ok(vec![setup::StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: Some(
+                "Allowed: letters, digits, '.', '_', '-' (and '+' in the user). \
+                 No leading '-', no whitespace, no shell metacharacters."
+                    .into(),
+            ),
+        }]);
+    }
+
     let mut results = Vec::new();
 
     // Legacy cleanup: earlier versions (≤ v0.1.1) patched the user's
@@ -135,10 +158,39 @@ async fn add_remote(
     // from past installs so we don't fight them over port 7777.
     let _ = setup::remove_ssh_forward(&host_alias, cfg.http_port);
 
+    // Run the three setup steps. Treat token push and config patch as
+    // *blocking* — without them the remote can't talk to us. Skill
+    // install is treated as non-blocking (warn but proceed) since a
+    // missing skill only degrades agent UX, not connectivity.
     let token_path = cfg.token_path.display().to_string();
-    results.push(setup::push_token_to_remote(&host_alias, &token_path));
-    results.push(skill::install_to_remote(&host_alias));
-    results.push(setup::patch_claude_code_config_remote(&host_alias));
+    let token_step = setup::push_token_to_remote(&host_alias, &token_path);
+    let token_ok = token_step.ok;
+    results.push(token_step);
+
+    let skill_step = skill::install_to_remote(&host_alias);
+    results.push(skill_step);
+
+    let config_step = setup::patch_claude_code_config_remote(&host_alias);
+    let config_ok = config_step.ok;
+    results.push(config_step);
+
+    if !(token_ok && config_ok) {
+        // Don't persist the host or start a tunnel for a half-failed
+        // setup. The user sees the per-step error in the log and can
+        // retry. Token may already be on the remote — that's harmless.
+        results.push(setup::StepResult {
+            ok: false,
+            message: format!(
+                "Setup für '{host_alias}' nicht abgeschlossen — Host nicht eingetragen."
+            ),
+            details: Some(
+                "Token-Push und Config-Patch müssen erfolgreich sein. \
+                 Behebe die Ursache und versuche es erneut."
+                    .into(),
+            ),
+        });
+        return Ok(results);
+    }
 
     let mut list = setup::load_remotes();
     if !list.contains(&host_alias) {
@@ -266,6 +318,13 @@ pub fn run() {
     let ui_acks = Arc::new(ack::AckRegistry::new());
     let lifetime_stats = Arc::new(lifetime::LifetimeStats::new());
     let tunnel_mgr = tunnel::TunnelManager::new(cfg.http_port);
+    // Shared cell that records a fatal HTTP-server bind/serve failure (e.g.
+    // port 7777 held by another process). Read by the `status` command and
+    // surfaced as a banner in the Settings UI — without it, a stale
+    // squatter would cause every render/health/version request to fail
+    // later while the window kept *looking* alive.
+    let http_error: Arc<std::sync::Mutex<Option<String>>> =
+        Arc::new(std::sync::Mutex::new(None));
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -295,6 +354,7 @@ pub fn run() {
         .manage(ui_acks.clone())
         .manage(lifetime_stats.clone())
         .manage(tunnel_mgr.clone())
+        .manage(http_error.clone())
         .invoke_handler(tauri::generate_handler![
             dialog_submit,
             dialog_cancel,
@@ -355,7 +415,13 @@ pub fn run() {
             // so skill updates ride with app updates.
             let _ = skill::install_locally();
 
-            // HTTP server on localhost:7777.
+            // HTTP server on localhost:7777. If bind fails (port held by
+            // a stale aiui or unrelated process) we record the error in
+            // the shared `http_error` cell so the Settings UI can surface
+            // a banner — silently logging it left users staring at a
+            // window that *looked* alive but answered no requests.
+            let http_error_for_serve = http_error.clone();
+            let port_for_error = cfg.http_port;
             rt.spawn(async move {
                 if let Err(e) = http::serve(
                     cfg_http,
@@ -367,6 +433,11 @@ pub fn run() {
                 .await
                 {
                     log::error!("[aiui] http server error: {e}");
+                    if let Ok(mut slot) = http_error_for_serve.lock() {
+                        *slot = Some(format!(
+                            "Konnte localhost:{port_for_error} nicht öffnen — Port wahrscheinlich belegt. {e}"
+                        ));
+                    }
                 }
             });
 

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -110,17 +110,107 @@ fn split_user_host(input: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// Validate that a remote host alias is safe to pass to ssh/scp without it
+/// being misinterpreted as an option (`-oProxyCommand=…` style injection).
+///
+/// Allows `[A-Za-z0-9._-]` for the host part and the same plus `+` for the
+/// user part — i.e. real RFC-style hostnames, IPs, IPv6 in brackets, and
+/// SSH-config aliases. Rejects whitespace, control characters, leading
+/// `-`, shell metacharacters, and anything > 253 chars per part.
+///
+/// Public so the `add_remote` Tauri command can validate at the boundary
+/// before ever spawning ssh.
+pub fn is_valid_host_alias(input: &str) -> bool {
+    if input.is_empty() || input.len() > 256 {
+        return false;
+    }
+    if input.starts_with('-') {
+        return false;
+    }
+    let (host, user) = split_user_host(input);
+    if host.is_empty() || host.starts_with('-') || host.len() > 253 {
+        return false;
+    }
+    if let Some(u) = user {
+        if u.is_empty() || u.starts_with('-') || u.len() > 253 {
+            return false;
+        }
+        if !u.bytes().all(host_alias_user_byte_ok) {
+            return false;
+        }
+    }
+    // Host part: allow alphanumerics, dot, hyphen, underscore, colon (IPv6
+    // separators), and the bracketing chars `[]` for `[::1]`-style input.
+    host.bytes().all(host_alias_host_byte_ok)
+}
+
+fn host_alias_user_byte_ok(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_' | b'+')
+}
+
+fn host_alias_host_byte_ok(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_' | b':' | b'[' | b']')
+}
+
+#[cfg(test)]
+mod host_alias_tests {
+    use super::is_valid_host_alias;
+
+    #[test]
+    fn accepts_plain_host() { assert!(is_valid_host_alias("macmini")); }
+    #[test]
+    fn accepts_user_at_host() { assert!(is_valid_host_alias("customer@macmini")); }
+    #[test]
+    fn accepts_dotted_host() { assert!(is_valid_host_alias("dev.example.com")); }
+    #[test]
+    fn accepts_ipv4() { assert!(is_valid_host_alias("user@10.0.0.1")); }
+    #[test]
+    fn accepts_ipv6_bracketed() { assert!(is_valid_host_alias("[::1]")); }
+
+    #[test]
+    fn rejects_leading_dash() { assert!(!is_valid_host_alias("-oProxyCommand=foo")); }
+    #[test]
+    fn rejects_user_leading_dash() { assert!(!is_valid_host_alias("-evil@host")); }
+    #[test]
+    fn rejects_host_leading_dash() { assert!(!is_valid_host_alias("user@-evil")); }
+    #[test]
+    fn rejects_whitespace() { assert!(!is_valid_host_alias("foo bar")); }
+    #[test]
+    fn rejects_quotes() { assert!(!is_valid_host_alias("foo\"bar")); }
+    #[test]
+    fn rejects_semicolon() { assert!(!is_valid_host_alias("foo;rm -rf /")); }
+    #[test]
+    fn rejects_empty() { assert!(!is_valid_host_alias("")); }
+    #[test]
+    fn rejects_only_at() { assert!(!is_valid_host_alias("@")); }
+    #[test]
+    fn rejects_pipe() { assert!(!is_valid_host_alias("a|b")); }
+    #[test]
+    fn rejects_newline() { assert!(!is_valid_host_alias("a\nb")); }
+}
+
 // Note: an earlier version of aiui patched ~/.ssh/config with a
 // RemoteForward line. The tunnel manager now owns the forward directly, so
 // only the remove path remains (to clean up legacy installs).
 
 pub fn push_token_to_remote(host_alias: &str, token_path: &str) -> StepResult {
-    // ensure remote dir
+    if !is_valid_host_alias(host_alias) {
+        return StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: Some("Only [A-Za-z0-9._-] in host, no leading '-', no shell metacharacters.".into()),
+        };
+    }
+    // ensure remote dir. `--` keeps host_alias out of ssh option position
+    // even if validation regresses one day.
     let out1 = Command::new("ssh")
-        .arg("-o")
-        .arg("BatchMode=yes")
-        .arg(host_alias)
-        .arg("mkdir -p ~/.config/aiui && chmod 700 ~/.config/aiui")
+        .args([
+            "-o",
+            "BatchMode=yes",
+            "--",
+            host_alias,
+            "mkdir -p ~/.config/aiui && chmod 700 ~/.config/aiui",
+        ])
         .output();
     match out1 {
         Err(e) => {
@@ -500,6 +590,14 @@ pub fn remove_ssh_forward(host_alias: &str, port: u16) -> StepResult {
 /// Patch ~/.claude.json on a remote host so aiui is available in every Claude
 /// Code session there. Uses python3 for atomic JSON editing — avoids
 /// shell-quoting pitfalls, universally available on macOS and Linux remotes.
+///
+/// Implementation note: the script is fed to `python3 -` over the ssh
+/// connection's stdin. Earlier versions tried `python3 -c "$1" -- <script>`
+/// in argv; the remote login shell expands `$1` to empty before python sees
+/// anything (no positional-argument scope), so the patch silently no-op'd
+/// while reporting success. Stdin avoids that whole class of shell-quoting
+/// trap, and we additionally check that the script printed "ok" so any
+/// future regression can't masquerade as success again.
 pub fn patch_claude_code_config_remote(host_alias: &str) -> StepResult {
     let script = r#"
 import json, os, pathlib, shutil, time
@@ -519,33 +617,102 @@ p.parent.mkdir(parents=True, exist_ok=True)
 p.write_text(json.dumps(data, indent=2))
 print("ok")
 "#;
-    let out = Command::new("ssh")
+    run_remote_python(host_alias, script, "Patching ~/.claude.json", |stdout| {
+        let confirmed = stdout.trim() == "ok";
+        StepResult {
+            ok: confirmed,
+            message: if confirmed {
+                format!("aiui registered in ~/.claude.json on {host_alias}")
+            } else {
+                format!("Patching ~/.claude.json on {host_alias} did not confirm 'ok'")
+            },
+            details: if confirmed {
+                None
+            } else {
+                Some(format!("stdout: {}", stdout.trim()))
+            },
+        }
+    })
+}
+
+/// Run a Python script on a remote host via `ssh ... python3 -` with the
+/// script piped on stdin. Captures stdout for the caller to verify a
+/// success marker. We validate `host_alias` and additionally use `--` so
+/// it can't slip into ssh option position even if validation regresses.
+fn run_remote_python(
+    host_alias: &str,
+    script: &str,
+    op: &str,
+    on_success: impl FnOnce(&str) -> StepResult,
+) -> StepResult {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    if !is_valid_host_alias(host_alias) {
+        return StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: None,
+        };
+    }
+
+    let child = Command::new("ssh")
         .args([
             "-o",
             "BatchMode=yes",
-            host_alias,
-            "python3 -c \"$1\"",
             "--",
-            script,
+            host_alias,
+            "python3 -",
         ])
-        .output();
-    match out {
-        Err(e) => StepResult {
-            ok: false,
-            message: format!("ssh {host_alias} could not start"),
-            details: Some(e.to_string()),
-        },
-        Ok(o) if !o.status.success() => StepResult {
-            ok: false,
-            message: format!("Patching ~/.claude.json on {host_alias} failed"),
-            details: Some(String::from_utf8_lossy(&o.stderr).to_string()),
-        },
-        Ok(_) => StepResult {
-            ok: true,
-            message: format!("aiui registered in ~/.claude.json on {host_alias}"),
-            details: None,
-        },
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn();
+
+    let mut child = match child {
+        Ok(c) => c,
+        Err(e) => {
+            return StepResult {
+                ok: false,
+                message: format!("ssh {host_alias} could not start"),
+                details: Some(e.to_string()),
+            };
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(e) = stdin.write_all(script.as_bytes()) {
+            return StepResult {
+                ok: false,
+                message: format!("{op} on {host_alias}: stdin write failed"),
+                details: Some(e.to_string()),
+            };
+        }
+        // Drop stdin so python3 sees EOF and starts executing.
+        drop(stdin);
     }
+
+    let out = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => {
+            return StepResult {
+                ok: false,
+                message: format!("{op} on {host_alias}: wait failed"),
+                details: Some(e.to_string()),
+            };
+        }
+    };
+
+    if !out.status.success() {
+        return StepResult {
+            ok: false,
+            message: format!("{op} on {host_alias} failed"),
+            details: Some(String::from_utf8_lossy(&out.stderr).to_string()),
+        };
+    }
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    on_success(&stdout)
 }
 
 pub fn remove_claude_code_config_remote(host_alias: &str) -> StepResult {
@@ -565,36 +732,40 @@ else:
     p.write_text(json.dumps(data, indent=2))
     print("ok")
 "#;
+    run_remote_python(host_alias, script, "Removing aiui from ~/.claude.json", |stdout| {
+        let confirmed = stdout.trim() == "ok";
+        StepResult {
+            ok: confirmed,
+            message: if confirmed {
+                format!("Removed aiui from ~/.claude.json on {host_alias}")
+            } else {
+                format!("Removal on {host_alias} did not confirm 'ok'")
+            },
+            details: if confirmed {
+                None
+            } else {
+                Some(format!("stdout: {}", stdout.trim()))
+            },
+        }
+    })
+}
+
+pub fn remove_token_from_remote(host_alias: &str) -> StepResult {
+    if !is_valid_host_alias(host_alias) {
+        return StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: None,
+        };
+    }
     let out = Command::new("ssh")
         .args([
             "-o",
             "BatchMode=yes",
-            host_alias,
-            "python3 -c \"$1\"",
             "--",
-            script,
+            host_alias,
+            "rm -f ~/.config/aiui/token",
         ])
-        .output();
-    match out {
-        Err(e) => StepResult {
-            ok: false,
-            message: format!("ssh {host_alias} could not start"),
-            details: Some(e.to_string()),
-        },
-        Ok(_) => StepResult {
-            ok: true,
-            message: format!("Removed aiui from ~/.claude.json on {host_alias}"),
-            details: None,
-        },
-    }
-}
-
-pub fn remove_token_from_remote(host_alias: &str) -> StepResult {
-    let out = Command::new("ssh")
-        .arg("-o")
-        .arg("BatchMode=yes")
-        .arg(host_alias)
-        .arg("rm -f ~/.config/aiui/token")
         .output();
     match out {
         Err(e) => StepResult {

--- a/companion/src-tauri/src/skill.rs
+++ b/companion/src-tauri/src/skill.rs
@@ -53,6 +53,13 @@ pub fn install_locally() -> StepResult {
 /// scp the skill to a remote host's ~/.claude/skills/aiui/SKILL.md.
 /// Requires passwordless SSH (same requirement as the tunnel manager).
 pub fn install_to_remote(host_alias: &str) -> StepResult {
+    if !crate::setup::is_valid_host_alias(host_alias) {
+        return StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: None,
+        };
+    }
     // stage a temp file so scp has a filename to work with
     let stage = std::env::temp_dir().join(format!("aiui-skill-{}.md", std::process::id()));
     if let Err(e) = fs::write(&stage, SKILL_MD) {
@@ -67,6 +74,7 @@ pub fn install_to_remote(host_alias: &str) -> StepResult {
         .args([
             "-o",
             "BatchMode=yes",
+            "--",
             host_alias,
             "mkdir -p ~/.claude/skills/aiui",
         ])
@@ -118,10 +126,18 @@ pub fn remove_locally() -> StepResult {
 
 /// Counterpart remote cleanup, used from uninstall_all and remove_remote.
 pub fn remove_from_remote(host_alias: &str) -> StepResult {
+    if !crate::setup::is_valid_host_alias(host_alias) {
+        return StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: None,
+        };
+    }
     let out = Command::new("ssh")
         .args([
             "-o",
             "BatchMode=yes",
+            "--",
             host_alias,
             "rm -f ~/.claude/skills/aiui/SKILL.md; rmdir ~/.claude/skills/aiui 2>/dev/null; true",
         ])

--- a/companion/src-tauri/src/tunnel.rs
+++ b/companion/src-tauri/src/tunnel.rs
@@ -56,6 +56,16 @@ impl TunnelManager {
     }
 
     pub async fn ensure(self: &Arc<Self>, host: String) {
+        // Refuse to even start a tunnel task for a host alias that
+        // would be misinterpreted as an ssh option (defense in depth —
+        // `add_remote` validates at the API boundary, this catches
+        // anything that slips in through an old `remotes.json`).
+        if !crate::setup::is_valid_host_alias(&host) {
+            trace(&format!(
+                "tunnel[{host}]: refusing to start tunnel — host alias rejected by validator"
+            ));
+            return;
+        }
         let mut entries = self.entries.lock().await;
         if entries.contains_key(&host) {
             return;
@@ -112,21 +122,37 @@ impl TunnelManager {
 const SHARED_FORWARD_POLL_SECS: u64 = 30;
 
 /// Ask the remote whether localhost:`port` is already answering `/ping` from
-/// aiui. Uses ssh in batch mode + curl; no-op if either ssh or curl aren't
-/// available. Returns Some(true) on a clean `pong`, Some(false) on a clean
-/// "port is empty", None on inconclusive errors (ssh failed to connect at
-/// all — different failure mode than "port unreachable").
+/// aiui. Returns Some(true) only when an *authenticated* probe to the
+/// remote-side port confirms a same-token aiui is responding (the typical
+/// stale-sshd-sess case where our reverse-forward keeps tunneling to *our*
+/// aiui through a zombie session). Returns Some(false) on a clean "port
+/// is empty" or "answering process isn't aiui or has wrong token".
+/// Returns None when ssh itself failed to connect at all (different
+/// failure mode than "port unreachable") so the retry loop can stay
+/// patient instead of flipping state on every blip.
+///
+/// Token source: `~/.config/aiui/token` on the *remote* host (scp'd
+/// there at remote-registration time). If the file is missing on the
+/// remote, the probe is treated as inconclusive — we don't have enough
+/// to decide.
 async fn probe_remote_shared_forward(host: &str, port: u16) -> Option<bool> {
-    let url = format!("http://localhost:{port}/ping");
-    // -f makes curl return non-zero on 4xx/5xx; -m 3 caps the total time.
-    // We do NOT need the auth token for /ping; it's public on the companion.
-    let cmd = format!("curl -sS -f -m 3 {url} 2>/dev/null");
+    let url = format!("http://localhost:{port}/probe");
+    // Read the token *on the remote* and auth-bind the curl in one shell
+    // command so the token never appears in our local argv. -f makes curl
+    // return non-zero on 4xx/5xx (so 401 = not-shared); -m 3 caps total
+    // time; --json-out marker makes the success body easy to recognize.
+    let cmd = format!(
+        "T=$(cat ~/.config/aiui/token 2>/dev/null) && \
+         [ -n \"$T\" ] && \
+         curl -sS -f -m 3 -H \"Authorization: Bearer $T\" {url} 2>/dev/null"
+    );
     let out = Command::new("ssh")
         .args([
             "-o",
             "BatchMode=yes",
             "-o",
             "ConnectTimeout=5",
+            "--",
             host,
             &cmd,
         ])
@@ -134,12 +160,17 @@ async fn probe_remote_shared_forward(host: &str, port: u16) -> Option<bool> {
         .await;
     match out {
         Ok(o) if o.status.success() => {
+            // Body must be JSON containing `"aiui":true` — otherwise some
+            // other authed-but-unrelated service answered. (Defensive:
+            // /probe is ours, but be paranoid.)
             let body = String::from_utf8_lossy(&o.stdout);
-            Some(body.trim() == "pong")
+            Some(body.contains("\"aiui\":true") || body.contains("\"aiui\": true"))
         }
         Ok(o) => {
-            // ssh ran, curl returned non-zero (port not answering → not shared).
-            // exit 255 from ssh itself means "connection error" — distinguish.
+            // ssh ran, but the remote command failed (curl 401, port
+            // empty, missing token, …). exit 255 from ssh itself means
+            // "connection error" — keep that as inconclusive so we don't
+            // oscillate.
             if o.status.code() == Some(255) {
                 None
             } else {
@@ -181,6 +212,7 @@ async fn run_tunnel(
                 "BatchMode=yes",
                 "-o",
                 "StrictHostKeyChecking=accept-new",
+                "--",
                 &host,
             ])
             .stdout(std::process::Stdio::null())

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -5,6 +5,8 @@
     "status.not_connected": "Claude Desktop Config wird beim nächsten Start automatisch gesetzt"
   },
   "settings": {
+    "http_error.title": "aiui nimmt keine Requests entgegen",
+    "http_error.hint": "Ein anderer Prozess hält Port {port} auf diesem Mac. Beende eine alte aiui-Instanz oder prüfe mit `lsof -nP -iTCP:{port}` welcher Prozess sitzt, dann aiui neu starten.",
     "welcome.title": "aiui ist eingerichtet",
     "welcome.body": "Claude Code kann jetzt native Fenster auf diesem Mac öffnen, statt Dich im Chat zu fragen. Probier in einer Claude-Code-Session:",
     "welcome.point.test": "/aiui:test-dialog — kurzer Demo-Dialog zum Verifizieren.",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -5,6 +5,8 @@
     "status.not_connected": "Claude Desktop config will be set automatically on next launch"
   },
   "settings": {
+    "http_error.title": "aiui can't accept requests",
+    "http_error.hint": "Something else is holding port {port} on this Mac. Quit any old aiui instance, or check `lsof -nP -iTCP:{port}` for the squatter, then relaunch aiui.",
     "welcome.title": "aiui is set up",
     "welcome.body": "Claude Code can now open native dialogs on this Mac instead of asking you in chat. Try one of these in any Claude Code session:",
     "welcome.point.test": "Type /aiui:test-dialog — pops a small demo window so you can verify the wiring.",

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -21,6 +21,7 @@
     tunnels: Record<string, TunnelStatus>;
     build_info: string;
     welcome_pending: boolean;
+    http_error: string | null;
   };
 
   let status = $state<Status | null>(null);
@@ -145,6 +146,14 @@
       </div>
       <div class="build-info" title={status.build_info}>{status.build_info.split(" ")[1]}</div>
     </header>
+
+    {#if status.http_error}
+      <section class="http-error">
+        <strong>{$_("settings.http_error.title")}</strong>
+        <p>{status.http_error}</p>
+        <p class="http-error-hint">{$_("settings.http_error.hint", { values: { port: status.http_port } })}</p>
+      </section>
+    {/if}
 
     {#if status.welcome_pending}
       <section class="welcome">
@@ -351,6 +360,21 @@
     flex-shrink: 0;
   }
   .dot-small.err { background: var(--danger); }
+
+  /* --- HTTP error banner --- */
+  .http-error {
+    border: 1px solid var(--danger);
+    background: color-mix(in srgb, var(--danger) 12%, var(--surface));
+    border-radius: 10px;
+    padding: 10px 14px;
+    color: var(--fg);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .http-error strong { font-size: 13px; color: var(--danger); }
+  .http-error p { margin: 0; font-size: 12.5px; line-height: 1.5; }
+  .http-error-hint { color: var(--muted); }
 
   /* --- first-run welcome --- */
   .welcome {


### PR DESCRIPTION
Closes #51 #52 #53 #54 #55 #56.

External review (Codex) flagged six substantive defects in the SSH-tunnel and remote-setup paths. All fixed for the public launch.

| # | Sev | What |
|---|---|---|
| 51 | blocker | Remote claude.json patcher fixed — script via stdin to `python3 -`, verifies "ok" marker. Old version had $1 expanded to empty by the remote shell. |
| 52 | high security | host_alias validator + `--` end-of-options at every ssh/scp call site. 15 unit tests. |
| 53 | high security | New auth-protected `/probe` endpoint. Remote curl reads ~/.config/aiui/token and sends it as Bearer. Only same-token aiui counted as shared owner. |
| 54 | medium | add_remote transactional: token-push + config-patch must succeed; otherwise no persist, no tunnel start. |
| 55 | medium | New `http_error` field in status + red banner in Settings when port 7777 is held. |
| 56 | medium | /health uses `< HARD_CAP` so readiness leads eviction. |

Bumps 0.4.1 → 0.4.2.

## Test plan
- [x] cargo test — 38 pass (15 new validator tests + existing)
- [x] cargo clippy --all-targets -D warnings — clean
- [x] svelte-check — 0 errors
- [ ] Manual: register a remote on a fresh setup, ssh in, confirm `~/.claude.json` actually got the aiui entry
- [ ] Manual: register `-evil` as remote, expect refusal
- [ ] Manual: occupy port 7777 with another process, launch aiui, expect red banner