### PR TITLE
release: keep PyPI in lockstep with Tauri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- **Release pipeline now publishes the PyPI side in lockstep.**
+  `scripts/release.sh` gained a fourth version-sync gate
+  (`python/pyproject.toml`), runs `uv build` alongside the Tauri build
+  (covered by `--dry`), and runs `uv publish` after the GitHub release.
+  Required `UV_PUBLISH_TOKEN` is checked up-front, so a missing token
+  fails the run before any Tauri work happens. Background: `aiui-mcp`
+  0.4.2 stayed pinned on PyPI long after the Tauri side had moved past
+  the `widgets` → `teach` rename, leaving every remote-host install in
+  the old prompt world. This closes that gap structurally — next
+  release the two sides ship or fail together.
+
 ## [0.4.21] — 2026-04-28
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,24 @@ present) or read the script; the required environment variables are:
 - `APPLE_SIGNING_IDENTITY`, `NOTARY_PROFILE`,
   `BUILD_KEYCHAIN`, `BUILD_KEYCHAIN_PASS_FILE` — Apple codesign + notary
 - `TAURI_SIGNING_PRIVATE_KEY_PATH` — Ed25519 key for the updater feed
+- `UV_PUBLISH_TOKEN` — PyPI API token (project-scoped to `aiui-mcp`).
+  Without it, `scripts/release.sh` aborts before any work is done — that
+  guard exists because shipping the Tauri side without the matching PyPI
+  bump produces silent slash-command-mismatch on remote hosts.
 
-Running `scripts/release.sh 0.2.3` builds, signs, notarizes, creates a
-DMG + updater artifacts + `latest.json`, tags, pushes, and creates the
-GitHub release via `gh`.
+A single run of `scripts/release.sh 0.2.3` performs the full pipeline:
+
+1. Pre-flight checks — `.env.release` loaded, all required env present,
+   versions agree across `Cargo.toml`, `tauri.conf.json`, and
+   `python/pyproject.toml`.
+2. Tauri companion: build, codesign, notarize, staple, DMG, updater
+   bundle + signature, `latest.json`.
+3. Python `aiui-mcp`: `uv build` produces wheel + sdist into
+   `python/dist/`. Done before the dry-run gate so dry runs catch
+   packaging breakage too.
+4. Tag, push, GitHub release.
+5. `uv publish` from `python/` — pushes the wheel + sdist to PyPI so
+   `uvx aiui-mcp` resolves to the matching version on remote hosts.
 
 ## Issues
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.2"
+version = "0.4.21"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,6 +15,12 @@
 #   BUILD_KEYCHAIN_PASS_FILE         path to file holding keychain password
 #   TAURI_SIGNING_PRIVATE_KEY_PATH   minisign private key for updater feed
 #   TAURI_SIGNING_PRIVATE_KEY_PASSWORD  (optional; empty if no password)
+#   UV_PUBLISH_TOKEN                 PyPI API token for publishing aiui-mcp.
+#                                    Generate at https://pypi.org/manage/account/token/
+#                                    (scope: project = aiui-mcp). Without this, the
+#                                    Tauri side ships but the Python side stays stale
+#                                    on PyPI — exactly how the v0.4.2/v0.4.21 split
+#                                    happened on 2026-04-28.
 #
 # Usage:
 #   scripts/release.sh 0.1.2
@@ -44,6 +50,8 @@ fi
 : "${BUILD_KEYCHAIN:?not set}"
 : "${BUILD_KEYCHAIN_PASS_FILE:?not set}"
 : "${TAURI_SIGNING_PRIVATE_KEY_PATH:?not set}"
+: "${UV_PUBLISH_TOKEN:?not set — needed for publishing aiui-mcp to PyPI. Put it in .env.release or export before running. See script header for details.}"
+export UV_PUBLISH_TOKEN
 # Tauri bundler reads TAURI_SIGNING_PRIVATE_KEY (literal key content) during
 # `tauri build`, not the _PATH variant. Load the file content here.
 export TAURI_SIGNING_PRIVATE_KEY="$(cat "${TAURI_SIGNING_PRIVATE_KEY_PATH}")"
@@ -62,14 +70,18 @@ DIRECT_DMG="${REPO_ROOT}/aiui-${VERSION}-arm64.dmg"
 UPDATER_BUNDLE="${APP_DIR}/aiui.app.tar.gz"
 UPDATER_SIG="${UPDATER_BUNDLE}.sig"
 
-echo "→ Checking version sync (Cargo.toml ↔ tauri.conf.json)"
-# Three places need to agree on the version:
+echo "→ Checking version sync (Cargo.toml ↔ tauri.conf.json ↔ python/pyproject.toml)"
+# Four places need to agree on the version:
 #   - Cargo.toml `version` (drives the build)
 #   - tauri.conf.json `version` (drives the bundled Info.plist)
+#   - python/pyproject.toml `version` (drives the PyPI artifact and
+#     therefore what `uvx aiui-mcp` resolves to on remote hosts)
 #   - the `${VERSION}` argument to this script (drives the tag/release)
 # Any drift produces a bundle whose CFBundleShortVersionString doesn't
 # match what the in-app updater reports — that's how #82 happened.
-# Issue C-3 in v0.4.10 review.
+# Drift between Tauri and PyPI is how the v0.4.2/v0.4.21 widgets-vs-teach
+# split happened on 2026-04-28: Tauri shipped, PyPI didn't, remotes kept
+# resolving the old prompt names. Issue C-3 in v0.4.10 review.
 if ! grep -q "^version = \"${VERSION}\"" companion/src-tauri/Cargo.toml; then
   echo "  Cargo.toml version does not match ${VERSION} — bump it first." >&2
   exit 1
@@ -77,6 +89,11 @@ fi
 TAURI_CONF_VERSION="$(python3 -c 'import json,sys;print(json.load(open("companion/src-tauri/tauri.conf.json"))["version"])')"
 if [[ "${TAURI_CONF_VERSION}" != "${VERSION}" ]]; then
   echo "  tauri.conf.json version is ${TAURI_CONF_VERSION}, expected ${VERSION} — bump it." >&2
+  exit 1
+fi
+PYPI_VERSION="$(grep -E '^version = ' python/pyproject.toml | awk -F'"' '{print $2}')"
+if [[ "${PYPI_VERSION}" != "${VERSION}" ]]; then
+  echo "  python/pyproject.toml version is ${PYPI_VERSION}, expected ${VERSION} — bump it." >&2
   exit 1
 fi
 
@@ -166,12 +183,30 @@ echo "✓ Wrote ${LATEST_JSON}"
 UPDATER_NAMED="${REPO_ROOT}/aiui-${VERSION}-updater-arm64.tar.gz"
 cp "${UPDATER_BUNDLE}" "${UPDATER_NAMED}"
 
+# Build the Python package alongside the Tauri artifacts. Done before the
+# --dry exit so dry runs catch packaging regressions (missing files,
+# version-string drift inside the wheel) too.
+echo "→ Building Python package (aiui-mcp ${VERSION})"
+PY_DIST_DIR="${REPO_ROOT}/python/dist"
+rm -rf "${PY_DIST_DIR}"
+(cd python && uv build)
+PY_WHEEL="$(ls "${PY_DIST_DIR}"/aiui_mcp-${VERSION}-*.whl 2>/dev/null | head -1)"
+PY_SDIST="${PY_DIST_DIR}/aiui_mcp-${VERSION}.tar.gz"
+if [[ -z "${PY_WHEEL}" || ! -f "${PY_SDIST}" ]]; then
+  echo "  uv build did not produce expected artifacts in ${PY_DIST_DIR}" >&2
+  ls -l "${PY_DIST_DIR}" >&2 || true
+  exit 1
+fi
+echo "  ✓ Python artifacts: $(basename "${PY_WHEEL}"), $(basename "${PY_SDIST}")"
+
 if [[ "$DRY" == "--dry" ]]; then
   echo "Dry run — artifacts:"
   echo "  ${DIRECT_DMG}"
   echo "  ${DIRECT_ZIP}"
   echo "  ${UPDATER_NAMED}"
   echo "  ${LATEST_JSON}"
+  echo "  ${PY_WHEEL}"
+  echo "  ${PY_SDIST}"
   exit 0
 fi
 
@@ -205,3 +240,12 @@ gh release create "${TAG}" \
   --notes-file "${NOTES_FILE}"
 
 echo "✓ Released ${TAG} on GitHub"
+
+# PyPI publish AFTER the GitHub release succeeds. If this step fails the
+# Tauri side is already shipped and the manual recovery is `cd python &&
+# uv publish dist/*` once the credential issue is fixed. The pre-flight
+# token check at the top of this script is what stops us from getting
+# here without a token.
+echo "→ Publishing aiui-mcp ${VERSION} to PyPI"
+(cd python && uv publish)
+echo "✓ Published aiui-mcp ${VERSION} to PyPI"


### PR DESCRIPTION
## Why

Today the Tauri companion shipped 0.4.21 with the `teach` slash-command rename intact, but `aiui-mcp` on PyPI is still 0.4.2 from March (still using `widgets`). Every remote host in the wild that runs `uvx aiui-mcp` is resolving the old prompts — that's the symptom the user just hit (autocomplete shows `aiui:widgets`, manual `/aiui:teach` does nothing).

The release pipeline never closed that gap structurally — Tauri and PyPI were two separate manual rituals.

## What changed

- `scripts/release.sh` now treats `python/pyproject.toml` as a peer of `Cargo.toml` / `tauri.conf.json`. Version drift across the three is a hard fail before any work runs.
- Required env `UV_PUBLISH_TOKEN`, checked up front alongside the Apple credentials. Missing token = early abort, no half-shipped release.
- `uv build` runs alongside the Tauri build (so `--dry` catches packaging breakage too).
- `uv publish` runs after the GitHub release — same script, same run.
- Doc updates in CONTRIBUTING + a CHANGELOG `[Unreleased]` entry.
- `python/pyproject.toml` bumped to 0.4.21 so the manual `uv publish` immediately after this merges produces the matched PyPI artifact.

## Test plan

- [x] `uv build` produces `aiui_mcp-0.4.21.tar.gz` and the wheel — verified locally
- [ ] `scripts/release.sh 0.4.21 --dry` runs through pre-flight checks and emits both Tauri and Python artifacts (will run after merge)
- [ ] After merge: `cd python && uv publish dist/*` (or re-run the build) to push 0.4.21 to PyPI
- [ ] Verify `pip index versions aiui-mcp` shows 0.4.21 as latest