### PR TITLE
feat: confirm.image and ask.options[].thumbnail (v0.4.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.23] — 2026-04-28
+
+### Added
+
+- **`confirm` accepts an `image`.** Pass `image: {src, alt?, max_height?}`
+  to fold a visual sign-off into a plain yes/no — no more `form`-with-
+  one-image-and-two-buttons workaround for "is this generated logo OK?".
+  `src` follows the standard aiui resolution rules (data: URL, http(s)
+  URL, or absolute / `~/`-rooted local path on the host the agent runs
+  on).
+- **`ask` options accept a `thumbnail`.** Each option in the array can
+  now carry a `thumbnail: <src>` rendered as a 56 × 56 preview to the
+  left of the label. Same resolution rules. Closes the gap between
+  text-only `ask` and full-blown `image_grid`: 2–6 visual options
+  belong here, not in a `form` wrapper.
+
+### Changed
+
+- **Skill catalog calls out the visual variants.** Tool-choice table
+  gains explicit rows for "yes/no on a generated image" → `confirm`
+  with `image`, and "pick one of 2–6 images" → `ask` with `thumbnail`.
+  Removes the implicit pressure to reach for `form` for either case.
+
 ## [0.4.22] — 2026-04-28
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.22"
+version = "0.4.23"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/imageresolve.rs
+++ b/companion/src-tauri/src/imageresolve.rs
@@ -424,6 +424,52 @@ mod tests {
     }
 
     #[test]
+    fn resolve_local_paths_walks_confirm_image_and_ask_thumbnail() {
+        // confirm.image.src and ask.options[].thumbnail are new image
+        // slots in 0.4.23. The resolver is shape-agnostic — it walks
+        // any `src`/`thumbnail` key regardless of which tool spec it
+        // sits under — but pin that down with a test so a future
+        // refactor can't accidentally narrow it.
+        let tmpdir = std::env::temp_dir();
+        let f = tmpdir.join(format!("aiui-confirm-ask-test-{}.png", std::process::id()));
+        std::fs::write(&f, b"\x89PNG\r\n\x1a\nfake bytes").unwrap();
+        let path_str = f.to_string_lossy().to_string();
+
+        let mut spec = json!({
+            "kind": "confirm",
+            "title": "OK?",
+            "image": {"src": path_str.clone()}
+        });
+        resolve_local_paths(&mut spec);
+        assert!(spec["image"]["src"]
+            .as_str()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+
+        let mut spec = json!({
+            "kind": "ask",
+            "question": "Which?",
+            "options": [
+                {"label": "A", "thumbnail": path_str.clone()},
+                {"label": "B", "thumbnail": "https://leave.me/b.png"},
+                {"label": "C"},
+            ]
+        });
+        resolve_local_paths(&mut spec);
+        assert!(spec["options"][0]["thumbnail"]
+            .as_str()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+        assert_eq!(
+            spec["options"][1]["thumbnail"].as_str(),
+            Some("https://leave.me/b.png")
+        );
+        assert!(spec["options"][2].get("thumbnail").is_none());
+
+        std::fs::remove_file(&f).ok();
+    }
+
+    #[test]
     fn resolve_local_paths_fails_soft_on_missing_file() {
         let original = "/this/path/should/not/exist/aiui-test-missing.png";
         let mut spec = json!({"src": original});

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -243,7 +243,7 @@ fn tools_list() -> Value {
     json!([
         {
             "name": "confirm",
-            "description": "Before writing any yes/no question into chat, call this tool instead. Pass `destructive: true` (red button) for delete / drop / force-push / rollback / prod-deploy — never trust loose prior approval for irreversible steps; re-confirm in a dialog. Returns {cancelled, confirmed}. For 3+ options, use `ask`. For pure information the user only reads, render in chat.",
+            "description": "Before writing any yes/no question into chat, call this tool instead. Pass `destructive: true` (red button) for delete / drop / force-push / rollback / prod-deploy — never trust loose prior approval for irreversible steps; re-confirm in a dialog. For visual sign-off (\"is this image OK?\", \"keep this generated diagram?\") pass `image: {src, alt?, max_height?}` — `src` accepts data: URLs, http(s) URLs, or absolute / `~/`-rooted local paths (resolved on YOUR host). Returns {cancelled, confirmed}. For 3+ options, use `ask`. For pure information the user only reads, render in chat.",
             "inputSchema": {
                 "type": "object",
                 "required": ["title"],
@@ -253,13 +253,23 @@ fn tools_list() -> Value {
                     "header": { "type": "string", "description": "Short chip above the title (≤ 14 chars)." },
                     "destructive": { "type": "boolean", "default": false, "description": "Red confirm button — for deletions/rollbacks only." },
                     "confirm_label": { "type": "string" },
-                    "cancel_label": { "type": "string" }
+                    "cancel_label": { "type": "string" },
+                    "image": {
+                        "type": "object",
+                        "description": "Optional image shown between header and title for visual sign-off.",
+                        "required": ["src"],
+                        "properties": {
+                            "src": { "type": "string", "description": "data: URL, http(s):// URL, or absolute / ~/ local path on YOUR host. Same resolution rules as the form `image` field." },
+                            "alt": { "type": "string" },
+                            "max_height": { "type": "number" }
+                        }
+                    }
                 }
             }
         },
         {
             "name": "ask",
-            "description": "Before listing options in chat and waiting for the user to type back which one (deploy strategy, migration path, file to act on …), call this tool instead. Per-option `description` carries the trade-off; `multi_select` and `allow_other` cover the rest. Returns {cancelled, answers, other?}. For yes/no, use `confirm`. For ≥ 2 related inputs, use `form`.",
+            "description": "Before listing options in chat and waiting for the user to type back which one (deploy strategy, migration path, file to act on …), call this tool instead. Per-option `description` carries the trade-off; `multi_select` and `allow_other` cover the rest. For visual choice (\"which of these images?\") pass `thumbnail: <src>` per option — same resolution rules as anywhere else in aiui (data:, http(s)://, or absolute local path). Returns {cancelled, answers, other?}. For yes/no, use `confirm`. For ≥ 2 related inputs, use `form`.",
             "inputSchema": {
                 "type": "object",
                 "required": ["question", "options"],
@@ -272,7 +282,8 @@ fn tools_list() -> Value {
                             "properties": {
                                 "label": { "type": "string" },
                                 "description": { "type": "string" },
-                                "value": { "type": "string" }
+                                "value": { "type": "string" },
+                                "thumbnail": { "type": "string", "description": "Optional image src shown next to the option label. Same resolution rules as the form image field." }
                             },
                             "required": ["label"]
                         }
@@ -416,7 +427,8 @@ async fn tools_call(
                 "header": args.get("header"),
                 "destructive": args.get("destructive").and_then(|v| v.as_bool()).unwrap_or(false),
                 "confirmLabel": args.get("confirm_label"),
-                "cancelLabel": args.get("cancel_label")
+                "cancelLabel": args.get("cancel_label"),
+                "image": args.get("image")
             }),
             cfg,
             http,

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/app.css
+++ b/companion/src/app.css
@@ -273,6 +273,15 @@ pre {
   font-size: 12px;
   margin-top: 2px;
 }
+.option-thumb {
+  width: 56px;
+  height: 56px;
+  flex: 0 0 56px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
 
 /* subtle entrance animation for dialog content */
 @keyframes aiui-enter {

--- a/companion/src/lib/widgets/Ask.svelte
+++ b/companion/src/lib/widgets/Ask.svelte
@@ -5,6 +5,7 @@
     label: string;
     description?: string;
     value?: string;
+    thumbnail?: string; // data: URL, http(s) URL, or absolute / `~/` local path — bridge-resolved
   };
   type Spec = {
     kind: "ask";
@@ -58,8 +59,12 @@
         type="button"
         class="option"
         class:selected={selected.has(i)}
+        class:has-thumbnail={!!opt.thumbnail}
         onclick={() => toggle(i)}
       >
+        {#if opt.thumbnail}
+          <img class="option-thumb" src={opt.thumbnail} alt="" />
+        {/if}
         <div>
           <div class="label">{opt.label}</div>
           {#if opt.description}<div class="description">{opt.description}</div>{/if}

--- a/companion/src/lib/widgets/Confirm.svelte
+++ b/companion/src/lib/widgets/Confirm.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
 
+  type ConfirmImage = {
+    src: string; // data: URL, http(s) URL, or absolute / `~/` local path — bridge resolves before the spec hits the WebView
+    alt?: string;
+    max_height?: number;
+  };
   type Spec = {
     kind: "confirm";
     title: string;
@@ -9,6 +14,7 @@
     destructive?: boolean;
     confirmLabel?: string;
     cancelLabel?: string;
+    image?: ConfirmImage;
   };
 
   let { spec, onsubmit, oncancel }: { spec: Spec; onsubmit: (r: any) => void; oncancel: () => void } = $props();
@@ -23,6 +29,11 @@
 
 <div class="stack">
   {#if spec.header}<span class="chip">{spec.header}</span>{/if}
+  {#if spec.image}
+    <figure class="confirm-image" style={spec.image.max_height ? `max-height: ${spec.image.max_height}px` : ""}>
+      <img src={spec.image.src} alt={spec.image.alt ?? spec.title} />
+    </figure>
+  {/if}
   <div>
     <p class="title">{spec.title}</p>
     {#if spec.message}<p class="subtitle">{spec.message}</p>{/if}
@@ -35,3 +46,22 @@
     >
   </div>
 </div>
+
+<style>
+  .confirm-image {
+    margin: 0;
+    padding: 8px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    display: flex;
+    justify-content: center;
+    overflow: hidden;
+  }
+  .confirm-image img {
+    max-width: 100%;
+    max-height: 240px;
+    height: auto;
+    object-fit: contain;
+  }
+</style>

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -33,6 +33,12 @@ instead:
   sortable `list` field.
 - Any step that wants a **date, datetime, range, color, or numeric value
   in a bounded interval** → `form` with the matching field.
+- Any step that asks **"is this generated image OK?"** → `confirm`
+  with `image: {src}`. Don't fall back to a `form`-with-image-and-two-
+  buttons when the question is a plain yes/no.
+- Any step that asks **"which of these images?"** with 2–6 candidates
+  → `ask` with `thumbnail` per option. Use `form` + `image_grid` only
+  when there are many candidates (≥ 7) or the picker needs multi-select.
 
 ## When chat actually wins
 
@@ -49,8 +55,11 @@ Skip the dialog for content the user reads, doesn't answer:
 | Intent | Tool |
 |---|---|
 | Yes/no, especially destructive | `confirm` |
+| Yes/no on a generated image ("is this OK?") | `confirm` with `image: {src}` |
 | 2–6 options, possibly with per-option context | `ask` |
+| Pick one of N images ("A or B or C") | `ask` with `thumbnail` per option |
 | Multi-field input, multi-action footer | `form` |
+| Pick one of *many* images (e.g. 12 logo variants) | `form` with `image_grid` |
 | Single free-text answer | just ask in chat |
 | More than 8 fields | split into multiple `form` calls; do not cram one dialog |
 
@@ -137,9 +146,15 @@ Each `src` follows the same rules as `image` — see below.
 
 ## Image sources (`src` / `thumbnail`)
 
-Anywhere aiui takes a `src` or `thumbnail` (the `image` field, the
-`image_grid.images[]` entries, the `list.items[].thumbnail`), three
-input formats render correctly:
+aiui takes an image source in five places:
+
+- `confirm` → `image: {src, alt?, max_height?}` — visual yes/no
+- `ask` → `options[].thumbnail` — visual pick-one-of-N
+- `form` → `image` field → `src`
+- `form` → `image_grid` → `images[].src`
+- `form` → `list` → `items[].thumbnail`
+
+In all of them the same three input formats render correctly:
 
 - **Local filesystem path** (`/Users/me/foo.png`, `~/Pictures/x.jpg`)
   — *the natural choice when the file is already on disk*. The aiui

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.22"
+version = "0.4.23"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/aiui_mcp/server.py
+++ b/python/src/aiui_mcp/server.py
@@ -236,7 +236,7 @@ def _format_result(payload: dict[str, Any]) -> dict[str, Any]:
 @mcp.tool()
 async def ask(
     question: str,
-    options: list[dict[str, str]],
+    options: list[dict[str, Any]],
     header: str | None = None,
     multi_select: bool = False,
     allow_other: bool = True,
@@ -253,6 +253,10 @@ async def ask(
     - Label: noun or short imperative, ≤ 5 words, no punctuation, no emoji.
     - Description: one sentence stating the trade-off or consequence.
     - Keep options parallel in grammar.
+    - For visual choice ("which of these images?") add `thumbnail` per
+      option — same `src` rules as everywhere else (data: URL, http(s)
+      URL, or absolute / `~/` local path on YOUR host). aiui resolves
+      paths and URLs to data: URLs before render.
 
     ANTI-PATTERNS: > 8 options (use `form` with a `list` field); generic labels
     like "Option 1"; redundant descriptions that just restate the label.
@@ -261,7 +265,8 @@ async def ask(
 
     Args:
         question: Full question, imperative or interrogative.
-        options: List of `{"label": str, "description"?: str, "value"?: str}`.
+        options: List of `{"label": str, "description"?: str, "value"?: str,
+            "thumbnail"?: str}`.
         header: Short chip above the question (≤ 14 chars).
         multi_select: Allow selecting multiple options.
         allow_other: Offer a free-text fallback.
@@ -388,6 +393,7 @@ async def confirm(
     destructive: bool = False,
     confirm_label: str | None = None,
     cancel_label: str | None = None,
+    image: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Before writing any yes/no question into chat, call this tool instead.
     Pass `destructive=True` (red button) for delete / drop / force-push /
@@ -396,6 +402,7 @@ async def confirm(
 
     WHEN TO USE: irreversible or high-stakes step where "just proceed" is
     unsafe. For pure information, respond in chat. For 3+ options, use `ask`.
+    For visual sign-off ("is this generated image OK?"), pass `image`.
 
     WRITE:
     - Title: the decision as a question, ≤ 10 words.
@@ -403,6 +410,8 @@ async def confirm(
     - `destructive=True` for deletions/force-pushes/rollbacks — never for
       saves or creates.
     - Custom `confirm_label`/`cancel_label` when verbs clarify.
+    - `image` for visual confirmation — same `src` rules as elsewhere
+      (data: URL, http(s) URL, or absolute / `~/` local path on YOUR host).
 
     Returns `{cancelled, confirmed}`. `cancelled=True` means Escape or window
     close. `cancelled=False, confirmed=False` means the explicit No button.
@@ -414,6 +423,9 @@ async def confirm(
         destructive: Red confirm button.
         confirm_label: Defaults to "Ja".
         cancel_label: Defaults to "Nein".
+        image: `{"src": str, "alt"?: str, "max_height"?: int}`. Shown above
+            the title for visual confirmation. `src` follows the standard
+            aiui resolution rules.
     """
     spec = {
         "kind": "confirm",
@@ -423,6 +435,7 @@ async def confirm(
         "destructive": destructive,
         "confirmLabel": confirm_label,
         "cancelLabel": cancel_label,
+        "image": image,
     }
     return _format_result(await _post_render(spec))
 

--- a/python/tests/test_resolve_local_paths.py
+++ b/python/tests/test_resolve_local_paths.py
@@ -110,3 +110,35 @@ def test_resolve_local_paths_ignores_non_src_keys() -> None:
     # though the values would qualify if they were under the right key.
     assert spec["title"].endswith("/src.png")
     assert spec["label"] == "/this/is/just/text"
+
+
+def test_resolve_local_paths_walks_confirm_image_and_ask_thumbnail(tmp_path: Path) -> None:
+    """`confirm.image.src` and `ask.options[].thumbnail` are new image slots
+    in 0.4.23. The resolver walks any `src`/`thumbnail` key regardless of
+    tool spec — pin that down so a future refactor can't narrow it.
+    """
+    f = tmp_path / "tiny.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\nfake bytes")
+    path_str = str(f)
+
+    confirm_spec = {
+        "kind": "confirm",
+        "title": "OK?",
+        "image": {"src": path_str},
+    }
+    _resolve_local_paths(confirm_spec)
+    assert confirm_spec["image"]["src"].startswith("data:image/png;base64,")
+
+    ask_spec = {
+        "kind": "ask",
+        "question": "Which?",
+        "options": [
+            {"label": "A", "thumbnail": path_str},
+            {"label": "B", "thumbnail": "https://leave.me/b.png"},
+            {"label": "C"},
+        ],
+    }
+    _resolve_local_paths(ask_spec)
+    assert ask_spec["options"][0]["thumbnail"].startswith("data:image/png;base64,")
+    assert ask_spec["options"][1]["thumbnail"] == "https://leave.me/b.png"
+    assert "thumbnail" not in ask_spec["options"][2]


### PR DESCRIPTION
## Why

Two visual use-cases agents kept reaching for `form` to express:

1. \"Is this generated image OK?\" — natural shape is yes/no, but `confirm` had no image slot, so agents wrapped a `form` around a single `image`-field with Bestätigen/Ablehnen actions
2. \"A or B or nothing?\" with 2–6 visual options — natural shape is pick-one, but `ask` had no thumbnail, so agents reached for `form` + `image_grid`

Both workarounds work. Neither is something an agent comes up with from first principles — they require knowing the indirection \"hide the image inside a form that's not really a form\".

## What

| Tool | New | Render |
|---|---|---|
| `confirm` | `image: {src, alt?, max_height?}` | between header and title, max-height 240px default |
| `ask` | `options[].thumbnail: string` | 56×56 preview to the left of label |

Both `src` slots follow the same resolution rules as everywhere else in aiui — `data:` URL, `http(s)://` URL (Mac-side fetch), or absolute / `~/`-rooted local path (bridge-side read). The resolver is shape-agnostic; the new slots cost zero code there. Pinned tests in both Rust and Python so a future refactor narrowing the walk fails loudly.

## Skill changes

Tool-choice table grows two rows so agents land on the right tool from the description alone:

- \"Yes/no on a generated image\" → `confirm` with `image`
- \"Pick one of 2–6 images\" → `ask` with `thumbnail`

Plus a new line in \"Default to a dialog\": don't use `form` with one image and two buttons when the question is plain yes/no.

## Test plan

- [x] `cargo test --lib imageresolve` — 8 passed (1 new)
- [x] `cd python && uv run --extra dev pytest tests/` — 9 passed (1 new)
- [x] `npx svelte-check` — 0 errors
- [ ] CI green
- [ ] After merge: `scripts/release.sh 0.4.23`
- [ ] Smoke: prompt agent for \"is this image OK?\" → confirm pops with image, no form wrapper. Prompt for \"which of these 3 logos?\" → ask pops with thumbnails per option.