### PR TITLE
chore: bump v0.4.6 — onboarding fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.6] — 2026-04-26
+
+### Fixed
+
+- **`/aiui:test-dialog` returned "Unknown command" on Claude Desktop.**
+  Root cause: `claude_desktop_config.json` was written under the key
+  `aiui-local` while `~/.claude.json` used `aiui`. Slash commands on
+  Claude Desktop would have needed `/aiui-local:test-dialog`. Both
+  configs now use `aiui`; legacy `aiui-local` entry is removed on every
+  patch (idempotent for fresh installs, healing for upgrades).
+
+### Changed
+
+- **Welcome banner is a live setup health-check.** Replaces the static
+  "everything ready" copy with four real checks read at refresh time:
+  Claude Desktop config registered, Claude Code config registered,
+  skill installed, HTTP server up. Each row shows ✓ / miss in real time.
+  Banner now also tells the user explicitly that aiui does **not**
+  appear in Claude Desktop's Connectors list — that's only for cloud
+  services.
+- **"Skill installieren" button replaced with status row.** The old
+  button suggested optionality where there isn't any (the skill is
+  mandatory and auto-installed every GUI launch). Now a quiet "Skill
+  installiert ✓" row by default; only if the file is missing does a
+  red row + "Skill reparieren" button appear.
+
+### Added
+
+- **"Test-Dialog jetzt" button.** Pops a small confirm dialog through
+  the local aiui server, end-to-end, without going through Claude.
+  Verifies the wiring strecke independently.
+- **"Claude Desktop (neu) starten" button.** Quits + relaunches Claude
+  Desktop so it re-reads the current `claude_desktop_config.json`
+  entry. Label switches between Start / Restart depending on whether
+  Claude is running.
+- **Uninstall completion modal.** After Uninstall removes configs,
+  tokens, and the skill, a modal explains that and points the user at
+  the Finder for the actual `.app` removal — running app self-deleting
+  is fragile, and "Uninstall" is honest about being a configuration
+  cleanup, not self-destruct.
+
 ## [0.4.5] — 2026-04-26
 
 ### Removed (breaking, pre-1.0)

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.5"
+version = "0.4.6"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
Bumpt auf v0.4.6, damit der In-App-Updater die Onboarding-Fixes aus #68 anbietet. CHANGELOG-Entry erfasst die User-facing Änderungen (Server-Naming, Health-Check-Welcome, Test-Dialog-Button, Claude-Desktop-Restart-Button, Skill-Status, Uninstall-Modal).

Kein Release-Tag in diesem PR — wird vom \`scripts/release.sh\`-Run getriggert sobald lokale Verifikation auf dem Tester-Mac durch ist.

## Test Plan
- [x] Versionen in Cargo.toml + tauri.conf.json synchron
- [x] CHANGELOG-Entry zeitlich korrekt einsortiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)