### PR TITLE
v0.4.20: probe checks uvx --version, no server launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.20] — 2026-04-27
+
+### Fixed
+
+- **Reachability probe doesn't try to launch the aiui-mcp server
+  anymore.** v0.4.19's diagnostic output revealed the actual macmini
+  bug: `uvx aiui-mcp --help` was meant as a "does the package resolve
+  from PyPI" probe, but aiui-mcp ignores `--help` and starts the full
+  MCP server which then waits for stdin. Bash hangs on the subprocess,
+  ssh eventually truncates output, the script never reaches STAGE:OK.
+  Probe now uses `uvx --version` instead — idempotent, no server
+  side-effects, tells us uvx is reachable. The "does aiui-mcp resolve
+  from PyPI" question is deferred to first-tool-call time, where any
+  failure shows up as a structured Claude error with full stderr.
+
 ## [0.4.19] — 2026-04-27
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "axum",
  "chrono",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.19"
+version = "0.4.20"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -772,15 +772,21 @@ fi
 
 echo "STAGE:UVX_FOUND $UVX"
 
-# mktemp instead of cwd-relative — current dir of an ssh-login may not
-# be writable, causing a redirect-error that aborts the script before
-# the actual uvx call.
+# Verify uvx itself is callable. Earlier versions tried `uvx aiui-mcp
+# --help` here as a "does the package resolve from PyPI" probe — but
+# aiui-mcp has no `--help` handler; the flag gets ignored and the full
+# MCP server starts, blocking on stdin. Bash hangs on the child, ssh
+# eventually truncates output, the script never reaches STAGE:OK.
+# Better: trust that if `uvx` itself is healthy, `uvx aiui-mcp` will
+# resolve at first-tool-call time — and fail there with a clear error
+# from Claude Code if PyPI is unreachable. Cheap, idempotent, no
+# server side-effects.
 ERR_FILE="$(mktemp -t aiui-probe.XXXXXX)"
-if ! "$UVX" aiui-mcp --help >/dev/null 2>"$ERR_FILE"; then
-    echo "STAGE:UVX_AIUI_MCP_FAILED" >&2
+if ! "$UVX" --version >/dev/null 2>"$ERR_FILE"; then
+    echo "STAGE:UVX_BROKEN" >&2
     cat "$ERR_FILE" >&2
     rm -f "$ERR_FILE"
-    exit 12
+    exit 13
 fi
 rm -f "$ERR_FILE"
 echo "STAGE:OK"
@@ -905,12 +911,11 @@ echo "STAGE:OK"
                 dump(&stderr)
             ),
         ),
-        12 => (
-            format!("`uvx aiui-mcp` lässt sich auf {host_alias} nicht ausführen"),
+        13 => (
+            format!("uvx auf {host_alias} ist nicht ausführbar"),
             format!(
-                "uv ist da, aber das aiui-mcp-Package konnte nicht aufgelöst/gestartet werden. \
-                 Häufige Ursachen: kein Internet auf dem Remote, PyPI blockiert, alte uv-Version. \
-                 Detail-Output vom Remote:\n{}",
+                "uvx wurde gefunden, aber `uvx --version` schlug fehl. \
+                 Vermutlich beschädigte uv-Installation. Detail vom Remote:\n{}",
                 dump(&stderr)
             ),
         ),

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
v0.4.19's diagnostic output zeigte was los war: \`uvx aiui-mcp --help\` startet den vollen MCP-Server (aiui-mcp ignoriert --help), der wartet auf stdin, bash hängt am Subprocess, ssh truncated Output bevor STAGE:OK durchkommt.

Probe jetzt: \`uvx --version\`. Idempotent, kein Server-Start. \"Resolved aiui-mcp von PyPI?\" verschiebt sich auf den ersten echten MCP-Tool-Call, wo jeder Fehler ohnehin als strukturierte Claude-Meldung mit vollem stderr ankommt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)