### PR TITLE
v0.4.18: probe needs bash -ls, not just -l

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.18] — 2026-04-27
+
+### Fixed
+
+- **Reachability probe actually runs the script.** v0.4.17 changed the
+  invocation to pipe the script via SSH stdin and switched to `bash -l`,
+  but missed the `-s` flag — without it, bash doesn't read the script
+  from stdin, starts interactively (or hangs until TTY timeout), exits
+  0 with empty output. User saw "Pre-Flight-Check schlug fehl
+  (exit 0)" with no diagnostic. Now `bash -ls` (login + read-from-stdin),
+  matching the existing `python3 -` pattern in `run_remote_python`.
+
 ## [0.4.17] — 2026-04-27
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.16"
+version = "0.4.18"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.17"
+version = "0.4.18"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -777,7 +777,10 @@ echo "STAGE:OK"
 "#;
 
     // Pipe the script via stdin so ssh doesn't word-split a multi-line
-    // command argument on the remote shell.
+    // command argument on the remote shell. `bash -ls`: -l for login
+    // shell (sources /etc/profile + ~/.profile), -s to read the script
+    // from stdin. Without -s, bash starts interactively and the piped
+    // script never reaches it — exit 0, empty output, mystery failure.
     let mut child = match Command::new("ssh")
         .args([
             "-o",
@@ -787,7 +790,7 @@ echo "STAGE:OK"
             "--",
             host_alias,
             "bash",
-            "-l",
+            "-ls",
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
v0.4.17 hatte den Probe-Aufruf von \`bash -lc <script>\` auf stdin-pipe + \`bash -l\` umgebaut, aber das \`-s\`-Flag vergessen das bash zwingt, Script von stdin zu lesen. Ohne -s startet bash als interaktive login-shell und liest gar nicht von stdin → script läuft nie, exit 0, leerer Output → User sieht \"Pre-Flight-Check schlug fehl (exit 0)\".

Fix: \`bash -ls\`. 5-Zeichen-Diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)