### PR TITLE
fix: Rust-side HTTP liveness probe + sticky footer (v0.4.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.9] — 2026-04-27
+
+### Fixed
+
+- **HTTP-server liveness probe now actually works on macOS.** v0.4.8's
+  fix for the stale `http_error` banner used a WebView `fetch()` to
+  poll `/ping`. macOS App Transport Security blocks plaintext HTTP
+  requests from WKWebView by default — including to localhost — so the
+  probe always failed and the banner stayed permanently red on healthy
+  servers. The probe now runs Rust-side: a quick TCP connect to
+  `localhost:cfg.http_port` with 200 ms timeout, result delivered as
+  `http_alive: bool` in the existing `StatusReport`. Tokio doesn't go
+  through WebView's net stack, so ATS is irrelevant. Closes #77.
+- **Settings footer no longer rolls under the fold.** With the welcome
+  banner expanded the content exceeded the fixed 560 px window and the
+  Uninstall / Updates / Report buttons disappeared below the bottom
+  edge — invisible without scrolling, which macOS settings panes
+  conventionally don't have. Footer is now `position: sticky; bottom: 0`
+  with an opaque background, pinned to the visible viewport while
+  content scrolls above. Closes #78.
+
 ## [0.4.8] — 2026-04-27
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.8"
+version = "0.4.9"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -111,6 +111,12 @@ struct StatusReport {
     /// red banner in Settings so the user knows why dialogs aren't
     /// landing.
     http_error: Option<String>,
+    /// Live result of a TCP self-probe to `localhost:http_port`. The Rust
+    /// side does this for us because a WebView `fetch()` would be blocked
+    /// by macOS App Transport Security (ATS) on plaintext localhost
+    /// requests — that's how v0.4.8 ended up showing a permanent red
+    /// banner on a perfectly healthy server. Issue #77.
+    http_alive: bool,
 }
 
 #[tauri::command]
@@ -120,6 +126,7 @@ async fn status(
     http_err: tauri::State<'_, Arc<std::sync::Mutex<Option<String>>>>,
 ) -> Result<StatusReport, String> {
     let bin = setup::app_binary_path();
+    let http_alive = probe_http_self(cfg.http_port).await;
     Ok(StatusReport {
         app_binary_path: bin.clone(),
         token_path: cfg.token_path.display().to_string(),
@@ -133,7 +140,25 @@ async fn status(
         build_info: logging::BUILD_INFO,
         welcome_pending: is_first_run(&cfg),
         http_error: http_err.lock().ok().and_then(|s| s.clone()),
+        http_alive,
     })
+}
+
+/// Quick TCP self-connect to verify our own HTTP server is actually
+/// accepting connections. Done from Rust because a WebView `fetch()`
+/// would be ATS-blocked on macOS for plaintext localhost. 200ms timeout
+/// is plenty for loopback — if the server can't accept in that window
+/// we treat it as down. Issue #77.
+async fn probe_http_self(port: u16) -> bool {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    matches!(
+        tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            tokio::net::TcpStream::connect(&addr),
+        )
+        .await,
+        Ok(Ok(_))
+    )
 }
 
 /// Marks the welcome banner as dismissed so it doesn't reappear on the

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/app.css
+++ b/companion/src/app.css
@@ -193,12 +193,32 @@ label {
 }
 
 .footer {
+  /* `margin-top: auto` keeps the footer pinned to the bottom of the
+     visible viewport when content fits. `position: sticky; bottom: 0`
+     keeps it pinned there even when the content above scrolls. Without
+     this, the welcome banner pushes the footer (with Uninstall etc.)
+     below the fold — and macOS settings windows aren't typically
+     scrollable, so users miss the buttons entirely. Issue #78. */
   margin-top: auto;
+  position: sticky;
+  bottom: 0;
   display: flex;
   justify-content: flex-end;
   gap: 8px;
   padding-top: 12px;
+  /* Opaque background so scrolled content doesn't show through. Use the
+     same color as `.container`'s parent background to blend in. */
+  background: var(--bg);
   border-top: 1px solid var(--border);
+  /* Pull-out below the container's bottom padding so the border sits
+     flush with the window edge while the buttons keep their breathing
+     room above. */
+  margin-left: -20px;
+  margin-right: -20px;
+  padding-left: 20px;
+  padding-right: 20px;
+  margin-bottom: -16px;
+  padding-bottom: 16px;
 }
 
 code {

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -25,6 +25,7 @@
     build_info: string;
     welcome_pending: boolean;
     http_error: string | null;
+    http_alive: boolean;
   };
   let status = $state<Status | null>(null);
   let newHost = $state("");
@@ -33,32 +34,14 @@
   let confirmUninstall = $state(false);
   let uninstallDone = $state(false);
   let demoCopied = $state(false);
-  /** Live result of the last `/ping` probe. The Rust-side `http_error`
-   *  field in the status report is set only at startup and never reset,
-   *  so it can lie if the server later recovered (or if a transient
-   *  squatter is gone now). We therefore probe every refresh and treat
-   *  THIS as the source of truth for "is the server actually alive?".
-   *  Issue #74. */
-  let httpAlive = $state(true);
   let timer: number | undefined;
 
-  async function probeHttp(port: number): Promise<boolean> {
-    try {
-      const resp = await fetch(`http://127.0.0.1:${port}/ping`, {
-        // /ping is unauthenticated and returns "pong" plain-text; a 200
-        // proves the HTTP server is bound and responsive.
-        signal: AbortSignal.timeout(800),
-      });
-      return resp.ok;
-    } catch {
-      return false;
-    }
-  }
-
   async function refresh() {
-    const next = await invoke<Status>("status");
-    httpAlive = await probeHttp(next.http_port);
-    status = next;
+    // The status report carries `http_alive` from a Rust-side TCP
+    // self-probe — WebView `fetch()` would be ATS-blocked on macOS for
+    // plaintext localhost, which is how v0.4.8 ended up with a permanent
+    // false-positive banner. Issue #77.
+    status = await invoke<Status>("status");
   }
 
   function pushLog(results: StepResult[]) {
@@ -215,12 +198,12 @@
       <div class="build-info" title={status.build_info}>{status.build_info.split(" ")[1]}</div>
     </header>
 
-    <!-- Show the banner only when the LIVE probe says the HTTP server is
-      actually unreachable. The Rust-side `status.http_error` is the
-      original bind-failure reason if any — useful as the explanatory
-      hint, but on its own it's a stale flag once the server later
-      recovers. Issue #74. -->
-    {#if !httpAlive}
+    <!-- Show the banner only when the live Rust-side TCP self-probe says
+      the HTTP server isn't accepting connections. `status.http_error` is
+      the explanatory text from the original bind-failure if any — but
+      it's not the source of truth for whether to show the banner; that's
+      `http_alive`. Issue #77. -->
+    {#if !status.http_alive}
       <section class="http-error">
         <strong>{$_("settings.http_error.title")}</strong>
         {#if status.http_error}


### PR DESCRIPTION
## Summary
v0.4.8 hatte zwei bekannte Defekte sobald getestet auf einem User-MacBook: der frische Banner-Self-Healing-Probe war ATS-blockiert (false-positive Banner) und der Settings-Footer rollte unter den Fold sobald das Welcome-Banner ausgeklappt war.

Closes #77, #78.

### #77 — ATS-Block-Bug im Live-Probe
Statt WebView \`fetch()\` macht jetzt das \`status\`-Tauri-Command einen Rust-seitigen TCP-Connect zu \`localhost:cfg.http_port\` mit 200 ms Timeout. Ergebnis als \`http_alive: bool\` im \`StatusReport\`. Frontend liest \`status.http_alive\` direkt — kein WebView-Roundtrip, ATS irrelevant.

### #78 — Footer rollte unter den Fold
\`.footer { position: sticky; bottom: 0; background: var(--bg); }\` — pinned am unteren Fensterrand wenn Content scrollt, klebt sonst weiterhin am Boden via \`margin-top: auto\`. Plus negative Side-Margins um die Border bündig mit der Container-Padding-Kante zu halten.

## Test Plan
- [x] cargo check + clippy --tests -- -D warnings clean
- [x] cargo test 38/38
- [x] npm run build clean
- [ ] Manuell auf User-MacBook (v0.4.9 frisch installiert): Banner ist NICHT da wenn Server läuft
- [ ] Manuell: aiui hat das Welcome-Banner offen → Footer-Buttons (Problem melden / Updates / Uninstall) sind sichtbar ohne Scroll, beim Scrollen oben kleben sie am unteren Fensterrand

🤖 Generated with [Claude Code](https://claude.com/claude-code)