### PR TITLE
v0.4.4: break the chat-first default (instructions + imperative voice + /aiui:teach)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.4] — 2026-04-26
+
+### Added
+
+- **`initialize.instructions` injection.** The MCP `initialize` response
+  now carries a top-level `instructions` string that Claude Code (and
+  Claude Desktop) feed to the agent before the first turn. Short
+  imperative brief telling the agent to default to dialogs for yes/no,
+  pick-one-of-N, and multi-input prompts. Replaces the previous purely
+  passive trigger model where the agent had to *deduce* aiui-relevance
+  from the skill description.
+- **`/aiui:teach` slash-command** as a discoverable alias for
+  `/aiui:widgets`. Same content (full widget catalog), more telling
+  name. The old `/aiui:widgets` keeps working.
+
+### Changed
+
+- **Tool descriptions on imperative voice** ("Before writing a yes/no
+  question into chat, call this tool instead.") instead of "USE WHEN…".
+  Same content, but framed as a directive — gives the agent a stronger
+  pull out of the chat-first default.
+- **Skill frontmatter description** rewritten to start with the trigger
+  ("Before writing a yes/no question, a numbered option list, or a
+  multi-question request into the chat, …"). Same goal: prime the
+  agent to *use* aiui rather than *consider* aiui.
+- **`aiui-mcp` PyPI 0.4.0 → 0.4.1** for parity (instructions field,
+  imperative docstrings, `/aiui:teach` alias).
+
 ## [0.4.3] — 2026-04-26
 
 ### Changed

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "aiui companion — renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.2"
+version = "0.4.4"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.3"
+version = "0.4.4"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -22,6 +22,26 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 const SKILL_MD: &str = include_str!("../../../docs/skill.md");
 
+/// Top-level instruction string returned in the `initialize` MCP response.
+/// Loaded by the client (Claude Code / Claude Desktop) as a session-wide
+/// hint, *before* the agent decides how to respond to anything. This is
+/// what shifts the agent's default away from chat-first replies on the
+/// kind of prompts aiui is meant to handle.
+const INSTRUCTIONS: &str = "\
+aiui is connected — you can render native dialogs on the user's Mac \
+instead of asking via chat. Default behaviour for this session:
+
+- Yes/no question (esp. before delete / drop / force-push / deploy) → \
+  call `confirm` instead of asking in chat.
+- Pick-one-of-N options where context per option matters → call `ask`.
+- Multiple related inputs, secret, date, slider, sortable order, \
+  table-row triage, image confirm/grid → call `form`.
+- Pure information the user only reads → keep it in chat.
+
+Type `/aiui:teach` (or `/aiui:widgets`) for the full widget catalog \
+when composing a complex form.
+";
+
 const UPDATE_PROMPT: &str = "\
 Check whether an aiui update is available and install it if so. Call the \
 `update` tool now, then report back concisely:
@@ -173,7 +193,15 @@ async fn dispatch(
             "serverInfo": {
                 "name": "aiui",
                 "version": env!("CARGO_PKG_VERSION")
-            }
+            },
+            // MCP `instructions` is the only spec-sanctioned way to push a
+            // top-level hint into every session at handshake time. We use it
+            // to break the LLM's chat-first default — without this nudge, the
+            // skill description and tool descriptions are passive triggers
+            // that rarely fire on plain "Should I … ?" prompts. Kept short
+            // (≤ 500 chars) on purpose; the full widget catalog still lives
+            // in `prompts/get widgets`.
+            "instructions": INSTRUCTIONS
         })),
         "tools/list" => Ok(json!({ "tools": tools_list() })),
         "tools/call" => tools_call(params, cfg, http).await,
@@ -192,7 +220,7 @@ fn tools_list() -> Value {
     json!([
         {
             "name": "confirm",
-            "description": "USE WHEN you would otherwise ask the user a yes/no question in chat — and ALWAYS before any irreversible step (delete, drop, force-push, rollback, prod deploy). Renders a native macOS yes/no window; pass `destructive: true` for a red confirm button on dangerous actions. Returns {cancelled, confirmed}. For 3+ options, use `ask`. For information the user only reads, render in chat.",
+            "description": "Before writing any yes/no question into chat, call this tool instead. Pass `destructive: true` (red button) for delete / drop / force-push / rollback / prod-deploy — never trust loose prior approval for irreversible steps; re-confirm in a dialog. Returns {cancelled, confirmed}. For 3+ options, use `ask`. For pure information the user only reads, render in chat.",
             "inputSchema": {
                 "type": "object",
                 "required": ["title"],
@@ -208,7 +236,7 @@ fn tools_list() -> Value {
         },
         {
             "name": "ask",
-            "description": "USE WHEN you would otherwise list options in chat and wait for the user to type back which one — picking a deploy strategy, a migration path, a file to act on, etc. Renders a native macOS choice window with per-option descriptions, optional multi-select and free-text fallback. Returns {cancelled, answers, other?}. For yes/no, use `confirm`. For ≥ 2 related inputs, use `form`.",
+            "description": "Before listing options in chat and waiting for the user to type back which one (deploy strategy, migration path, file to act on …), call this tool instead. Per-option `description` carries the trade-off; `multi_select` and `allow_other` cover the rest. Returns {cancelled, answers, other?}. For yes/no, use `confirm`. For ≥ 2 related inputs, use `form`.",
             "inputSchema": {
                 "type": "object",
                 "required": ["question", "options"],
@@ -234,7 +262,7 @@ fn tools_list() -> Value {
         },
         {
             "name": "form",
-            "description": "USE WHEN the user needs to give you ≥ 2 related inputs, or any single input that's better entered somewhere other than the chat — secrets (password field, masked on screen), dates and ranges (date, datetime, date_range), bounded numbers (slider), sortable rankings (list, also with thumbnails), multi-selects, color picks, table-row triage with column context, image preview/grid for visual confirmation. Renders a native macOS form window. Fields: text, password, number, select, checkbox, slider, date, datetime, date_range, color, static_text, markdown, image, image_grid, list, table, tree. Group long forms with `tabs: [{label, fields: [...]}]` instead of `fields` (one submit, all tabs validated together). Footer actions support primary (blue), success (green), destructive (red). Returns {cancelled, action?, values}. For yes/no, use `confirm`. For one option pick, use `ask`.",
+            "description": "Whenever the user needs to provide ≥ 2 related inputs, or any single input that doesn't belong in chat (secret, date/datetime/range, bounded number, sortable ranking, multi-select, color pick, table-row triage with column context, image confirm/grid), call this tool instead of typing the questions one by one. Fields: text, password, number, select, checkbox, slider, date, datetime, date_range, color, static_text, markdown, image, image_grid, list, table, tree. Group long forms with `tabs: [{label, fields: [...]}]` (one submit, all tabs validated). Footer actions support primary (blue), success (green), destructive (red). Returns {cancelled, action?, values}. For yes/no, use `confirm`. For one-of-N pick, use `ask`.",
             "inputSchema": {
                 "type": "object",
                 "required": ["title"],
@@ -497,6 +525,11 @@ fn prompts_list() -> Value {
             "arguments": []
         },
         {
+            "name": "teach",
+            "description": "Brief the agent on aiui — same content as /aiui:widgets, but with a more discoverable name. Run once per project to give the agent the full widget catalog and design rules.",
+            "arguments": []
+        },
+        {
             "name": "update",
             "description": "Check for an aiui update and install it silently, reporting the outcome.",
             "arguments": []
@@ -531,7 +564,7 @@ fn prompts_get(params: Value) -> Result<Value, RpcError> {
         .unwrap_or("")
         .to_string();
     let text = match name.as_str() {
-        "widgets" => SKILL_MD,
+        "widgets" | "teach" => SKILL_MD,
         "update" => UPDATE_PROMPT,
         "version" => VERSION_PROMPT,
         "health" => HEALTH_PROMPT,

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -1,6 +1,6 @@
 ---
 name: aiui widgets
-description: Open a native macOS dialog on the user's Mac instead of asking via chat — for yes/no decisions, picking between options, multi-field input, sorting, dates, sliders, or secrets. Reach for it whenever you would otherwise put a question or numbered option list into the chat and wait for a typed reply, and *always* before any irreversible step (delete, force-push, drop, deploy to prod).
+description: Before writing a yes/no question, a numbered option list, or a multi-question request into the chat, open a native macOS dialog instead — `confirm` for yes/no (always for delete/force-push/drop/deploy), `ask` for one-of-N with per-option context, `form` for ≥ 2 related inputs / secrets / dates / sliders / sortable lists / table-row triage / image confirm.
 ---
 
 # aiui — Dialog design for Claude agents

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/aiui_mcp/server.py
+++ b/python/src/aiui_mcp/server.py
@@ -54,7 +54,26 @@ ENDPOINT = os.environ.get("AIUI_ENDPOINT", "http://127.0.0.1:7777")
 TIMEOUT_S = float(os.environ.get("AIUI_TIMEOUT_S", "120"))
 HEALTH_TIMEOUT_S = float(os.environ.get("AIUI_HEALTH_TIMEOUT_S", "3"))
 
-mcp = FastMCP("aiui")
+_INSTRUCTIONS = """\
+aiui is connected — you can render native dialogs on the user's Mac \
+instead of asking via chat. Default behaviour for this session:
+
+- Yes/no question (esp. before delete / drop / force-push / deploy) → \
+  call `confirm` instead of asking in chat.
+- Pick-one-of-N options where context per option matters → call `ask`.
+- Multiple related inputs, secret, date, slider, sortable order, \
+  table-row triage, image confirm/grid → call `form`.
+- Pure information the user only reads → keep it in chat.
+
+Type `/aiui:teach` (or `/aiui:widgets`) for the full widget catalog \
+when composing a complex form.
+"""
+
+# `instructions` is the spec-sanctioned way to push a top-level hint
+# into every session at the MCP handshake — Claude Code (and Claude
+# Desktop) feed it to the agent before the first turn.  Kept short on
+# purpose; the full catalog lives in the `widgets`/`teach` prompts.
+mcp = FastMCP("aiui", instructions=_INSTRUCTIONS)
 
 
 def _token() -> str:
@@ -141,10 +160,10 @@ async def ask(
     multi_select: bool = False,
     allow_other: bool = True,
 ) -> dict[str, Any]:
-    """USE WHEN you would otherwise list options in chat and wait for the user
-    to type back which one — picking a deploy strategy, a migration path,
-    a file to act on, etc. Renders a native macOS choice window with
-    per-option descriptions, optional multi-select and free-text fallback.
+    """Before listing options in chat and waiting for the user to type back
+    which one (deploy strategy, migration path, file to act on …), call
+    this tool instead. Per-option `description` carries the trade-off;
+    `multi_select` and `allow_other` cover the rest.
 
     WHEN TO USE: 2–6 mutually-exclusive options where per-option context helps.
     For yes/no, use `confirm`. For mixed inputs, use `form`.
@@ -188,11 +207,11 @@ async def form(
     submit_label: str | None = None,
     cancel_label: str | None = None,
 ) -> dict[str, Any]:
-    """USE WHEN the user needs to give you ≥ 2 related inputs, or any single
-    input that's better entered somewhere other than the chat — secrets
-    (password, masked on screen), dates and ranges, bounded numbers (slider),
-    sortable rankings, multi-selects, color picks. Renders a native macOS
-    form window with multiple typed fields + multiple action buttons.
+    """Whenever the user needs to provide ≥ 2 related inputs, or any single
+    input that doesn't belong in chat (secret, date/datetime/range,
+    bounded number, sortable ranking, multi-select, color pick,
+    table-row triage with column context, image confirm/grid), call
+    this tool instead of typing the questions one by one.
 
     WHEN TO USE: ≥ 2 related inputs, or one input plus context/confirmation.
     For yes/no, use `confirm`. For a single choice, use `ask`.
@@ -289,10 +308,10 @@ async def confirm(
     confirm_label: str | None = None,
     cancel_label: str | None = None,
 ) -> dict[str, Any]:
-    """USE WHEN you would otherwise ask the user a yes/no question in chat —
-    and ALWAYS before any irreversible step (delete, drop, force-push,
-    rollback, prod deploy). Renders a native macOS yes/no window; pass
-    `destructive=True` for a red confirm button on dangerous actions.
+    """Before writing any yes/no question into chat, call this tool instead.
+    Pass `destructive=True` (red button) for delete / drop / force-push /
+    rollback / prod-deploy — never trust loose prior approval for
+    irreversible steps; re-confirm in a dialog.
 
     WHEN TO USE: irreversible or high-stakes step where "just proceed" is
     unsafe. For pure information, respond in chat. For 3+ options, use `ask`.
@@ -327,11 +346,7 @@ async def confirm(
     return _format_result(await _post_render(spec))
 
 
-@mcp.prompt()
-def widgets() -> str:
-    """The full aiui widget catalog — when to use which dialog, copy
-    conventions, anti-patterns, example payloads. Read before composing the
-    first dialog in a session."""
+def _widget_catalog() -> str:
     try:
         return (resources.files("aiui_mcp") / "skill.md").read_text()
     except Exception:
@@ -339,6 +354,22 @@ def widgets() -> str:
             "aiui skill doc not bundled with this install. "
             "See https://github.com/byte5ai/aiui/blob/main/docs/skill.md"
         )
+
+
+@mcp.prompt()
+def widgets() -> str:
+    """The full aiui widget catalog — when to use which dialog, copy
+    conventions, anti-patterns, example payloads. Read before composing the
+    first dialog in a session."""
+    return _widget_catalog()
+
+
+@mcp.prompt(name="teach")
+def teach_prompt() -> str:
+    """Brief the agent on aiui — same content as `/aiui:widgets`, but with
+    a more discoverable name. Run once per project to give the agent the
+    full widget catalog and design rules."""
+    return _widget_catalog()
 
 
 # Prompt texts kept in sync verbatim with the Rust MCP server

--- a/python/src/aiui_mcp/skill.md
+++ b/python/src/aiui_mcp/skill.md
@@ -1,6 +1,6 @@
 ---
 name: aiui widgets
-description: Open a native macOS dialog on the user's Mac instead of asking via chat — for yes/no decisions, picking between options, multi-field input, sorting, dates, sliders, or secrets. Reach for it whenever you would otherwise put a question or numbered option list into the chat and wait for a typed reply, and *always* before any irreversible step (delete, force-push, drop, deploy to prod).
+description: Before writing a yes/no question, a numbered option list, or a multi-question request into the chat, open a native macOS dialog instead — `confirm` for yes/no (always for delete/force-push/drop/deploy), `ask` for one-of-N with per-option context, `form` for ≥ 2 related inputs / secrets / dates / sliders / sortable lists / table-row triage / image confirm.
 ---
 
 # aiui — Dialog design for Claude agents


### PR DESCRIPTION
Fixes the empirical observation that even with all our discoverability work, agents (incl. Claude Code itself) only reach for aiui on explicit user request.

## Three active counter-pulls

1. **`initialize.instructions`** — MCP-spec-sanctioned top-level hint pushed at handshake time. Claude Code/Desktop feed it to the agent before the first turn. Short, imperative, trigger-scoped. The first thing in this PR that's *not* a passive trigger.
2. **Imperative tool descriptions** — "Before writing a yes/no question into chat, call this tool instead." replaces "USE WHEN you would otherwise …". Same content, framed as a directive.
3. **Imperative skill frontmatter** — trigger-first instead of capability-first.

## Discoverable rename

`/aiui:teach` alias for `/aiui:widgets` (both work). The old name was a leftover from the "list of widgets" era; today the prompt *briefs* the agent.

## Versions

- aiui companion 0.4.3 → 0.4.4
- aiui-mcp PyPI 0.4.0 → 0.4.1

## Test plan

- [x] cargo check + clippy --all-targets -D warnings clean
- [x] cargo test — 38 pass
- [x] svelte-check — 0 errors
- [x] Rust MCP smoke: initialize.instructions returns 591 chars; prompts/list returns 7 incl. `teach`
- [x] Python MCP smoke: same shape (595 chars instructions, `teach` alias)
- [ ] Manual after release: open a fresh Claude Code session and observe whether the agent reaches for confirm/ask/form unprompted on plain Y/N requests