### PR TITLE
v0.4.12: mask cold-start window in mcp tool dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.12] — 2026-04-27
+
+### Fixed
+
+- **Cold-start race after closing aiui via the window X.** Closing the
+  GUI by the red X exits the process — fine — and `mcp_attach`'s
+  auto-resurrect path then re-spawns the GUI on the next tool call.
+  But the GUI takes a beat to bind port 7777, and Claude's tool call
+  was hitting that port before the bind landed, getting connection-
+  refused, and reporting "aiui not reachable" even though aiui was in
+  fact coming up half a second later. mcp-stdio now polls `/ping` for
+  up to 8 s on every tool call before dispatching — masks the cold-
+  start window invisibly. If the HTTP endpoint really doesn't come up
+  in time (e.g. the user is on a remote dev host whose SSH-reverse-
+  tunnel is genuinely down), the response is a clear, actionable
+  message instead of a raw connection error.
+
 ## [0.4.11] — 2026-04-27
 
 ### Changed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.11"
+version = "0.4.12"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -330,6 +330,63 @@ fn tools_list() -> Value {
     ])
 }
 
+/// How long mcp-stdio waits for the aiui HTTP endpoint to become reachable
+/// before giving up on a tool call. The dominant case this catches: the
+/// user closed the GUI via the window's red X (which exits the app),
+/// then immediately triggered a render call — `mcp_attach`'s
+/// auto-resurrect (see `lifetime.rs`) IS firing in parallel and brings
+/// the GUI back, but Claude's tool call would otherwise race ahead and
+/// hit a not-yet-bound port. Eight seconds covers a realistic cold-start
+/// (Tauri init + WebView load + HTTP bind) on a normal Mac.
+const COLDSTART_WAIT: std::time::Duration = std::time::Duration::from_secs(8);
+
+/// Poll `/ping` until the HTTP server answers, or `COLDSTART_WAIT` elapses.
+/// `/ping` is unauthenticated and cheap, returning `pong` in plain text —
+/// any 2xx means aiui is bound and serving. Returns `true` once reachable,
+/// `false` on timeout. Issue surfaced 2026-04-27 when a fresh Claude
+/// session ran the demo prompt right after the user X-closed the GUI.
+async fn wait_for_aiui(http: &reqwest::Client, cfg: &AppConfig) -> bool {
+    let url = format!("http://127.0.0.1:{}/ping", cfg.http_port);
+    let deadline = std::time::Instant::now() + COLDSTART_WAIT;
+    loop {
+        let probe = http
+            .get(&url)
+            .timeout(std::time::Duration::from_millis(800))
+            .send()
+            .await;
+        if let Ok(r) = probe {
+            if r.status().is_success() {
+                return true;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            trace(&format!(
+                "mcp-stdio: aiui /ping not reachable after {:?}, giving up",
+                COLDSTART_WAIT
+            ));
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    }
+}
+
+/// Tool-call response signaling that the local aiui companion isn't
+/// reachable. Phrased as user-facing guidance rather than a raw error
+/// because Claude tends to relay this verbatim to the user.
+fn aiui_unreachable_result() -> Value {
+    json!({
+        "content": [{
+            "type": "text",
+            "text": "aiui companion is not reachable on localhost:7777. \
+                     If you're on the local machine: open aiui from /Applications. \
+                     If you're on a remote dev host: the SSH-reverse-tunnel to your \
+                     Mac is down — check that aiui is running there and the tunnel \
+                     in aiui Settings shows 'connected'."
+        }],
+        "isError": true
+    })
+}
+
 async fn tools_call(
     params: Value,
     cfg: &Arc<AppConfig>,
@@ -341,6 +398,14 @@ async fn tools_call(
         .unwrap_or("")
         .to_string();
     let args = params.get("arguments").cloned().unwrap_or(json!({}));
+
+    // Cold-start gate: every tool we expose hits the local HTTP server.
+    // Wait for it to become reachable instead of returning a connection-
+    // refused error the moment we get one — that masks the auto-resurrect
+    // path's startup window cleanly.
+    if !wait_for_aiui(http, cfg).await {
+        return Ok(aiui_unreachable_result());
+    }
 
     let outcome = match name.as_str() {
         "confirm" => render_dialog(

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
Fix für Race aufgedeckt durch Tester: aiui via X geschlossen → frische Claude-Session → Demo-Prompt → \"nicht erreichbar\". Auto-Resurrect feuerte korrekt, aber Claudes erster tool-call schlug die HTTP-Bind-Phase um 1–2 s.

## Fix
\`tools_call\` in mcp.rs ruft \`wait_for_aiui()\` vorab auf — pollt \`/ping\` mit 800ms-Timeout, alle 300ms, bis zu 8 s. Wenn aiui in dem Fenster hochkommt: invisible für Claude. Wenn nicht: strukturierte Fehlermeldung statt rohem Transport-Error.

Costs: ein einziger localhost-roundtrip pro tool-call wenn aiui schon läuft (~5 ms loopback). Lohnt sich.

## Test Plan
- [x] cargo clippy + 41 tests grün
- [ ] Manuell: aiui via X schließen, sofort frische Code-Session + Demo-Prompt → muss durchlaufen ohne \"unreachable\"-Fehler
- [ ] Manuell: aiui gar nicht installiert → strukturierte Meldung statt raw error

🤖 Generated with [Claude Code](https://claude.com/claude-code)