### PR TITLE
v0.4.5: drop /aiui:widgets, keep only /aiui:teach (pre-1.0 cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.5] — 2026-04-26
+
+### Removed (breaking, pre-1.0)
+
+- **`/aiui:widgets` slash-command.** Replaced by `/aiui:teach` (added
+  in 0.4.4 as an alias). The `widgets` name was a leftover from the
+  era when the command listed widget names; today it briefs the agent
+  on the full design rules. Cleaning up before a wider audience picks
+  up the old name from old blog posts. Same goes for the skill
+  frontmatter `name`: `aiui widgets` → `aiui`.
+
+### Notes
+
+- Anyone who picked up the alias in v0.4.4 only needs to type
+  `/aiui:teach` from now on. Same content, same effect.
+- `aiui-mcp` PyPI 0.4.1 → 0.4.2 for parity.
+
 ## [0.4.4] — 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ settings.
 
 | Command | What it does |
 |---|---|
-| `/aiui:widgets` | Loads the full widget catalog into the session. Use this right before UI-heavy work so the agent has the rules in context. |
+| `/aiui:teach` | Briefs the agent on aiui — loads the full widget catalog and design rules into the session. Run once per project. |
 | `/aiui:update` | Agent calls the `update` tool; aiui checks the release feed, silently installs any available update, and reports the version delta back. Responds before the background relaunch, so the agent always gets the answer. |
 | `/aiui:version` | Reports the currently installed aiui version in one line. |
 

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiui-companion",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "aiui companion — renders dialogs for remote Claude Code sessions",
   "type": "module",
   "scripts": {

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.4"
+version = "0.4.5"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -38,8 +38,8 @@ instead of asking via chat. Default behaviour for this session:
   table-row triage, image confirm/grid → call `form`.
 - Pure information the user only reads → keep it in chat.
 
-Type `/aiui:teach` (or `/aiui:widgets`) for the full widget catalog \
-when composing a complex form.
+Type `/aiui:teach` for the full widget catalog when composing a \
+complex form.
 ";
 
 const UPDATE_PROMPT: &str = "\
@@ -520,13 +520,8 @@ fn format_dialog_result(render: Value) -> Value {
 fn prompts_list() -> Value {
     json!([
         {
-            "name": "widgets",
-            "description": "Full widget catalog, rules, and patterns for building aiui dialogs. Load at the start of UI-heavy work.",
-            "arguments": []
-        },
-        {
             "name": "teach",
-            "description": "Brief the agent on aiui — same content as /aiui:widgets, but with a more discoverable name. Run once per project to give the agent the full widget catalog and design rules.",
+            "description": "Brief the agent on aiui. Loads the full widget catalog, design rules, and anti-patterns into the session. Run once per project so the agent reaches for the right dialog without further prompting.",
             "arguments": []
         },
         {
@@ -564,7 +559,7 @@ fn prompts_get(params: Value) -> Result<Value, RpcError> {
         .unwrap_or("")
         .to_string();
     let text = match name.as_str() {
-        "widgets" | "teach" => SKILL_MD,
+        "teach" => SKILL_MD,
         "update" => UPDATE_PROMPT,
         "version" => VERSION_PROMPT,
         "health" => HEALTH_PROMPT,

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -10,7 +10,7 @@
     "welcome.title": "aiui ist eingerichtet",
     "welcome.body": "Claude Code kann jetzt native Fenster auf diesem Mac öffnen, statt Dich im Chat zu fragen. Probier in einer Claude-Code-Session:",
     "welcome.point.test": "/aiui:test-dialog — kurzer Demo-Dialog zum Verifizieren.",
-    "welcome.point.skill": "/aiui:widgets — lädt das Agent-Skill, damit künftige Agents von alleine Fenster nutzen.",
+    "welcome.point.skill": "/aiui:teach — briefst den Agent auf aiui, dann greift er von selbst zu Fenstern.",
     "welcome.point.remote": "Arbeitest Du via SSH auf einem Dev-Host? Trag ihn unten ein, aiui tunnelt die Dialoge zurück.",
     "welcome.cta": "Verstanden",
     "welcome.dismiss": "Schließen",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -10,7 +10,7 @@
     "welcome.title": "aiui is set up",
     "welcome.body": "Claude Code can now open native dialogs on this Mac instead of asking you in chat. Try one of these in any Claude Code session:",
     "welcome.point.test": "Type /aiui:test-dialog — pops a small demo window so you can verify the wiring.",
-    "welcome.point.skill": "Type /aiui:widgets — loads the agent skill so the next agent uses dialogs without prompting.",
+    "welcome.point.skill": "Type /aiui:teach — briefs the agent on aiui so it reaches for dialogs without prompting.",
     "welcome.point.remote": "Working over SSH? Add the dev host below and aiui tunnels dialogs back to your Mac.",
     "welcome.cta": "Got it",
     "welcome.dismiss": "Dismiss",

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -1,5 +1,5 @@
 ---
-name: aiui widgets
+name: aiui
 description: Before writing a yes/no question, a numbered option list, or a multi-question request into the chat, open a native macOS dialog instead — `confirm` for yes/no (always for delete/force-push/drop/deploy), `ask` for one-of-N with per-option context, `form` for ≥ 2 related inputs / secrets / dates / sliders / sortable lists / table-row triage / image confirm.
 ---
 

--- a/python/README.md
+++ b/python/README.md
@@ -30,7 +30,7 @@ See the main repo for the full install flow and companion download:
 
 ## Prompts
 
-- `/aiui:widgets` — full widget catalog with rules, patterns, anti-patterns
+- `/aiui:teach` — briefs the agent on aiui (full widget catalog, design rules, anti-patterns)
 
 ## License
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/aiui_mcp/server.py
+++ b/python/src/aiui_mcp/server.py
@@ -65,8 +65,8 @@ instead of asking via chat. Default behaviour for this session:
   table-row triage, image confirm/grid → call `form`.
 - Pure information the user only reads → keep it in chat.
 
-Type `/aiui:teach` (or `/aiui:widgets`) for the full widget catalog \
-when composing a complex form.
+Type `/aiui:teach` for the full widget catalog when composing a \
+complex form.
 """
 
 # `instructions` is the spec-sanctioned way to push a top-level hint
@@ -346,7 +346,11 @@ async def confirm(
     return _format_result(await _post_render(spec))
 
 
-def _widget_catalog() -> str:
+@mcp.prompt(name="teach")
+def teach_prompt() -> str:
+    """Brief the agent on aiui. Loads the full widget catalog, design
+    rules, and anti-patterns into the session. Run once per project so
+    the agent reaches for the right dialog without further prompting."""
     try:
         return (resources.files("aiui_mcp") / "skill.md").read_text()
     except Exception:
@@ -354,22 +358,6 @@ def _widget_catalog() -> str:
             "aiui skill doc not bundled with this install. "
             "See https://github.com/byte5ai/aiui/blob/main/docs/skill.md"
         )
-
-
-@mcp.prompt()
-def widgets() -> str:
-    """The full aiui widget catalog — when to use which dialog, copy
-    conventions, anti-patterns, example payloads. Read before composing the
-    first dialog in a session."""
-    return _widget_catalog()
-
-
-@mcp.prompt(name="teach")
-def teach_prompt() -> str:
-    """Brief the agent on aiui — same content as `/aiui:widgets`, but with
-    a more discoverable name. Run once per project to give the agent the
-    full widget catalog and design rules."""
-    return _widget_catalog()
 
 
 # Prompt texts kept in sync verbatim with the Rust MCP server

--- a/python/src/aiui_mcp/skill.md
+++ b/python/src/aiui_mcp/skill.md
@@ -1,5 +1,5 @@
 ---
-name: aiui widgets
+name: aiui
 description: Before writing a yes/no question, a numbered option list, or a multi-question request into the chat, open a native macOS dialog instead — `confirm` for yes/no (always for delete/force-push/drop/deploy), `ask` for one-of-N with per-option context, `form` for ≥ 2 related inputs / secrets / dates / sliders / sortable lists / table-row triage / image confirm.
 ---
 


### PR DESCRIPTION
Two days into the alias from v0.4.4 — clean up before HN picks up the old name. Single sharp story is worth more than backward compatibility for an alias nobody depends on yet.

- `/aiui:widgets` removed from prompts/list and prompts/get (Rust + Python)
- `initialize.instructions`, README, welcome banner i18n point only at `/aiui:teach`
- Skill frontmatter `name: aiui widgets` → `name: aiui` (the directory is `~/.claude/skills/aiui`, the doubled name was always redundant)

Bumps companion 0.4.4 → 0.4.5, aiui-mcp 0.4.1 → 0.4.2.