### PR TITLE
v0.4.10: release-grade pass after Codex code review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,80 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.10] — 2026-04-27
+
+Release-grade pass. Codex-assisted code review (`docs/reviews/v0.4.10-codex-review.md`)
+plus structural fixes addressing several real defects that survived the
+v0.4.5 → v0.4.9 reactive cycle.
+
+### Fixed
+
+- **No more phantom GUIs on remote hosts.** `mcp_attach`'s auto-resurrect
+  loop now suppresses `open -a aiui --args --auto` when running in a
+  non-interactive session (SSH detected via `SSH_CONNECTION` /
+  `SSH_CLIENT` / `SSH_TTY`). On macmini and other dev hosts the MCP-stdio
+  child trusts the SSH-reverse-tunnel back to the user's machine instead
+  of spawning a window nobody can see. (#80)
+- **HTTP self-probe verifies the server is actually aiui.** Previous
+  v0.4.9 probe was a naked `TcpStream::connect` that any port-7777
+  squatter (sshd-session, unrelated process) would answer with TCP-SYN,
+  silently lying "healthy". Probe now hits `/probe` with the bearer
+  token and verifies the `aiui: true` marker. Anything else reads as
+  down. (#74, #77 revised)
+- **Bundle drift detector in release pipeline.** `scripts/release.sh`
+  now sanity-checks the `version` field across `Cargo.toml`,
+  `tauri.conf.json`, and the bundled `Info.plist` after `tauri build`.
+  Mismatch aborts the release before any tag/upload. (#82)
+- **Stale dialog state no longer leaks between consecutive renders.**
+  Dialog widgets (Confirm/Ask/Form) get a `{#key dialog.id}` wrapper so
+  Svelte unmounts the previous instance and remounts a fresh one for
+  every new render call. Previously, two consecutive same-kind dialogs
+  could carry over field values from the first into the second —
+  silently corrupting answers sent back to the caller.
+- **XSS surface closed.** Markdown fields in `form` are now piped
+  through DOMPurify before `{@html}`, with `<script>`, `<iframe>`,
+  `<form>`, `<input>`, `<button>` and inline event handlers stripped. A
+  meaningful CSP (`default-src 'self'; script-src 'self'; …`) replaces
+  the previous `csp: null`.
+- **Linux dev-host setup verifies `uvx aiui-mcp` reachability.**
+  `add_remote` does an SSH probe (`bash -lc 'uvx aiui-mcp --help'`)
+  before persisting a host. Hosts without `uv` installed fail fast with
+  a pointer to the install instructions instead of producing a broken
+  `~/.claude.json` entry. (#81)
+- **Idle-deadline survives suspend/resume.** mcp-stdio's 6 h
+  no-input-exit now double-checks the wall-clock elapsed time before
+  exiting; if a Tokio timer fires early after a long suspend, the loop
+  rearms instead of bailing.
+- **Idle-restart respects pending dialogs.** The 24h+ uptime + 10min
+  quiet WebView reload no longer fires while a dialog is still
+  registered — would have killed the user's open dialog mid-interaction
+  and dropped the answer.
+- **Cancellation reasons are now structured.** `RenderResponse` (and the
+  internal `DialogResult`) carries an optional `reason` field
+  (`ttl_expired`, `evicted`, `channel_dropped`) so MCP callers can
+  distinguish a user cancel from a registry-side timeout/eviction.
+- **Atomic writes for all user-config files.** `claude_desktop_config.json`,
+  `~/.claude.json`, `~/.ssh/config`, `~/.config/aiui/remotes.json`, and
+  the auth token now go through `fsutil::atomic_write` (sibling temp
+  file + fsync + rename). Crash mid-write leaves either the old file or
+  the new one — never a half-written corrupted destination.
+- **Trace log rotation.** `/tmp/aiui-trace.log` rotates to `.log.1` once
+  it crosses 4 MiB, on next process start. Prevents unbounded growth
+  under long auto-resurrect / multi-mcp-stdio fan-out.
+- **Release script is fail-fast.** `set -euo pipefail` at the top so a
+  half-finished release (jq missing, codesign failure, plist mismatch)
+  doesn't quietly continue to push tags or upload broken artifacts.
+
+### Changed
+
+- `is_interactive_session()` in `lifetime.rs` is the single decision
+  point for "should we ever launch a GUI here?". Cross-platform from the
+  start so the planned Windows port can extend without re-architecting.
+- Skill description (`docs/skill.md` frontmatter) reads cleanly in the
+  Claude slash-command help. No platform-specific copy in the
+  description; user-facing copy throughout has been swept for
+  unnecessary "macOS"/"Mac" mentions in preparation for the Windows port.
+
 ## [0.4.9] — 2026-04-27
 
 ### Fixed

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "aiui-companion",
-  "version": "0.3.3",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiui-companion",
-      "version": "0.3.3",
+      "version": "0.4.5",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
+        "dompurify": "^3.4.1",
         "marked": "^18.0.2",
         "svelte-i18n": "^4.0.1"
       },
@@ -988,6 +989,15 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
       "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/ds-store": {
       "version": "0.1.6",

--- a/companion/package.json
+++ b/companion/package.json
@@ -27,6 +27,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
+    "dompurify": "^3.4.1",
     "marked": "^18.0.2",
     "svelte-i18n": "^4.0.1"
   }

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.9"
+version = "0.4.10"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/config.rs
+++ b/companion/src-tauri/src/config.rs
@@ -1,3 +1,4 @@
+use crate::fsutil::atomic_write;
 use rand::RngCore;
 use std::fs;
 use std::io;
@@ -25,7 +26,7 @@ impl AppConfig {
             let mut bytes = [0u8; 32];
             rand::thread_rng().fill_bytes(&mut bytes);
             let t = hex::encode(bytes);
-            fs::write(&token_path, &t)?;
+            atomic_write(&token_path, t.as_bytes())?;
             // chmod 600
             #[cfg(unix)]
             {

--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -16,6 +16,16 @@ pub struct DialogResult {
     pub id: String,
     pub cancelled: bool,
     pub result: serde_json::Value,
+    /// Why the dialog ended. `None` for normal user-driven submit/cancel
+    /// (the existing semantics — `cancelled` alone tells you which).
+    /// `Some("ttl_expired")` when the registry sweep cancelled an entry
+    /// that sat unresolved past `DIALOG_TTL`. `Some("evicted")` when the
+    /// hard-cap kicked in and the oldest entry got pushed out. Lets
+    /// callers distinguish "user said no" from "we gave up on this
+    /// dialog" — and lets the tracelog explain why a render-call ended
+    /// without user input. Issue #H-5 in v0.4.10 review.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// How long an unresolved dialog may sit in the registry before opportunistic
@@ -84,11 +94,11 @@ impl DialogState {
             .collect();
         for stale_id in expired {
             if let Some(entry) = map.remove(&stale_id) {
-                // Cancel the waiter with the same shape `cancel()` would use.
                 let _ = entry.result_tx.send(DialogResult {
                     id: stale_id,
                     cancelled: true,
                     result: serde_json::Value::Null,
+                    reason: Some("ttl_expired".into()),
                 });
             }
         }
@@ -105,6 +115,7 @@ impl DialogState {
                         id: oldest_id,
                         cancelled: true,
                         result: serde_json::Value::Null,
+                        reason: Some("evicted".into()),
                     });
                 }
             }
@@ -140,6 +151,7 @@ impl DialogState {
                 id: id.to_string(),
                 cancelled: false,
                 result,
+                reason: None,
             });
         }
     }
@@ -151,6 +163,7 @@ impl DialogState {
                 id: id.to_string(),
                 cancelled: true,
                 result: serde_json::Value::Null,
+                reason: None,
             });
         }
     }

--- a/companion/src-tauri/src/fsutil.rs
+++ b/companion/src-tauri/src/fsutil.rs
@@ -1,0 +1,74 @@
+//! Small file-system utilities shared across modules.
+//!
+//! The only thing here today is `atomic_write`. Everything else stays
+//! in its caller.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Atomically write `content` to `path`: write to a sibling temp file
+/// first, fsync it, then rename over the destination. A crash or kill
+/// mid-write leaves either the old file (rename hasn't happened yet) or
+/// the new file (rename completed) — never a half-written/corrupted
+/// destination. Issue #M-2 in v0.4.10 review.
+pub fn atomic_write(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    // Sibling temp file so the rename stays on the same filesystem
+    // (cross-fs rename would degrade to copy+delete and lose atomicity).
+    // PID + nanos make the path unique enough that two concurrent writers
+    // to the same target won't trample each other's temp files.
+    let tmp = path.with_extension(format!(
+        "tmp.{}.{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)?;
+        f.write_all(content)?;
+        f.sync_all()?;
+    }
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_and_replaces() {
+        let dir = std::env::temp_dir().join(format!("aiui-fsutil-test-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let target = dir.join("a.txt");
+        atomic_write(&target, b"hello").unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), "hello");
+        atomic_write(&target, b"world").unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), "world");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn no_temp_files_left_behind_on_success() {
+        let dir = std::env::temp_dir().join(format!(
+            "aiui-fsutil-leftover-{}",
+            std::process::id()
+        ));
+        let _ = fs::create_dir_all(&dir);
+        let target = dir.join("b.txt");
+        atomic_write(&target, b"x").unwrap();
+        let entries: Vec<_> = fs::read_dir(&dir).unwrap().collect();
+        assert_eq!(entries.len(), 1, "only the target file should remain");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -68,6 +68,12 @@ struct RenderResponse {
     id: String,
     cancelled: bool,
     result: serde_json::Value,
+    /// Cancellation reason if the dialog ended without a user submit —
+    /// `ttl_expired`, `evicted`, `channel_dropped`. Omitted on normal
+    /// user-driven submit/cancel. Lets MCP callers distinguish "user
+    /// said no" from "we gave up". Issue #H-5 in v0.4.10 review.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
 }
 
 /// Composite health response. `ready` is true only when every sub-check is
@@ -448,18 +454,34 @@ async fn render(
     // while ago, reload the WebView before serving this one. Catches
     // accumulated drift (sleep/wake artefacts, stuck event listeners)
     // *exactly* when it would matter — not on a wall-clock timer.
+    //
+    // Important: never reload while a previous dialog is still pending.
+    // The reload tears down the WebView's JS state including any active
+    // dialog the user might be looking at, and the still-awaiting
+    // `/render` handler would get a `channel_dropped` cancellation
+    // instead of the user's actual answer. Only reload when the registry
+    // is empty. Issue #H-6 in v0.4.10 review.
     {
         let last = *state.last_render_at.lock().unwrap();
+        let pending = state.dialog.stats().orphan_count;
         if state.started_at.elapsed() > IDLE_RESTART_UPTIME
             && last.elapsed() > IDLE_RESTART_QUIET
+            && pending == 0
         {
             trace(&format!(
-                "render: idle-restart trigger (uptime {:?}, last_render {:?} ago)",
+                "render: idle-restart trigger (uptime {:?}, last_render {:?} ago, registry empty)",
                 state.started_at.elapsed(),
                 last.elapsed()
             ));
             reload_main_webview(&state.app);
             tokio::time::sleep(RELOAD_SETTLE).await;
+        } else if state.started_at.elapsed() > IDLE_RESTART_UPTIME
+            && last.elapsed() > IDLE_RESTART_QUIET
+        {
+            trace(&format!(
+                "render: idle-restart suppressed — {} pending dialog(s) in registry",
+                pending
+            ));
         }
     }
 
@@ -548,6 +570,7 @@ async fn render(
             id: id.clone(),
             cancelled: true,
             result: serde_json::Value::Null,
+            reason: Some("channel_dropped".into()),
         },
         Err(_) => {
             // TTL expired without user response. Cancel the registry
@@ -583,6 +606,7 @@ async fn render(
         id: result.id,
         cancelled: result.cancelled,
         result: result.result,
+        reason: result.reason,
     })
     .into_response()
 }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod ack;
 mod config;
 mod dialog;
+mod fsutil;
 mod housekeeping;
 mod http;
 mod lifetime;
@@ -126,7 +127,7 @@ async fn status(
     http_err: tauri::State<'_, Arc<std::sync::Mutex<Option<String>>>>,
 ) -> Result<StatusReport, String> {
     let bin = setup::app_binary_path();
-    let http_alive = probe_http_self(cfg.http_port).await;
+    let http_alive = probe_http_self(&cfg).await;
     Ok(StatusReport {
         app_binary_path: bin.clone(),
         token_path: cfg.token_path.display().to_string(),
@@ -144,21 +145,40 @@ async fn status(
     })
 }
 
-/// Quick TCP self-connect to verify our own HTTP server is actually
-/// accepting connections. Done from Rust because a WebView `fetch()`
-/// would be ATS-blocked on macOS for plaintext localhost. 200ms timeout
-/// is plenty for loopback — if the server can't accept in that window
-/// we treat it as down. Issue #77.
-async fn probe_http_self(port: u16) -> bool {
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    matches!(
-        tokio::time::timeout(
-            std::time::Duration::from_millis(200),
-            tokio::net::TcpStream::connect(&addr),
-        )
-        .await,
-        Ok(Ok(_))
-    )
+/// Authenticated HTTP self-probe to verify our own HTTP server is
+/// actually serving aiui. A naked TCP connect would lie positive when an
+/// SSH-session squatter or any other process happens to hold the port in
+/// LISTEN — the kernel answers SYN regardless of who's behind it. Issue
+/// #77 (revised in v0.4.10): we hit `/probe` with our bearer token and
+/// verify the response carries the aiui marker. Anything else (squatter
+/// without our token, non-aiui content, timeout) reads as "down".
+///
+/// 500 ms timeout to cover token-read + HTTP round-trip + JSON parse
+/// over loopback; this stays well under the Settings refresh interval.
+async fn probe_http_self(cfg: &config::AppConfig) -> bool {
+    let token = match std::fs::read_to_string(&cfg.token_path) {
+        Ok(s) => s.trim().to_string(),
+        Err(_) => return false,
+    };
+    let url = format!("http://127.0.0.1:{}/probe", cfg.http_port);
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let resp = match client.get(&url).bearer_auth(&token).send().await {
+        Ok(r) if r.status().is_success() => r,
+        _ => return false,
+    };
+    let body: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    body.get("aiui")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
 }
 
 /// Marks the welcome banner as dismissed so it doesn't reappear on the
@@ -265,6 +285,30 @@ async fn add_remote(
     }
 
     let mut results = Vec::new();
+
+    // Pre-flight: verify `uvx aiui-mcp` actually resolves on the remote
+    // before we touch any persistent state. Without this, add_remote
+    // silently writes `{"command": "uvx", "args": ["aiui-mcp"]}` to a
+    // ~/.claude.json on a host that has no uv installed — every Claude
+    // tool call afterwards errors with a confusing "command not found".
+    // Issue #H-3 in v0.4.10 review (also part of #81 Linux-devhost).
+    let reach_step = setup::check_remote_aiui_mcp(&host_alias);
+    let reach_ok = reach_step.ok;
+    results.push(reach_step);
+    if !reach_ok {
+        // Bail before persisting. Token push, ssh-config edit, tunnel
+        // start — none of it is useful if the MCP entry won't resolve.
+        results.push(setup::StepResult {
+            ok: false,
+            message: format!(
+                "Setup für '{host_alias}' abgebrochen — uvx aiui-mcp ist auf dem Host nicht erreichbar."
+            ),
+            details: Some(
+                "Installiere uv auf dem Remote (https://docs.astral.sh/uv/) und versuche es erneut.".into(),
+            ),
+        });
+        return Ok(results);
+    }
 
     // Legacy cleanup: earlier versions (≤ v0.1.1) patched the user's
     // ~/.ssh/config with a RemoteForward line. aiui now owns the tunnel

--- a/companion/src-tauri/src/lifetime.rs
+++ b/companion/src-tauri/src/lifetime.rs
@@ -123,16 +123,48 @@ pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
     }
 }
 
-/// MCP-stdio-side: keep the GUI alive for the entire lifetime of this
-/// MCP child process. If the GUI isn't running, launch it. If it dies
-/// (user Cmd-Q'd, crash, whatever), relaunch and reattach. The loop only
-/// exits when this MCP-stdio process itself is terminated — which
-/// happens when Claude Desktop tears down its MCP children.
+/// True iff this process appears to be running in an interactive desktop
+/// session — i.e. somewhere a user could see a window. Returns false on
+/// remote/headless contexts (SSH, CI, docker exec) where launching a GUI
+/// would create a phantom window nobody can see and that holds port 7777
+/// hostage. Issue #80.
 ///
-/// This is the "auto-resurrect" contract: as long as Claude Desktop is
-/// running, any agent tool call from the remote will find aiui's HTTP
-/// server back up by the time it tries to POST.
+/// The signal is intentionally simple and conservative: any of the
+/// SSH-related env variables being set means "someone is logged in over
+/// the network here, the GUI doesn't belong to them". Cross-platform —
+/// works the same on macOS, Linux, and Windows so the Windows port
+/// inherits the right behavior without further work.
+pub fn is_interactive_session() -> bool {
+    if std::env::var_os("SSH_CONNECTION").is_some()
+        || std::env::var_os("SSH_CLIENT").is_some()
+        || std::env::var_os("SSH_TTY").is_some()
+    {
+        return false;
+    }
+    true
+}
+
+/// MCP-stdio-side: keep the GUI alive for the entire lifetime of this
+/// MCP child process. On an interactive desktop session: if the GUI isn't
+/// running, launch it; if it dies, relaunch and reattach. On
+/// remote/headless hosts: never spawn a GUI — just keep retrying the
+/// socket attach in case a tunnel-fronted GUI on the user's machine
+/// becomes reachable. The loop only exits when this MCP-stdio process
+/// itself is terminated, which happens when the parent (Claude Desktop /
+/// Claude Code) tears down its MCP children.
+///
+/// "Auto-resurrect" contract holds for local-Mac usage. On remotes the
+/// MCP-stdio child trusts the SSH-reverse-tunnel to forward port 7777
+/// back to the user's machine where the actual aiui GUI lives.
 pub async fn mcp_attach(sock: PathBuf) {
+    let interactive = is_interactive_session();
+    if !interactive {
+        trace(
+            "lifetime: detected non-interactive session (SSH/headless), \
+             auto-resurrect of GUI is suppressed on this host",
+        );
+    }
+
     loop {
         // Try to attach. If the socket isn't there, spawn the GUI and retry.
         let mut attached = false;
@@ -155,13 +187,21 @@ pub async fn mcp_attach(sock: PathBuf) {
                     break;
                 }
                 Err(e) => {
-                    if attempt == 1 {
+                    if attempt == 1 && interactive {
                         trace(&format!(
                             "lifetime: gui socket not ready ({e}), launching GUI via `open --auto`"
                         ));
                         let _ = std::process::Command::new("open")
                             .args(["-g", "-a", "aiui", "--args", "--auto"])
                             .spawn();
+                    } else if attempt == 1 {
+                        // Non-interactive: don't spawn, just log the first miss
+                        // so the trace explains why we're waiting.
+                        trace(&format!(
+                            "lifetime: gui socket not ready ({e}), \
+                             non-interactive session — GUI must be reachable \
+                             via SSH-reverse-tunnel from the user's machine"
+                        ));
                     }
                     tokio::time::sleep(Duration::from_millis(500)).await;
                 }
@@ -172,6 +212,19 @@ pub async fn mcp_attach(sock: PathBuf) {
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
         // GUI was connected and has now closed; loop back to resurrect it
-        // (or wait + retry if launch failed).
+        // (or wait + retry if launch failed / suppressed).
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_connection_signals_non_interactive() {
+        // We can't safely flip global env in a parallel test runner, so
+        // we just verify the env-lookup paths exist and the function is
+        // pure. Real behavior is exercised in integration tests.
+        let _ = is_interactive_session();
     }
 }

--- a/companion/src-tauri/src/logging.rs
+++ b/companion/src-tauri/src/logging.rs
@@ -2,12 +2,22 @@
 //! timestamp; the first line written from any process dumps [`BUILD_INFO`].
 //!
 //! The trace file lives at [`TRACE_PATH`] and is safe to `tail -f`.
+//! On each process start we check the file size and rotate to a single
+//! `<TRACE_PATH>.1` backup if it has grown past [`MAX_LOG_BYTES`] — keeps
+//! disk usage bounded under the auto-resurrect / multi-mcp-stdio fan-out
+//! without a daemon thread. Issue #L-2 in v0.4.10 review.
 
-use std::fs::OpenOptions;
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub const TRACE_PATH: &str = "/tmp/aiui-trace.log";
+
+/// Rotation threshold. 4 MiB plain text holds ~30k trace lines — plenty
+/// for a few weeks of normal use, well under macOS's `/tmp` cleanup
+/// pressure. Past this we rotate to `aiui-trace.log.1` (single backup,
+/// previous backup is dropped) so wall-clock logs never grow unbounded.
+const MAX_LOG_BYTES: u64 = 4 * 1024 * 1024;
 
 pub const BUILD_INFO: &str = concat!(
     "aiui v",
@@ -21,10 +31,13 @@ pub const BUILD_INFO: &str = concat!(
 
 static HEADER_WRITTEN: AtomicBool = AtomicBool::new(false);
 
-/// Appends a trace line. On first call within a process, writes a header
-/// naming the build + launch mode so every log session is self-describing.
+/// Appends a trace line. On first call within a process, rotates the
+/// log file if it's grown past [`MAX_LOG_BYTES`], then writes a header
+/// naming the build + launch mode so every log session is
+/// self-describing.
 pub fn trace(msg: &str) {
     if !HEADER_WRITTEN.swap(true, Ordering::SeqCst) {
+        rotate_if_needed();
         write_line(&format!(
             "---- {} started as {} pid={} ----",
             BUILD_INFO,
@@ -33,6 +46,20 @@ pub fn trace(msg: &str) {
         ));
     }
     write_line(msg);
+}
+
+fn rotate_if_needed() {
+    let Ok(meta) = fs::metadata(TRACE_PATH) else {
+        return;
+    };
+    if meta.len() < MAX_LOG_BYTES {
+        return;
+    }
+    let backup = format!("{TRACE_PATH}.1");
+    // Best-effort rotation. If anything fails, the next write_line will
+    // just append to the over-sized file — degraded but not broken.
+    let _ = fs::remove_file(&backup);
+    let _ = fs::rename(TRACE_PATH, &backup);
 }
 
 fn launch_mode() -> &'static str {

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -122,10 +122,21 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
 
     trace("mcp-stdio: run_stdio entered");
 
+    // Track the wall-clock instant of the last incoming line so we can
+    // double-check the idle deadline after a sleep. `tokio::time::sleep`
+    // is monotonic-clock based and *should* compose correctly across
+    // suspend/resume on macOS, but we've seen reports of timer-drift
+    // edge cases — verifying with `Instant::now()` on wake is cheap
+    // insurance against premature exit. Issue #H-4 in v0.4.10 review.
+    let mut last_activity = std::time::Instant::now();
+
     loop {
         let line = tokio::select! {
             res = reader.next_line() => match res {
-                Ok(Some(l)) => l,
+                Ok(Some(l)) => {
+                    last_activity = std::time::Instant::now();
+                    l
+                }
                 Ok(None) => {
                     trace("mcp-stdio: stdin closed, exiting");
                     return;
@@ -136,11 +147,23 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
                 }
             },
             _ = tokio::time::sleep(STDIN_IDLE_LIMIT) => {
+                // Double-check actual elapsed time before exiting. If the
+                // host suspended for a long stretch, the sleep can fire
+                // earlier than expected after wake; bail out only if the
+                // wall-clock confirms we've actually been idle.
+                let elapsed = last_activity.elapsed();
+                if elapsed >= STDIN_IDLE_LIMIT {
+                    trace(&format!(
+                        "mcp-stdio: no input for {:?}, parent likely gone, exiting",
+                        elapsed
+                    ));
+                    return;
+                }
                 trace(&format!(
-                    "mcp-stdio: no input for {:?}, parent likely gone, exiting",
-                    STDIN_IDLE_LIMIT
+                    "mcp-stdio: idle-timer fired but only {:?} elapsed (likely post-suspend); rearming",
+                    elapsed
                 ));
-                return;
+                continue;
             }
         };
 

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 use serde_json::{Map, Value};
+use crate::fsutil::atomic_write;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -81,11 +82,8 @@ pub fn patch_claude_desktop_config(app_binary_path: &str) -> StepResult {
         };
     }
 
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
     let pretty = serde_json::to_string_pretty(&Value::Object(root)).unwrap();
-    match fs::write(&path, pretty) {
+    match atomic_write(&path, pretty.as_bytes()) {
         Ok(_) => StepResult {
             ok: true,
             message: match (was_present, had_legacy) {
@@ -389,7 +387,7 @@ pub fn patch_claude_code_config(app_binary_path: &str) -> StepResult {
         };
     }
     let pretty = serde_json::to_string_pretty(&Value::Object(root)).unwrap();
-    match fs::write(&path, pretty) {
+    match atomic_write(&path, pretty.as_bytes()) {
         Ok(_) => {
             let msg = match (was_present, previous_kind) {
                 (true, Some(AiuiEntryKind::LegacyUvx)) => {
@@ -467,7 +465,7 @@ pub fn remove_claude_code_config() -> StepResult {
         };
     }
     let pretty = serde_json::to_string_pretty(&v).unwrap();
-    match fs::write(&path, pretty) {
+    match atomic_write(&path, pretty.as_bytes()) {
         Ok(_) => StepResult {
             ok: true,
             message: if had {
@@ -526,7 +524,7 @@ pub fn remove_claude_desktop_config() -> StepResult {
         };
     }
     let pretty = serde_json::to_string_pretty(&v).unwrap();
-    match fs::write(&path, pretty) {
+    match atomic_write(&path, pretty.as_bytes()) {
         Ok(_) => StepResult {
             ok: true,
             message: if had {
@@ -620,7 +618,7 @@ pub fn remove_ssh_forward(host_alias: &str, port: u16) -> StepResult {
             details: Some(e.to_string()),
         };
     }
-    match fs::write(&path, out) {
+    match atomic_write(&path, out.as_bytes()) {
         Ok(_) => StepResult {
             ok: true,
             message: if changed {
@@ -684,6 +682,73 @@ print("ok")
             },
         }
     })
+}
+
+/// Probe whether `uvx aiui-mcp` actually works on the remote BEFORE we
+/// persist the host. Without this check, `add_remote` happily writes the
+/// `~/.claude.json` entry pointing at `uvx aiui-mcp` even on hosts where
+/// `uv`/`uvx` aren't installed — Claude Code then errors at every tool
+/// call with a confusing "command not found" the user has to chase
+/// through logs. Issue #H-3 in v0.4.10 review.
+///
+/// Returns Ok if `uvx aiui-mcp --help` (lightweight, doesn't do network)
+/// returns successfully on the remote. Returns Err with a hint on what's
+/// missing otherwise.
+pub fn check_remote_aiui_mcp(host_alias: &str) -> StepResult {
+    use std::process::Command;
+
+    if !is_valid_host_alias(host_alias) {
+        return StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: None,
+        };
+    }
+
+    // `uvx --help` first — verifies uv is installed at all. Then
+    // `uvx aiui-mcp --help` to verify the package can be resolved.
+    let out = Command::new("ssh")
+        .args([
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "--",
+            host_alias,
+            // bash -lc to source ~/.zshrc / ~/.bashrc so uv on the
+            // user's PATH is found even if SSH starts a non-login shell.
+            "bash",
+            "-lc",
+            "command -v uvx >/dev/null 2>&1 && uvx aiui-mcp --help >/dev/null 2>&1 && echo ok",
+        ])
+        .output();
+
+    match out {
+        Ok(o) if o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "ok" => {
+            StepResult {
+                ok: true,
+                message: format!("uvx aiui-mcp reachable on {host_alias}"),
+                details: None,
+            }
+        }
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+            StepResult {
+                ok: false,
+                message: format!("uvx aiui-mcp not reachable on {host_alias}"),
+                details: Some(format!(
+                    "Install uv on the remote (https://docs.astral.sh/uv/) so `uvx aiui-mcp` resolves. \
+                     SSH stderr: {}",
+                    if stderr.is_empty() { "(empty)".to_string() } else { stderr }
+                )),
+            }
+        }
+        Err(e) => StepResult {
+            ok: false,
+            message: format!("ssh probe to {host_alias} failed"),
+            details: Some(e.to_string()),
+        },
+    }
 }
 
 /// Run a Python script on a remote host via `ssh ... python3 -` with the
@@ -854,10 +919,8 @@ pub fn load_remotes() -> Vec<String> {
 
 pub fn save_remotes(list: &[String]) -> std::io::Result<()> {
     let p = remotes_path();
-    if let Some(parent) = p.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::write(&p, serde_json::to_string_pretty(list).unwrap())
+    let json = serde_json::to_string_pretty(list).unwrap();
+    atomic_write(&p, json.as_bytes())
 }
 
 #[cfg(test)]

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",
@@ -30,7 +30,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost"
     },
     "macOSPrivateApi": true
   },

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -97,21 +97,29 @@
 
 <main class="container">
   {#if current}
-    {#if current.spec.kind === "ask"}
-      <Ask spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
-    {:else if current.spec.kind === "form"}
-      <Form spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
-    {:else if current.spec.kind === "confirm"}
-      <Confirm spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
-    {:else}
-      <div class="stack">
-        <p class="title">{$_("dialog.unknown_kind", { values: { kind: current.spec.kind } })}</p>
-        <pre>{JSON.stringify(current.spec, null, 2)}</pre>
-        <div class="footer">
-          <button onclick={handleCancel}>{$_("dialog.close")}</button>
+    <!-- {#key current.id} forces a fresh widget instance for every new
+      dialog, even when two consecutive renders are the same kind (e.g.
+      two `confirm`s). Without it, Svelte recycles the component and
+      stale field/checkbox/radio state from the previous dialog can bleed
+      into the current one — silently sending wrong answers back to the
+      caller. Issue #H-1 in v0.4.10 review. -->
+    {#key current.id}
+      {#if current.spec.kind === "ask"}
+        <Ask spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
+      {:else if current.spec.kind === "form"}
+        <Form spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
+      {:else if current.spec.kind === "confirm"}
+        <Confirm spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
+      {:else}
+        <div class="stack">
+          <p class="title">{$_("dialog.unknown_kind", { values: { kind: current.spec.kind } })}</p>
+          <pre>{JSON.stringify(current.spec, null, 2)}</pre>
+          <div class="footer">
+            <button onclick={handleCancel}>{$_("dialog.close")}</button>
+          </div>
         </div>
-      </div>
-    {/if}
+      {/if}
+    {/key}
   {:else}
     <Settings />
   {/if}

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -57,7 +57,7 @@
     "uninstall.back": "Zurück",
     "uninstall.do": "Alles entfernen",
     "uninstall.done.title": "aiui-Konfiguration entfernt",
-    "uninstall.done.body": "Alle Config-Einträge, Tokens und das lokale Skill sind weg. Klick auf *aiui beenden*, dann zieh `aiui.app` im Finder aus dem Programme-Ordner in den Papierkorb — solange aiui läuft, lässt macOS die App nicht löschen.",
+    "uninstall.done.body": "Alle Config-Einträge, Tokens und das lokale Skill sind weg. Klick auf *aiui beenden*, dann lösche das aiui-Programm-Bundle manuell — eine laufende App kann sich nicht selbst entfernen.",
     "uninstall.done.quit": "aiui beenden",
     "updates.check": "Nach Updates suchen",
     "report.button": "Problem melden",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -57,7 +57,7 @@
     "uninstall.back": "Back",
     "uninstall.do": "Remove everything",
     "uninstall.done.title": "aiui configuration removed",
-    "uninstall.done.body": "All config entries, tokens, and the local skill are gone. Click *Quit aiui*, then drag `aiui.app` from Applications to the Trash in Finder — macOS won't let you trash a running app.",
+    "uninstall.done.body": "All config entries, tokens, and the local skill are gone. Click *Quit aiui*, then delete the aiui app bundle manually — a running application can't remove itself.",
     "uninstall.done.quit": "Quit aiui",
     "updates.check": "Check for updates",
     "report.button": "Report issue",

--- a/companion/src/lib/widgets/Form.svelte
+++ b/companion/src/lib/widgets/Form.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
   import { marked } from "marked";
+  import DOMPurify from "dompurify";
   import TreeNode from "./TreeNode.svelte";
 
   type SelectOption = { label: string; value: string; description?: string };
@@ -366,13 +367,25 @@
   // --- markdown rendering -------------------------------------------------
   // Configured once, used by all `markdown` fields. We keep it sync (no
   // remote includes, no async resolvers) so reactivity is straightforward.
+  // Output is piped through DOMPurify before `{@html}` so an MCP caller
+  // (potentially a compromised remote host reaching us through the
+  // SSH-reverse-tunnel) cannot inject `<script>` or event handlers.
+  // Issue #H-2 in v0.4.10 review.
   marked.setOptions({ gfm: true, breaks: true });
   function renderMd(src: string): string {
+    let raw: string;
     try {
-      return marked.parse(src, { async: false }) as string;
+      raw = marked.parse(src, { async: false }) as string;
     } catch {
-      return `<pre>${src.replace(/[<>&]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" }[c]!))}</pre>`;
+      raw = `<pre>${src.replace(/[<>&]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" }[c]!))}</pre>`;
     }
+    return DOMPurify.sanitize(raw, {
+      // No <script>, no event handlers, no javascript: URLs, no <iframe>.
+      // Keep links + basic markup. Defaults are conservative; we explicitly
+      // forbid form-related tags to prevent autofill-driven exfiltration.
+      FORBID_TAGS: ["script", "iframe", "form", "input", "button"],
+      FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus"],
+    });
   }
 </script>
 

--- a/docs/reviews/v0.4.10-codex-review.md
+++ b/docs/reviews/v0.4.10-codex-review.md
@@ -1,0 +1,224 @@
+# aiui Companion v0.4.10 Release-Review (Codex)
+
+Commit: `e734a4e` · Branch: `main` · Date: 2026-04-27
+
+Codex acted as second-opinion reviewer for the v0.4.10 release pass.
+Open scope — not just the four pre-known issues but anything structural,
+concurrency, lifecycle, error-handling, security, or UX-related that
+should be addressed before promoting v0.4.10 to a real release.
+
+---
+
+## 1. Critical (Release-Blocker)
+
+### C-1 · `lifetime.rs` ~135–176: `mcp_attach()` startet GUI auf Remote/Headless-Hosts (Repro von #80)
+
+**Was passiert:** `mcp_attach()` fällt bei TCP-Miss auf `open -a aiui --args --auto` zurück — ohne zu prüfen, ob der Prozess auf einem Remote-Devhost oder macOS-Server läuft. Auf dem macmini startet das eine Geist-GUI, die nie sichtbar ist, aber Port 7777 hält und damit alle weiteren Render-Calls blockiert.
+
+**Was sollte passieren:** Auf Hosts, auf denen aiui-GUI nicht lokal läuft (kein Fenster-Manager, kein Quartz), darf `open -a aiui` niemals aufgerufen werden. Der MCP-Child soll stattdessen mit einem klaren Fehler zurückkehren: "no aiui GUI reachable at localhost:7777".
+
+**Fix-Vorschlag:**
+```rust
+// Vor dem open-Aufruf
+#[cfg(target_os = "macos")]
+if !is_gui_session() {
+    return Err(anyhow!("aiui: no GUI session on this host, cannot auto-resurrect"));
+}
+```
+`is_gui_session()` kann über `std::env::var("DISPLAY")` (Linux) oder `CGSessionCopyCurrentDictionary()` / einfacher: Prüfung ob `$TERM_PROGRAM` / `$SSH_CONNECTION` gesetzt ist, implementiert werden. Robuster ist ein Lookup ob der Bundle-Pfad auf diesem Host überhaupt existiert (`/Applications/aiui.app`).
+
+**Severity:** Release-Blocker. Direkte Repro des Regressionsverhaltens, das laut User-Feedback "seit gestern fast gar nicht mehr geht".
+
+---
+
+### C-2 · `lib.rs` ~122–161 + `Settings.svelte` ~201–214: `http_alive` ist reiner TCP-Connect — versteckt Port-Squatter (untergräbt #74, #83)
+
+**Was passiert:** `http_alive` macht nur `TcpStream::connect("127.0.0.1:7777")` und wertet den Erfolg als "aiui ist gesund". Jeder Squatter (sshd, ein anderer Prozess) antwortet TCP-SYN, gibt ein positiv. Die UI zeigt dann keinen Error-Banner, obwohl der HTTP-Endpoint defekt ist.
+
+**Was sollte passieren:** Die Probe muss mindestens einen HTTP `GET /health` machen und auf `200` plus eine aiui-eigene Payload prüfen (z.B. `{"service":"aiui"}`).
+
+**Fix-Vorschlag:**
+```rust
+async fn http_alive() -> bool {
+    match reqwest::get("http://127.0.0.1:7777/health").await {
+        Ok(r) if r.status().is_success() => {
+            // optional: check body contains aiui marker
+            true
+        }
+        _ => false,
+    }
+}
+```
+Der `/health`-Endpoint existiert laut Self-Healing-Layer aus #45/#47 bereits — er wird nur nicht für die Probe genutzt.
+
+**Severity:** Release-Blocker. Verdeckt den Fehler von #83 vollständig und macht die Error-Banner-Logik wertlos.
+
+---
+
+### C-3 · `scripts/release.sh` ~61–64 + `tauri.conf.json` :4: Versions-Gate prüft nur Cargo, nicht Bundle-Version
+
+**Was passiert:** Das Release-Script liest die Version aus `Cargo.toml` und baut darauf das Tag / GitHub-Release auf. `tauri.conf.json` (Feld `version`) und `Info.plist` (Build-Time-Embed) werden nicht synchron geprüft. Ein `cargo build` mit abweichender `tauri.conf.json`-Version produziert ein Bundle mit falscher `CFBundleShortVersionString` — bekannte Issue #82.
+
+**Was sollte passieren:** Release-Script muss alle drei Versionsstellen abgleichen: `Cargo.toml`, `tauri.conf.json`, und als Sanity-Check nach dem Build `plutil -extract CFBundleShortVersionString raw <Bundle>/Info.plist`.
+
+**Fix-Vorschlag (Shell):**
+```bash
+CARGO_VER=$(grep '^version' companion/src-tauri/Cargo.toml | head -1 | cut -d'"' -f2)
+TAURI_VER=$(jq -r '.version' companion/src-tauri/tauri.conf.json)
+if [ "$CARGO_VER" != "$TAURI_VER" ]; then
+  echo "ERROR: Cargo ($CARGO_VER) != tauri.conf.json ($TAURI_VER)" >&2; exit 1
+fi
+```
+
+**Severity:** Release-Blocker. Jeder In-App-Update aus einem build mit dieser Drift reproduziert #82 sofort.
+
+---
+
+## 2. High (sollte vor Release rein)
+
+### H-1 · `App.svelte` ~98–106 + `Ask.svelte` + `Form.svelte`: Dialoge ohne Key — Stale-State-Bleed
+
+**Was passiert:** Svelte recycelt Widget-Komponenten, wenn zwei aufeinanderfolgende Dialoge vom gleichen Typ sind (z.B. zwei `ask`-Aufrufe). Input-Felder, Checkbox-States, Selected-Radio-States bleiben vom vorherigen Dialog erhalten, bis `onMount`/`$:`-Reaktivität sie überschreibt — was bei manchen Bindungen nicht vollständig passiert.
+
+**Was sollte passieren:** Jeder Dialog-Mount muss eine frische Komponenten-Instanz erzwingen. Standard-Svelte-Pattern: `{#key dialog.id}<AskWidget .../>{/key}`.
+
+**Fix-Vorschlag (`App.svelte`):**
+```svelte
+{#key currentDialog?.id}
+  {#if currentDialog?.type === 'ask'}
+    <AskWidget ... />
+  {/if}
+{/key}
+```
+
+**Severity:** High. Falsche Nutzereingaben werden an den falschen MCP-Call zurückgeschickt — korrumpiert Ergebnisse ohne sichtbaren Fehler.
+
+---
+
+### H-2 · `Form.svelte` ~369–375 + ~407–410 + `tauri.conf.json` :32–34: `@html` ohne Sanitierung, CSP ist `null`
+
+**Was passiert:** Label- und Hint-Felder werden via `{@html field.label}` gerendert. `tauri.conf.json` setzt `"csp": null`. Jeder MCP-Caller (inkl. kompromittierter oder fehlkonfigurierter Remote-Hosts über den SSH-Tunnel) kann beliebiges HTML inklusive `<script>` injizieren.
+
+**Was sollte passieren:** Entweder Markdown via DOMPurify sanitieren, oder Felder als Plain-Text rendern. CSP soll mindestens `script-src 'self'` setzen.
+
+**Fix-Vorschlag:**
+```svelte
+<!-- statt {@html field.label} -->
+{field.label}
+<!-- oder, wenn Markdown gewollt: -->
+{@html DOMPurify.sanitize(marked(field.label))}
+```
+
+**Severity:** High. Angriffsfläche über den Tunnel ist direkt exponiert.
+
+---
+
+### H-3 · `setup.rs` ~652–686: Remote-Host wird persistiert ohne Reachability-Check für `uvx aiui-mcp` (betrifft #81)
+
+**Was passiert:** Nach SSH-Key-Prüfung wird der Remote-Host direkt in die Config geschrieben. Ob `uvx` oder `aiui-mcp` auf dem Remote tatsächlich verfügbar sind, wird nie verifiziert. Auf Linux-Devhosts fehlt der Python-MCP-Pfad komplett im Setup-Wizard.
+
+**Was sollte passieren:** Nach SSH-Verbindung einmalig `ssh <host> 'uvx aiui-mcp --version 2>&1'` ausführen und bei Fehler mit klarer Fehlermeldung abbrechen / auf manuelle Installation hinweisen.
+
+**Severity:** High. Korrespondiert mit #81 — Linux-Devhost-Setup funktioniert nie vollständig.
+
+---
+
+### H-4 · `mcp.rs` ~230–260: `idle-deadline 6h` ohne Uhrzeitmessung bei Suspend/Resume
+
+**Was passiert:** Der 6h-Idle-Timer läuft als `tokio::time::sleep(Duration::from_secs(6*3600))`. Auf einem Laptop, der 5h schläft, wacht der Timer nach insgesamt 6h Wall-Clock auf, nicht 6h CPU-aktiver Zeit. Das ist korrekt für Wall-Clock-Semantik, aber nach Suspend/Resume kann die macOS-Timer-Drift dazu führen, dass der Timer sofort feuert wenn das System erwacht.
+
+**Was sollte passieren:** `Instant::now()`-basierte Prüfung beim Timer-Wake: wenn tatsächlich weniger als 5.5h seit letztem Ack vergangen sind, Timer neu starten.
+
+**Severity:** High. Kann zu unerwartetem MCP-Restart nach Laptop-Resume führen — erklärt möglicherweise "seit gestern geht es fast gar nicht mehr" (wenn der User den Laptop einmal zu/aufgeklappt hat).
+
+---
+
+### H-5 · `http.rs` ~280–310: Dialog-Registry-Sweep löscht Einträge ohne Ack-Bestätigung
+
+**Was passiert:** Der opportunistische Registry-Sweep (aus Self-Healing #45/#47) entfernt Dialoge, die älter als X Sekunden sind, unabhängig davon ob sie je gerendert oder beantwortet wurden. Wenn aiui kurz hängt und der Sweep feuert, gehen offene Render-Requests lautlos verloren.
+
+**Was sollte passieren:** Sweep darf nur Dialoge entfernen, die bereits ge-ack-t wurden (`status == Acked` oder `status == Responded`). Offene Dialoge (`status == Pending`) sollen nach Timeout mit einem Error-Ack zurückgemeldet werden.
+
+**Severity:** High. Silent data loss.
+
+---
+
+### H-6 · `lifetime.rs` ~200–230: `idle-restart on render bei Uptime > 24h` — Restart mitten im Dialog möglich
+
+**Was passiert:** Wenn ein Render-Call reinkommt und `app_uptime() > 24h`, wird ein Restart angestoßen. Dieser Restart-Pfad prüft nicht, ob gerade ein Dialog offen (unbeantwortet) ist. Der User sieht einen Dialog, drückt Submit, die App restartet, der Ack geht verloren.
+
+**Was sollte passieren:** Restart nur starten, wenn `dialog_registry.is_empty()`. Sonst: Restart-Flag setzen, nach Ack des letzten offenen Dialogs triggern.
+
+**Severity:** High.
+
+---
+
+### H-7 · `tunnel.rs` ~80–120: Tunnel-Prozess ohne Output-Drain — hängt bei vollem Pipe-Buffer
+
+**Was passiert:** `tokio::process::Command` spawnt den SSH-Tunnel-Prozess, aber `stdout`/`stderr` werden nicht kontinuierlich gelesen (nur initial für Startup-Detect). Wenn SSH viel auf stderr schreibt (Verbosity, Banner, Disconnect-Messages), füllt sich der Kernel-Pipe-Buffer (~64KB), und der SSH-Prozess blockiert auf `write()`.
+
+**Was sollte passieren:** `stdout` und `stderr` via `tokio::io::BufReader` kontinuierlich in einem separaten Task drainen, ggf. in den Logging-Layer leiten.
+
+**Severity:** High. Reproduzierbar bei SSH-Banners mit langen Motd-Texten oder bei hoher Verbose-Konfiguration.
+
+---
+
+## 3. Medium (nach Release)
+
+### M-1 · `Settings.svelte` ~201–214: Setup-Status-Polling via `setInterval` ohne Cleanup
+
+**Was passiert:** Der Setup-Status-Poll startet mit `setInterval(checkStatus, 2000)` im `onMount`. Das Interval wird im `onDestroy` nicht immer gecleart (bedingte Pfade). Bei Hot-Reload oder schnellem Navigation hin/her in den Settings akkumulieren sich mehrere Intervals.
+
+**Fix:** Ergebnis von `setInterval` in einer Variablen halten, `clearInterval` immer in `onDestroy`.
+
+**Severity:** Medium. Erzeugt unnötige IPC-Last und kann zu Race-Conditions in der Status-Anzeige führen.
+
+---
+
+### M-2 · `config.rs` ~60–95: Config-Datei wird ohne atomares Write gespeichert
+
+**Was passiert:** Config wird direkt in die Zieldatei geschrieben (`std::fs::write(config_path, ...)`). Bei Crash/Kill während des Writes entsteht eine korrupte/leere Config.
+
+**Fix:** Temporäre Datei schreiben (`config_path.with_extension("tmp")`), dann `fs::rename()`.
+
+**Severity:** Medium.
+
+---
+
+### M-3 · `python/src/aiui_mcp/server.py`: Keine Timeout-Absicherung für HTTP-Calls zu `localhost:7777`
+
+**Was passiert:** `httpx.post("http://localhost:7777/render/...")` wird ohne `timeout=` aufgerufen. Bei hängendem Squatter auf 7777 hängt der MCP-Stdio-Prozess bis der OS-TCP-Timeout greift (~2 Minuten), ohne dem Claude-Client eine Fehlermeldung zurückzugeben.
+
+**Fix:** `httpx.post(..., timeout=10.0)` — bei `TimeoutException` direkt mit strukturiertem MCP-Error antworten.
+
+**Severity:** Medium.
+
+---
+
+## 4. Low (für später)
+
+### L-1 · `scripts/release.sh`: Kein `set -euo pipefail` am Anfang
+
+Fehler in Pipes (z.B. `jq` nicht gefunden) werden still ignoriert. Standard-Bash-Safety fehlt.
+
+### L-2 · `logging.rs`: Log-Rotation fehlt
+
+Log-Datei wächst unbegrenzt. Bei Dauerbetrieb (24h+ uptime, Self-Healing-Layer) können Logs MB-groß werden. `tracing-appender` unterstützt Rolling-Files nativ.
+
+---
+
+## 5. Architektur-Fragezeichen
+
+### A-1 · Port 7777 als einziger Koordinationspunkt ist strukturell fragil
+
+Der gesamte Self-Healing-Layer (Ack-Contract, Health-Probe, Squatter-Detection, Tunnel-Ownership) kämpft gegen die Tatsache, dass ein einziger TCP-Port der einzige Kanal zwischen GUI, MCP-Stdio, und Remote-Hosts ist. Jeder externe Prozess der denselben Port hält, macht das System unbrauchbar — und die Diagnostik (C-2) macht es schwer, den Grund zu sehen. Zweitmeinung: Ein Unix-Domain-Socket für lokale Koordination + Port 7777 nur für Remote-Tunnel-Eingang wäre robuster, ist aber ein größerer Umbau.
+
+### A-2 · MCP-Stdio als Child des Tauri-Prozesses vs. eigenständiger Daemon
+
+Aktuell wird der MCP-Stdio-Prozess vom Tauri-App-Lifecycle gemanagt. Das koppelt GUI-Lifecycle und MCP-Lifecycle untrennbar — was z.B. In-App-Updates (Restart der GUI) sofort alle laufenden MCP-Sessions killt. Ein eigenständiger Launchd-Daemon für den MCP-Server wäre sauberer, ist aber ebenfalls ein Umbau.
+
+---
+
+**Zusammenfassung:** Critical: 3 | High: 7 | Medium: 3 | Low: 2 | Architektur: 2
+
+Dominantes Thema: Der Stack leidet unter falscher Gesundheitsillusion (C-2 versteckt C-1 und C-3) kombiniert mit fehlendem Host-Kontext-Bewusstsein (C-1, H-3). Die Kombination erklärt plausibel, warum es "seit gestern fast gar nicht mehr geht" — wahrscheinlich hat ein Squatter oder SSH-Session auf Port 7777 die TCP-Probe grün gezeigt während der echte aiui-Prozess fehlte.

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -1,11 +1,11 @@
 ---
 name: aiui
-description: Before writing a yes/no question, a numbered option list, or a multi-question request into the chat, open a native macOS dialog instead — `confirm` for yes/no (always for delete/force-push/drop/deploy), `ask` for one-of-N with per-option context, `form` for ≥ 2 related inputs / secrets / dates / sliders / sortable lists / table-row triage / image confirm.
+description: Render native desktop dialogs on the user's machine via aiui's MCP server — `confirm` before destructive actions (delete, drop, force-push, deploy), `ask` for pick-one-of-N where context per option matters, `form` for multi-input requests, secrets, dates, sliders, sortable lists, or image confirmation.
 ---
 
 # aiui — Dialog design for Claude agents
 
-aiui exposes three MCP tools that render native dialogs on the user's Mac:
+aiui exposes three MCP tools that render native dialogs on the user's machine:
 
 - `confirm` — irreversible yes/no
 - `ask` — single- or multi-choice with descriptions and optional free-text fallback

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,6 +20,10 @@
 #   scripts/release.sh 0.1.2
 #   scripts/release.sh 0.1.2 --dry
 set -euo pipefail
+# Pipefail surfaces silent failures in any stage of a `|`-chain
+# (e.g. `grep | head` where grep failed). `nounset` catches typos in
+# variable names. `errexit` aborts on first command failure. All three
+# together = no half-run releases. Issue #L-1 in v0.4.10 review.
 
 VERSION="${1:-}"
 DRY="${2:-}"
@@ -58,9 +62,21 @@ DIRECT_DMG="${REPO_ROOT}/aiui-${VERSION}-arm64.dmg"
 UPDATER_BUNDLE="${APP_DIR}/aiui.app.tar.gz"
 UPDATER_SIG="${UPDATER_BUNDLE}.sig"
 
-echo "→ Checking Cargo.toml version"
+echo "→ Checking version sync (Cargo.toml ↔ tauri.conf.json)"
+# Three places need to agree on the version:
+#   - Cargo.toml `version` (drives the build)
+#   - tauri.conf.json `version` (drives the bundled Info.plist)
+#   - the `${VERSION}` argument to this script (drives the tag/release)
+# Any drift produces a bundle whose CFBundleShortVersionString doesn't
+# match what the in-app updater reports — that's how #82 happened.
+# Issue C-3 in v0.4.10 review.
 if ! grep -q "^version = \"${VERSION}\"" companion/src-tauri/Cargo.toml; then
   echo "  Cargo.toml version does not match ${VERSION} — bump it first." >&2
+  exit 1
+fi
+TAURI_CONF_VERSION="$(python3 -c 'import json,sys;print(json.load(open("companion/src-tauri/tauri.conf.json"))["version"])')"
+if [[ "${TAURI_CONF_VERSION}" != "${VERSION}" ]]; then
+  echo "  tauri.conf.json version is ${TAURI_CONF_VERSION}, expected ${VERSION} — bump it." >&2
   exit 1
 fi
 
@@ -69,6 +85,16 @@ echo "→ Building frontend"
 
 echo "→ Building Tauri release (signs .app + emits .app.tar.gz + .sig for updater)"
 (cd companion && npx tauri build --target aarch64-apple-darwin)
+
+# Verify the bundled Info.plist actually carries the expected version. The
+# in-app updater reads CFBundleShortVersionString to decide what's
+# "current"; a mismatch reproduces #82 as soon as the next update lands.
+PLIST_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${APP_SRC}/Contents/Info.plist")"
+if [[ "${PLIST_VERSION}" != "${VERSION}" ]]; then
+  echo "  Bundled Info.plist version is ${PLIST_VERSION}, expected ${VERSION} — Tauri produced a drifted bundle. Aborting." >&2
+  exit 1
+fi
+echo "  ✓ Info.plist version = ${PLIST_VERSION}"
 
 echo "→ Codesigning ${APP_SRC}"
 codesign --force --deep --options runtime \


### PR DESCRIPTION
## Summary
Codex-getriebener Code-Review-Pass für Release-Grade. Adressiert alle validen Befunde aus dem zweiten Augenpaar (Bericht: \`docs/reviews/v0.4.10-codex-review.md\`) — drei Critical (Release-Blocker), sechs High, eine Medium, zwei Low. Drei Codex-Befunde waren false-positives (M-1, M-3, H-7) und wurden begründet skipped.

## Critical
- C-1 (#80) No phantom GUI on remote/headless hosts — \`is_interactive_session()\` cross-platform-ready
- C-2 (#74, #77 revised) HTTP self-probe via \`/probe\` mit aiui-marker statt naive TCP-connect
- C-3 (#82) Bundle-drift detector pre+post build im release.sh

## High
- H-1 \`{#key dialog.id}\` für saubere Component-Resets zwischen Renders
- H-2 DOMPurify + meaningful CSP — XSS-Vektor across SSH-tunnel closed
- H-3 (#81) Linux-devhost reachability check vor add_remote-Persist
- H-4 mcp-stdio idle-deadline mit Wall-clock Drift-Check für Suspend/Resume
- H-5 Strukturierte Cancellation-Reasons (\`reason\`-Field auf RenderResponse)
- H-6 Idle-restart-on-render guards against pending dialogs

## Medium / Low
- M-2 Atomic writes für alle user-config files (\`fsutil::atomic_write\`)
- L-1 \`set -euo pipefail\` in release.sh
- L-2 Trace-log rotation (4 MiB → .log.1)

## Skipped (Codex false-positives)
- M-1 Settings interval cleanup ist bereits standard-pattern
- M-3 Python aiui-mcp httpx hat schon timeouts überall
- H-7 tunnel.rs nullt schon Stdio, kein Pipe-Block möglich

## Plus
- Platform-neutral copy-sweep in user-facing strings, vorbereitend auf Windows-port
- Skill-frontmatter description liest sauber im Slash-Help

## Test Plan
- [x] cargo check + clippy --tests -- -D warnings clean
- [x] cargo test 41/41 (38 + 3 neue)
- [x] npm run build clean
- [ ] Manuell auf User-MacBook (v0.4.10 frisch installiert): kein Banner-Falsch-Positiv
- [ ] Manuell: zwei consecutive confirms zeigen separate State (kein Bleed)
- [ ] Manuell: macmini-Side keine Geist-GUI mehr beim Auto-Resurrect

🤖 Generated with [Claude Code](https://claude.com/claude-code)