### PR TITLE
fix: persistent TRACE logging for aiui_lib (v0.4.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.24] — 2026-04-29
+
+### Changed
+
+- **Persistent TRACE logging for aiui's own modules.** Bumps the
+  `aiui_lib::*` log level from Info to Trace by default; everything
+  else stays at Info to keep volume manageable. Log rotates at 5 MB
+  with one previous file kept — covers a multi-hour session without
+  filling up disk. Diagnosed after a 4-minute MCP-timeout on a trivial
+  form spec where the existing log gave us nothing because the entire
+  render pipeline emits only at Trace level. Next time something
+  hangs, the log under `~/Library/Logs/de.byte5.aiui/` will show
+  exactly which phase stuck.
+
 ## [0.4.23] — 2026-04-28
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.23"
+version = "0.4.24"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -535,8 +535,22 @@ pub fn run() {
             show_settings_window(app);
         }))
         .plugin(
+            // Persistent TRACE logging for aiui's own modules so a hung
+            // dialog leaves a forensic trail. Bumped from Info → Trace
+            // for `aiui_lib::*` only; dependencies (tauri, hyper, …)
+            // stay at Info to keep the volume manageable. Log rotates
+            // at 5 MB, one previous file kept — covers a multi-hour
+            // session at TRACE without filling up disk.
+            //
+            // Investigated 2026-04-29: a 4-minute MCP timeout on a
+            // trivial form spec was unrecoverable from logs because
+            // the entire render pipeline (`render: …` traces in
+            // http.rs / mcp.rs / dialog.rs) only emits at Trace level.
             tauri_plugin_log::Builder::default()
                 .level(log::LevelFilter::Info)
+                .level_for("aiui_lib", log::LevelFilter::Trace)
+                .max_file_size(5_000_000)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
                 .targets([
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.23"
+version = "0.4.24"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps tauri-plugin-log from Info to Trace for the aiui_lib crate. Dependencies stay at Info. Rotation: 5 MB, one previous kept. After 4-minute hang on 2026-04-29 the existing log gave us nothing because all render-pipeline traces sit at Trace level — this fixes that.