### PR TITLE
v0.4.16: add-remote failure visible + diagnostic probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes to this project are documented here.
   inner stderr (PATH dump on `uvx`-not-found, full error from `uvx
   aiui-mcp --help` on resolve failures). Failure details now name the
   exact step and include the remote's diagnostic output verbatim.
+- **"Problem melden"-Button öffnet jetzt tatsächlich GitHub.** The
+  click did nothing because `window.open()` is blocked in Tauri's
+  WebView for security. Replaced with a Tauri command `open_url` that
+  passes the URL to macOS `open`. Defensive: only allows http(s)
+  schemes. Surfaced 2026-04-27 by tester clicking the button for the
+  first time.
+- **Sortable list items no longer snap back after drag-drop.** Tauri
+  windows have file-drop handling enabled by default, which silently
+  swallows HTML5 drag-drop events inside the page — `ondrop` never
+  fired, the list-item visually returned to its original position.
+  `dragDropEnabled: false` on the main window lets HTML5 DnD events
+  through. Surfaced 2026-04-27 in tester's demo-prompt run.
 
 ## [0.4.15] — 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.16] — 2026-04-27
+
+### Fixed
+
+- **Add-remote failures land where the user can see them.** Previously
+  on failure the input field was cleared and the only feedback was a
+  log entry buried below the fold of the Settings window. Now the
+  input keeps its content (so the user can fix and retry), and the
+  first failing step is shown inline as a red banner directly under
+  the input with the full error detail. Issue surfaced 2026-04-27 by
+  tester re-adding their remotes after a fresh install — they thought
+  the host had been added, only noticed the failure when scrolling
+  down later.
+- **Reachability check actually tells you what's wrong.** Old probe
+  silenced both stdout and stderr of every inner command, so failure
+  details surfaced as "SSH stderr: (empty)" — useless. New probe is a
+  multi-stage script that emits tagged STAGE markers and forwards the
+  inner stderr (PATH dump on `uvx`-not-found, full error from `uvx
+  aiui-mcp --help` on resolve failures). Failure details now name the
+  exact step and include the remote's diagnostic output verbatim.
+
 ## [0.4.15] — 2026-04-27
 
 ### Changed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.15"
+version = "0.4.16"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -200,6 +200,32 @@ fn repair_skill() -> Result<setup::StepResult, String> {
     Ok(skill::install_locally())
 }
 
+/// Open a URL in the user's default browser. Tauri's WebView blocks
+/// `window.open()` calls from JavaScript for security, so the
+/// "Problem melden"-button (and any other future external-link case)
+/// has to round-trip through Rust. Issue surfaced 2026-04-27 by tester
+/// clicking the button for the first time.
+#[tauri::command]
+fn open_url(url: String) -> Result<(), String> {
+    // Sanity-check: only allow http(s) so a compromised renderer can't
+    // smuggle file:// or shell URIs through this command.
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err(format!("refusing non-http(s) URL: {url}"));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&url)
+            .spawn()
+            .map_err(|e| format!("open {url}: {e}"))?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = url; // silence unused on non-macos until ports land
+    }
+    Ok(())
+}
+
 /// Quit aiui after Uninstall has cleaned up configs/tokens/skill, killing
 /// every `aiui --mcp-stdio` child first so the auto-resurrect path in
 /// `mcp_attach` can't relaunch the GUI behind us. Without this, the user
@@ -537,7 +563,8 @@ pub fn run() {
             restart_claude_desktop,
             uninstall_all,
             quit_app,
-            dismiss_welcome
+            dismiss_welcome,
+            open_url
         ])
         .setup(move |app| {
             let app_handle = app.handle().clone();

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -705,8 +705,29 @@ pub fn check_remote_aiui_mcp(host_alias: &str) -> StepResult {
         };
     }
 
-    // `uvx --help` first — verifies uv is installed at all. Then
-    // `uvx aiui-mcp --help` to verify the package can be resolved.
+    // Multi-step diagnostic probe: reports WHICH step failed so the user
+    // gets actionable feedback instead of a generic "not reachable". The
+    // earlier silent `>/dev/null 2>&1` redirects swallowed any inner
+    // stderr, leaving us with "SSH stderr: (empty)" as the entire
+    // diagnostic — useless. Now each step writes a tagged marker on
+    // success and the inner stderr flows through on failure.
+    let probe_script = r#"
+        set +e
+        if ! command -v uvx >/dev/null 2>&1; then
+            echo "STAGE:NO_UVX" >&2
+            echo "PATH=$PATH" >&2
+            exit 11
+        fi
+        echo "STAGE:UVX_FOUND $(command -v uvx)"
+        if ! uvx aiui-mcp --help >/dev/null 2>uvx_err; then
+            echo "STAGE:UVX_AIUI_MCP_FAILED" >&2
+            cat uvx_err >&2
+            rm -f uvx_err
+            exit 12
+        fi
+        rm -f uvx_err
+        echo "STAGE:OK"
+    "#;
     let out = Command::new("ssh")
         .args([
             "-o",
@@ -715,38 +736,73 @@ pub fn check_remote_aiui_mcp(host_alias: &str) -> StepResult {
             "ConnectTimeout=10",
             "--",
             host_alias,
-            // bash -lc to source ~/.zshrc / ~/.bashrc so uv on the
-            // user's PATH is found even if SSH starts a non-login shell.
             "bash",
             "-lc",
-            "command -v uvx >/dev/null 2>&1 && uvx aiui-mcp --help >/dev/null 2>&1 && echo ok",
+            probe_script,
         ])
         .output();
 
     match out {
-        Ok(o) if o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "ok" => {
+        Ok(o) if o.status.success() && String::from_utf8_lossy(&o.stdout).contains("STAGE:OK") => {
+            // Pull the uvx path out of the STAGE:UVX_FOUND line for the
+            // success message — confirms WHERE uvx was found, useful
+            // when the user is debugging PATH issues.
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            let uvx_path = stdout
+                .lines()
+                .find_map(|l| l.strip_prefix("STAGE:UVX_FOUND ").map(str::to_string))
+                .unwrap_or_default();
             StepResult {
                 ok: true,
-                message: format!("uvx aiui-mcp reachable on {host_alias}"),
-                details: None,
+                message: format!("uvx aiui-mcp erreichbar auf {host_alias}"),
+                details: if uvx_path.is_empty() {
+                    None
+                } else {
+                    Some(format!("uvx-Pfad auf Remote: {uvx_path}"))
+                },
             }
         }
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+            let exit = o.status.code().unwrap_or(-1);
+            // Diagnose by exit code from the probe script
+            let (msg, hint) = match exit {
+                11 => (
+                    format!("uv ist auf {host_alias} nicht installiert"),
+                    format!(
+                        "Auf dem Remote installieren: `curl -LsSf https://astral.sh/uv/install.sh | sh`. \
+                         PATH-Diagnose:\n{stderr}"
+                    ),
+                ),
+                12 => (
+                    format!("`uvx aiui-mcp` lässt sich auf {host_alias} nicht ausführen"),
+                    format!(
+                        "uv ist da, aber das aiui-mcp-Package konnte nicht aufgelöst/gestartet werden. \
+                         Häufige Ursachen: kein Internet auf dem Remote, PyPI blockiert, alte uv-Version. \
+                         Detail-Output vom Remote:\n{stderr}"
+                    ),
+                ),
+                _ => (
+                    format!("Pre-Flight-Check auf {host_alias} schlug fehl (exit {exit})"),
+                    if stderr.is_empty() {
+                        "Keine Fehler-Ausgabe vom Remote. Prüfe SSH-Login zu der Maschine manuell.".into()
+                    } else {
+                        format!("SSH-Output:\n{stderr}")
+                    },
+                ),
+            };
             StepResult {
                 ok: false,
-                message: format!("uvx aiui-mcp not reachable on {host_alias}"),
-                details: Some(format!(
-                    "Install uv on the remote (https://docs.astral.sh/uv/) so `uvx aiui-mcp` resolves. \
-                     SSH stderr: {}",
-                    if stderr.is_empty() { "(empty)".to_string() } else { stderr }
-                )),
+                message: msg,
+                details: Some(hint),
             }
         }
         Err(e) => StepResult {
             ok: false,
-            message: format!("ssh probe to {host_alias} failed"),
-            details: Some(e.to_string()),
+            message: format!("SSH-Verbindung zu {host_alias} schlug fehl"),
+            details: Some(format!(
+                "Konnte ssh nicht starten: {e}. Prüfe ~/.ssh/config und Schlüssel-Auth zum Host."
+            )),
         },
     }
 }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -26,7 +26,8 @@
         "decorations": true,
         "center": true,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -162,14 +162,18 @@
     }
   }
 
-  function openIssue() {
+  async function openIssue() {
     const body = encodeURIComponent(
       `**Version:** ${status?.build_info ?? "unknown"}\n\n` +
         `**Describe the bug:**\n\n\n` +
         `**Steps to reproduce:**\n1.\n2.\n3.\n\n` +
         `**Expected / actual:**\n\n`,
     );
-    window.open(`https://github.com/byte5ai/aiui/issues/new?body=${body}`, "_blank");
+    // `window.open(url)` is blocked in Tauri's WebView (security). Round
+    // through a Rust command that hands the URL to macOS `open`.
+    await invoke("open_url", {
+      url: `https://github.com/byte5ai/aiui/issues/new?body=${body}`,
+    });
   }
 
   function statusLabel(t: TunnelStatus | undefined): { text: string; tone: "ok" | "warn" | "err" | "dim" } {

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -35,6 +35,10 @@
   let uninstallDone = $state(false);
   let demoCopied = $state(false);
   let step1Expanded = $state(false);
+  /** When add_remote fails, we keep the input populated and surface the
+   *  failure inline so the user can fix and retry without scrolling.
+   *  Cleared on next attempt or successful add. */
+  let addRemoteError = $state<{ message: string; details: string | null } | null>(null);
   let timer: number | undefined;
 
   async function refresh() {
@@ -59,10 +63,19 @@
   async function addRemote() {
     if (!newHost.trim() || busy) return;
     busy = true;
+    addRemoteError = null;
     try {
       const results = await invoke<StepResult[]>("add_remote", { hostAlias: newHost.trim() });
       pushLog(results);
-      newHost = "";
+      // Clear the input only on full success — otherwise keep what the
+      // user typed so they can fix and retry. Surface the first failing
+      // step inline so they don't have to hunt through the log.
+      const firstFailure = results.find((r) => !r.ok);
+      if (firstFailure) {
+        addRemoteError = { message: firstFailure.message, details: firstFailure.details };
+      } else {
+        newHost = "";
+      }
       await refresh();
     } finally {
       busy = false;
@@ -376,6 +389,22 @@
           {$_("settings.remotes.add.button")}
         </button>
       </div>
+      <!-- Inline failure banner. Stays put under the input the user just
+        typed into, so they don't have to scroll down to the log to find
+        out what went wrong. Tester on v0.4.15: input field cleared on
+        failure, error landed only in the scroll-buried log block. -->
+      {#if addRemoteError}
+        <div class="add-remote-error">
+          <strong>{addRemoteError.message}</strong>
+          {#if addRemoteError.details}
+            <pre>{addRemoteError.details}</pre>
+          {/if}
+          <button
+            class="add-remote-error-dismiss"
+            onclick={() => (addRemoteError = null)}
+            aria-label="Schließen">×</button>
+        </div>
+      {/if}
       <p class="subtitle" style="margin: 6px 0 0 0; font-size: 11.5px;">
         {$_("settings.remotes.add.hint")}
       </p>
@@ -575,6 +604,52 @@
     flex-shrink: 0;
   }
   .dot-small.err { background: var(--danger); }
+
+  /* --- inline error banner under add-remote input --- */
+  .add-remote-error {
+    position: relative;
+    margin-top: 6px;
+    padding: 8px 32px 8px 10px;
+    border: 1px solid var(--danger);
+    background: color-mix(in srgb, var(--danger) 10%, var(--surface));
+    border-radius: 8px;
+    font-size: 12px;
+    color: var(--fg);
+    line-height: 1.45;
+  }
+  .add-remote-error strong {
+    display: block;
+    color: var(--danger);
+    font-size: 12.5px;
+    margin-bottom: 2px;
+  }
+  .add-remote-error pre {
+    margin: 4px 0 0 0;
+    padding: 6px 8px;
+    background: var(--surface);
+    font-size: 11px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-word;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--muted);
+  }
+  .add-remote-error-dismiss {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    font-size: 16px;
+    line-height: 1;
+    padding: 2px 6px;
+    cursor: pointer;
+    box-shadow: none;
+    border-radius: 4px;
+  }
+  .add-remote-error-dismiss:hover { color: var(--danger); background: color-mix(in srgb, var(--danger) 8%, transparent); }
 
   /* --- HTTP error banner --- */
   .http-error {


### PR DESCRIPTION
## Summary
Zwei Bugs aus dem v0.4.15-Tester-Lauf:

**UX:** add-remote-Failure löschte das Input-Feld + Fehler landete nur im scroll-versteckten Log. Tester dachte, der Host wäre hinzugefügt — sah erst beim Scrollen, dass nichts geht.

**Diagnose:** Reachability-Probe pipte alle inneren stderr's nach \`/dev/null\` → Fehler-Detail im UI war \"SSH stderr: (empty)\".

## Fix
- Input-Feld bleibt bei Fehler bestehen
- Erster fehlgeschlagener Step als roter Banner direkt unter dem Input
- Probe ist jetzt ein multi-stage bash-Script mit STAGE-Markern + durchgereichtem stderr; Exit-Codes 11/12 unterscheiden \"uv nicht installiert\" von \"aiui-mcp resolve fehlgeschlagen\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)