### PR TITLE
feat: setup + dialog as separate movable windows (v0.4.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.25] — 2026-04-29
+
+### Changed
+
+- **Setup window and dialog window are now separate Tauri windows.**
+  The single-window-with-two-views design produced a class of bugs
+  where the agent's dialog ended up stacked behind the user's open
+  settings window — invisible, blocking every subsequent render call
+  for the rest of the session. Splitting them eliminates that
+  structurally: settings live in a `setup` window, dialogs in a
+  `dialog` window, both independently movable and stackable in the
+  normal macOS sense. Closing one no longer cancels the other.
+- **Windows are draggable from anywhere along the top edge.** Each
+  window has an invisible 28 px `data-tauri-drag-region` strip
+  layered over the macOS overlay title bar so the user can grab the
+  window and move it without aiming at the actual title-bar pixel
+  row. Reported by early testers when an agent dialog covered work.
+
+### Fixed
+
+- **HTTP-bind failure now exits the second instance.** Earlier
+  versions left a half-zombie aiui running when `localhost:7777` was
+  already taken — a window that looked alive but answered no
+  requests. Combined with the old single-window design that produced
+  the 2026-04-29 hung-dialog incident: a stale instance held the
+  pending dialog while a freshly started one masked it with its
+  settings view. The new behaviour is to exit(1) on bind failure,
+  surface the existing instance via tauri-plugin-single-instance,
+  and let mcp_attach's auto-resurrect bring things back cleanly.
+- **Window close on the setup window no longer kills an in-flight
+  dialog.** The close handler now checks whether any other window is
+  still visible before quitting the app. Dialog windows stay alive
+  when the user closes settings; the app only quits when the last
+  window goes away. Auto-resurrect on the next tool call still works
+  the same way.
+
+### Internal
+
+- `surface_main_window` / `reload_main_webview` now operate on the
+  `dialog` window label specifically. `dialog:show` and `ui:ping`
+  events are routed via `emit_to(DIALOG_WINDOW_LABEL, …)` so the
+  setup window never sees them.
+- New `DialogShell.svelte` holds the dialog-specific listeners and
+  routing; `App.svelte` branches on `getCurrentWebviewWindow().label`
+  and renders Settings or DialogShell accordingly.
+
 ## [0.4.24] — 2026-04-29
 
 ### Changed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.24"
+version = "0.4.25"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/capabilities/default.json
+++ b/companion/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "windows": ["main"],
+  "windows": ["setup", "dialog"],
   "permissions": [
     "core:default",
     "updater:default",

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -288,7 +288,25 @@ async fn health(
 async fn probe_webview(state: &AppState) -> WebviewHealth {
     let (id, rx) = state.ui_acks.register();
     let started = std::time::Instant::now();
-    if let Err(e) = state.app.emit("ui:ping", &id) {
+    // Probe the dialog window's webview specifically — the setup
+    // window is user-driven and irrelevant for render-pipeline health.
+    // If no dialog window exists yet, we report `responsive: true`
+    // because there's nothing to be unresponsive *about*.
+    if state
+        .app
+        .get_webview_window(crate::DIALOG_WINDOW_LABEL)
+        .is_none()
+    {
+        state.ui_acks.forget(&id);
+        return WebviewHealth {
+            responsive: true,
+            rtt_ms: Some(0),
+        };
+    }
+    if let Err(e) = state
+        .app
+        .emit_to(crate::DIALOG_WINDOW_LABEL, "ui:ping", &id)
+    {
         trace(&format!("health: emit ui:ping failed: {e}"));
         state.ui_acks.forget(&id);
         return WebviewHealth {
@@ -500,7 +518,10 @@ async fn render(
     surface_main_window(&state.app, &id);
 
     // Emit the dialog to the frontend.
-    if let Err(e) = state.app.emit("dialog:show", &dr) {
+    if let Err(e) = state
+        .app
+        .emit_to(crate::DIALOG_WINDOW_LABEL, "dialog:show", &dr)
+    {
         trace(&format!("render: emit FAILED: {e}"));
     } else {
         trace(&format!("render: emitted dialog:show id={}", id));
@@ -535,14 +556,19 @@ async fn render(
             // to a small generic ack via the AckRegistry for the second
             // round. That keeps DialogState simple.
             let (probe_id, probe_rx) = state.ui_acks.register();
-            if let Err(e) = state.app.emit("ui:ping", &probe_id) {
+            if let Err(e) = state
+                .app
+                .emit_to(crate::DIALOG_WINDOW_LABEL, "ui:ping", &probe_id)
+            {
                 trace(&format!("render: post-reload ui:ping emit failed: {e}"));
                 state.ui_acks.forget(&probe_id);
             }
             match tokio::time::timeout(DIALOG_ACK_TIMEOUT, probe_rx).await {
                 Ok(Ok(())) => {
                     trace("render: post-reload webview is responsive, re-emitting dialog:show");
-                    if let Err(e) = state.app.emit("dialog:show", &dr) {
+                    if let Err(e) =
+                        state.app.emit_to(crate::DIALOG_WINDOW_LABEL, "dialog:show", &dr)
+                    {
                         trace(&format!("render: re-emit FAILED: {e}"));
                     }
                 }
@@ -618,22 +644,22 @@ async fn render(
     .into_response()
 }
 
-/// Bring the main webview window to the front from any thread. All Tauri
-/// window operations have to run on the main thread, so we hop there via
-/// `run_on_main_thread`.
+/// Surface the dialog window for the incoming render. If the window
+/// already exists, show + focus + unminimize; otherwise build it.
+/// All Tauri window operations have to run on the main thread, so we
+/// hop there via `run_on_main_thread`.
 fn surface_main_window(app: &AppHandle, id: &str) {
     let app_for_show = app.clone();
     let id_for_log = id.to_string();
     let rc = app.clone().run_on_main_thread(move || {
         trace(&format!("render: main-thread callback id={}", id_for_log));
-        if let Some(win) = app_for_show.get_webview_window("main") {
-            trace("render: main-thread got window, calling show()");
-            let _ = win.show();
-            let _ = win.set_focus();
-            let _ = win.unminimize();
-            trace("render: main-thread show() returned");
-        } else {
-            trace("render: main-thread window MISSING");
+        match crate::ensure_dialog_window(&app_for_show) {
+            Ok(_win) => {
+                trace("render: main-thread dialog window ready (show/build)");
+            }
+            Err(e) => {
+                trace(&format!("render: main-thread dialog window FAILED: {e}"));
+            }
         }
     });
     trace(&format!("render: run_on_main_thread returned {:?}", rc.is_ok()));
@@ -648,8 +674,8 @@ fn surface_main_window(app: &AppHandle, id: &str) {
 fn reload_main_webview(app: &AppHandle) {
     let app_for_reload = app.clone();
     let _ = app.clone().run_on_main_thread(move || {
-        if let Some(win) = app_for_reload.get_webview_window("main") {
-            trace("render: reloading main webview");
+        if let Some(win) = app_for_reload.get_webview_window(crate::DIALOG_WINDOW_LABEL) {
+            trace("render: reloading dialog webview");
             if let Err(e) = win.eval("location.reload()") {
                 trace(&format!("render: reload eval failed: {e}"));
             }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -13,7 +13,17 @@ mod skill;
 mod tunnel;
 
 use std::sync::Arc;
-use tauri::Manager;
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// Tauri window labels. Setup and dialog live in *separate* windows so:
+///  • the agent's dialog never visually overlaps the user's settings,
+///  • neither window can hide behind the other in macOS' z-stack,
+///  • each gets its own movable title bar without weird re-layout
+///    artefacts when the content kind changes.
+/// See the v0.4.25 multi-window refactor in lib.rs for the lifecycle
+/// rules that govern when each is created and torn down.
+pub const SETUP_WINDOW_LABEL: &str = "setup";
+pub const DIALOG_WINDOW_LABEL: &str = "dialog";
 
 #[tauri::command]
 fn dialog_submit(
@@ -59,7 +69,18 @@ fn ui_pong(
 
 #[tauri::command]
 async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
-    let _ = window.hide();
+    // The frontend calls this after a dialog submit/cancel. We *destroy*
+    // the dialog window (not hide) so the next render starts from a clean
+    // slate — no stale Svelte state, no z-order quirks, no visible frame
+    // sitting empty. The setup window calls this too if the user clicks
+    // its custom close button (none today, but the contract should be
+    // symmetric).
+    let label = window.label().to_string();
+    let _ = window.close();
+    // If that was the last visible window and nothing else is pending,
+    // the OS-level CloseRequested handler will fire next and decide
+    // whether the app should quit.
+    log::debug!("[aiui] close_window: closed {label}");
     Ok(())
 }
 
@@ -73,7 +94,14 @@ async fn surface_for_dialog(app: tauri::AppHandle) -> Result<(), String> {
     {
         let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
     }
-    if let Some(win) = app.get_webview_window("main") {
+    // The update dialog is surfaced from whichever window is alive when
+    // the check fires — usually the setup window (frontend triggers it
+    // from there). We just need *some* visible window to attach the OS
+    // dialog to.
+    let win = app
+        .get_webview_window(SETUP_WINDOW_LABEL)
+        .or_else(|| app.get_webview_window(DIALOG_WINDOW_LABEL));
+    if let Some(win) = win {
         let _ = win.show();
         let _ = win.set_focus();
     }
@@ -471,10 +499,87 @@ fn show_settings_window(app: &tauri::AppHandle) {
     {
         let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
     }
-    if let Some(win) = app.get_webview_window("main") {
+    if let Some(win) = app.get_webview_window(SETUP_WINDOW_LABEL) {
         let _ = win.show();
         let _ = win.set_focus();
+        let _ = win.unminimize();
+        return;
     }
+    if let Err(e) = build_setup_window(app) {
+        log::error!("[aiui] failed to build setup window: {e}");
+    }
+}
+
+/// Build the setup (settings) window. Same dimensions as the legacy
+/// single-window setup: 520×480, fixed width, height capped at 640.
+/// `dragDropEnabled: false` because Sortable.js uses HTML5 DnD and
+/// Tauri's window-level file-drop interception steals those events.
+pub(crate) fn build_setup_window(
+    app: &tauri::AppHandle,
+) -> tauri::Result<tauri::WebviewWindow> {
+    WebviewWindowBuilder::new(
+        app,
+        SETUP_WINDOW_LABEL,
+        WebviewUrl::App("index.html".into()),
+    )
+    .title("aiui")
+    .inner_size(520.0, 480.0)
+    .min_inner_size(520.0, 380.0)
+    .max_inner_size(520.0, 640.0)
+    .resizable(false)
+    .center()
+    .decorations(true)
+    .title_bar_style(tauri::TitleBarStyle::Overlay)
+    .hidden_title(true)
+    .disable_drag_drop_handler()
+    .visible(true)
+    .build()
+}
+
+/// Build (or surface) the dialog window. Called from the render path
+/// when a `confirm` / `ask` / `form` arrives. Same look as the setup
+/// window so the user gets a consistent aiui chrome regardless of
+/// which view they're seeing — the *content* is what differs.
+///
+/// Reused across renders: if a dialog window already exists, we just
+/// surface it. The frontend handles the actual content swap when the
+/// `dialog:show` event arrives.
+pub(crate) fn ensure_dialog_window(
+    app: &tauri::AppHandle,
+) -> tauri::Result<tauri::WebviewWindow> {
+    if let Some(win) = app.get_webview_window(DIALOG_WINDOW_LABEL) {
+        let _ = win.show();
+        let _ = win.set_focus();
+        let _ = win.unminimize();
+        return Ok(win);
+    }
+    WebviewWindowBuilder::new(
+        app,
+        DIALOG_WINDOW_LABEL,
+        WebviewUrl::App("index.html".into()),
+    )
+    .title("aiui")
+    .inner_size(520.0, 480.0)
+    .min_inner_size(520.0, 380.0)
+    .max_inner_size(520.0, 640.0)
+    .resizable(false)
+    .center()
+    .decorations(true)
+    .title_bar_style(tauri::TitleBarStyle::Overlay)
+    .hidden_title(true)
+    .disable_drag_drop_handler()
+    .visible(true)
+    .build()
+}
+
+/// True when no aiui window is currently visible to the user. Used by
+/// the close-event handler to decide whether to keep the app alive
+/// (something else is open, e.g. a still-pending dialog) or to quit.
+#[allow(dead_code)]
+fn no_visible_windows(app: &tauri::AppHandle) -> bool {
+    app.webview_windows()
+        .values()
+        .all(|w| !w.is_visible().unwrap_or(false))
 }
 
 fn is_auto_launch() -> bool {
@@ -632,13 +737,22 @@ pub fn run() {
             // so skill updates ride with app updates.
             let _ = skill::install_locally();
 
-            // HTTP server on localhost:7777. If bind fails (port held by
-            // a stale aiui or unrelated process) we record the error in
-            // the shared `http_error` cell so the Settings UI can surface
-            // a banner — silently logging it left users staring at a
-            // window that *looked* alive but answered no requests.
+            // HTTP server on localhost:7777. If bind fails the most
+            // likely cause is a stale aiui already holding the port —
+            // exactly the multi-instance race that produced the
+            // 2026-04-29 hung-dialog incident. Rather than letting
+            // this instance run as a half-zombie (no server, but a
+            // window that *looks* alive), we exit hard. The other
+            // instance keeps serving; tauri-plugin-single-instance
+            // will surface its setup window if the user retried.
+            //
+            // The `http_error` cell stays for the rare case where the
+            // failure is something other than EADDRINUSE — we still
+            // want a banner to fire before exit, and the Settings UI
+            // reads this on its first tick.
             let http_error_for_serve = http_error.clone();
             let port_for_error = cfg.http_port;
+            let app_handle_for_exit = app_handle_http.clone();
             rt.spawn(async move {
                 if let Err(e) = http::serve(
                     cfg_http,
@@ -649,12 +763,19 @@ pub fn run() {
                 )
                 .await
                 {
-                    log::error!("[aiui] http server error: {e}");
+                    log::error!(
+                        "[aiui] http server error on :{port_for_error}: {e} — exiting (other instance owns the port)"
+                    );
                     if let Ok(mut slot) = http_error_for_serve.lock() {
                         *slot = Some(format!(
                             "Konnte localhost:{port_for_error} nicht öffnen — Port wahrscheinlich belegt. {e}"
                         ));
                     }
+                    // Hop to main thread to call exit cleanly.
+                    let app_for_exit = app_handle_for_exit.clone();
+                    let _ = app_handle_for_exit.run_on_main_thread(move || {
+                        app_for_exit.exit(1);
+                    });
                 }
             });
 
@@ -703,12 +824,52 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| {
-            // Red X quits the app outright — the MCP-stdio child's
-            // lifetime-socket loop will resurrect aiui on the next agent
-            // call, so there is no reason to keep a headless process
-            // running once the user asks for it to go away.
+            // Multi-window lifecycle (v0.4.25):
+            //
+            // The setup window and the dialog window are independent.
+            // Closing one shouldn't kill the other — and definitely
+            // shouldn't kill an in-flight dialog the agent is still
+            // waiting on.
+            //
+            //  • Red X on setup window: setup goes away. If a dialog is
+            //    visible *or* something is pending, the app stays alive.
+            //    Otherwise the app quits, and `mcp_attach`'s
+            //    auto-resurrect path brings it back on the next tool
+            //    call. Same UX promise as before, just without the
+            //    cross-window damage.
+            //  • Red X on dialog window: the dialog is treated as
+            //    cancelled (the frontend's CloseRequested-listener fires
+            //    `dialog_cancel` first; this branch runs after).
+            //    Otherwise identical to setup-window close.
             if let tauri::WindowEvent::CloseRequested { .. } = event {
-                window.app_handle().exit(0);
+                let app = window.app_handle();
+                let closed_label = window.label().to_string();
+                // Tauri lets the close proceed unless we set
+                // api.prevent_close(); we want the close to happen.
+                // Schedule the quit-check on the next tick so it runs
+                // *after* this window is actually destroyed.
+                let app_for_check = app.clone();
+                let _ = app.run_on_main_thread(move || {
+                    // Filter out the just-closed window — at this point
+                    // it may still appear in the registry briefly.
+                    let any_visible = app_for_check
+                        .webview_windows()
+                        .iter()
+                        .any(|(label, w)| {
+                            label.as_str() != closed_label
+                                && w.is_visible().unwrap_or(false)
+                        });
+                    if !any_visible {
+                        log::info!(
+                            "[aiui] last visible window ({closed_label}) closed — quitting; auto-resurrect will bring us back on next tool call"
+                        );
+                        app_for_check.exit(0);
+                    } else {
+                        log::debug!(
+                            "[aiui] {closed_label} closed, but other windows still visible — staying alive"
+                        );
+                    }
+                });
             }
         })
         .build(tauri::generate_context!())

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",
@@ -10,26 +10,7 @@
     "beforeBuildCommand": "npm run build"
   },
   "app": {
-    "windows": [
-      {
-        "label": "main",
-        "title": "aiui",
-        "width": 520,
-        "height": 480,
-        "minWidth": 520,
-        "minHeight": 380,
-        "maxWidth": 520,
-        "maxHeight": 640,
-        "resizable": false,
-        "fullscreen": false,
-        "visible": false,
-        "decorations": true,
-        "center": true,
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true,
-        "dragDropEnabled": false
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost"
     },

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
   import { listen } from "@tauri-apps/api/event";
-  import { invoke } from "@tauri-apps/api/core";
-  import { _ } from "svelte-i18n";
+  import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
   import { onMount } from "svelte";
-  import Ask from "./lib/widgets/Ask.svelte";
-  import Form from "./lib/widgets/Form.svelte";
-  import Confirm from "./lib/widgets/Confirm.svelte";
   import Settings from "./lib/Settings.svelte";
+  import DialogShell from "./lib/DialogShell.svelte";
   import { checkForUpdates } from "./lib/updater";
 
-  type DialogReq = { id: string; spec: any };
-
-  let current = $state<DialogReq | null>(null);
+  // Tauri 2 multi-window: the same Vite bundle is loaded into both the
+  // setup and the dialog windows. We branch the *contents* on the
+  // window label, so each window sees exactly the listeners and DOM it
+  // needs — no cross-window state, no `dialog:show` leaking into
+  // settings, no settings UI flashing during a dialog.
+  let label = $state<string | null>(null);
 
   // Update checks are lifecycle-driven, not interval-driven. Triggers:
   //  • on mount (initial check at GUI start),
   //  • on `update:check` event from Rust (fired after each successful
   //    render — clusters around real user activity),
-  //  • on window focus (covers wake-from-sleep and "user came back to the
-  //    Mac" without needing an OS-level event hook).
+  //  • on window focus (covers wake-from-sleep and "user came back to
+  //    the Mac" without needing an OS-level event hook).
   // A 30-minute cooldown debounces bursts so a chatty session doesn't
   // hammer the GitHub release endpoint.
   const UPDATE_COOLDOWN_MS = 30 * 60 * 1000;
@@ -37,90 +37,34 @@
   }
 
   onMount(() => {
-    // Dialog event from Rust. We acknowledge receipt back to the Rust side
-    // immediately so the `/render` handler knows the WebView event loop is
-    // alive — this is the per-request liveness check that replaces the
-    // need for any background UI heartbeat.
-    const unDialog = listen<DialogReq>("dialog:show", (e) => {
-      current = e.payload;
-      void invoke("dialog_received", { id: e.payload.id });
-    });
+    label = getCurrentWebviewWindow().label;
 
-    // UI ping from Rust (used by /health to verify the event loop). We
-    // pong back synchronously — the Rust side has a 100 ms timeout and a
-    // missed pong is what flips /health to `degraded`.
-    const unPing = listen<string>("ui:ping", (e) => {
-      void invoke("ui_pong", { id: e.payload });
-    });
-
-    // Update-check trigger from Rust — fired after each successful render.
-    // Frontend gates with the cooldown so we don't actually hit GitHub on
-    // every render.
+    // Update-check trigger from Rust — fired after each successful
+    // render. Frontend gates with the cooldown so we don't actually hit
+    // GitHub on every render. Both windows can hear this; first one
+    // through the cooldown wins.
     const unUpdate = listen<string>("update:check", (e) => {
       maybeCheckForUpdates(`rust:${e.payload}`);
     });
 
-    window.addEventListener("keydown", onKey);
     window.addEventListener("focus", onFocus);
 
     // Initial check on mount.
     maybeCheckForUpdates("startup");
 
     return async () => {
-      (await unDialog)();
-      (await unPing)();
       (await unUpdate)();
-      window.removeEventListener("keydown", onKey);
       window.removeEventListener("focus", onFocus);
     };
   });
-
-  function onKey(e: KeyboardEvent) {
-    if (e.key === "Escape") handleCancel();
-  }
-
-  async function handleSubmit(result: any) {
-    if (!current) return;
-    await invoke("dialog_submit", { id: current.id, result });
-    current = null;
-    await invoke("close_window");
-  }
-
-  async function handleCancel() {
-    if (current) {
-      await invoke("dialog_cancel", { id: current.id });
-      current = null;
-      await invoke("close_window");
-    }
-  }
 </script>
 
-<main class="container">
-  {#if current}
-    <!-- {#key current.id} forces a fresh widget instance for every new
-      dialog, even when two consecutive renders are the same kind (e.g.
-      two `confirm`s). Without it, Svelte recycles the component and
-      stale field/checkbox/radio state from the previous dialog can bleed
-      into the current one — silently sending wrong answers back to the
-      caller. Issue #H-1 in v0.4.10 review. -->
-    {#key current.id}
-      {#if current.spec.kind === "ask"}
-        <Ask spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
-      {:else if current.spec.kind === "form"}
-        <Form spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
-      {:else if current.spec.kind === "confirm"}
-        <Confirm spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
-      {:else}
-        <div class="stack">
-          <p class="title">{$_("dialog.unknown_kind", { values: { kind: current.spec.kind } })}</p>
-          <pre>{JSON.stringify(current.spec, null, 2)}</pre>
-          <div class="footer">
-            <button onclick={handleCancel}>{$_("dialog.close")}</button>
-          </div>
-        </div>
-      {/if}
-    {/key}
-  {:else}
-    <Settings />
-  {/if}
-</main>
+{#if label === "setup"}
+  <Settings />
+{:else if label === "dialog"}
+  <DialogShell />
+{:else}
+  <!-- During the first paint label is null — render nothing rather
+       than guess wrong. Tauri sets the label synchronously, so this
+       lasts only one micro-task. -->
+{/if}

--- a/companion/src/lib/DialogShell.svelte
+++ b/companion/src/lib/DialogShell.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import { listen } from "@tauri-apps/api/event";
+  import { invoke } from "@tauri-apps/api/core";
+  import { _ } from "svelte-i18n";
+  import { onMount } from "svelte";
+  import Ask from "./widgets/Ask.svelte";
+  import Form from "./widgets/Form.svelte";
+  import Confirm from "./widgets/Confirm.svelte";
+
+  type DialogReq = { id: string; spec: any };
+
+  let current = $state<DialogReq | null>(null);
+
+  onMount(() => {
+    // Dialog event from Rust. We acknowledge receipt back to the Rust
+    // side immediately so the `/render` handler knows the WebView event
+    // loop is alive — this is the per-request liveness check that
+    // replaces the need for any background UI heartbeat. Backend emits
+    // this event with `emit_to("dialog", ...)`, so the setup window
+    // never sees it.
+    const unDialog = listen<DialogReq>("dialog:show", (e) => {
+      current = e.payload;
+      void invoke("dialog_received", { id: e.payload.id });
+    });
+
+    // UI ping from Rust (used by /health to verify the event loop). We
+    // pong back synchronously — the Rust side has a 100 ms timeout and
+    // a missed pong is what flips /health to `degraded`.
+    const unPing = listen<string>("ui:ping", (e) => {
+      void invoke("ui_pong", { id: e.payload });
+    });
+
+    window.addEventListener("keydown", onKey);
+
+    return async () => {
+      (await unDialog)();
+      (await unPing)();
+      window.removeEventListener("keydown", onKey);
+    };
+  });
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Escape") handleCancel();
+  }
+
+  async function handleSubmit(result: any) {
+    if (!current) return;
+    const id = current.id;
+    current = null;
+    await invoke("dialog_submit", { id, result });
+    await invoke("close_window");
+  }
+
+  async function handleCancel() {
+    if (current) {
+      const id = current.id;
+      current = null;
+      await invoke("dialog_cancel", { id });
+      await invoke("close_window");
+    } else {
+      // No dialog yet — the user closed an empty dialog window. Just
+      // close it.
+      await invoke("close_window");
+    }
+  }
+</script>
+
+<!-- Drag region: invisible 28px strip at the very top, lets the user
+     pick the window up by anywhere not covered by an interactive
+     control. Tauri reads `data-tauri-drag-region` on every event. -->
+<div class="drag-region" data-tauri-drag-region></div>
+
+<main class="container">
+  {#if current}
+    <!-- {#key current.id} forces a fresh widget instance for every new
+      dialog, even when two consecutive renders are the same kind (e.g.
+      two `confirm`s). Without it, Svelte recycles the component and
+      stale field/checkbox/radio state from the previous dialog can bleed
+      into the current one — silently sending wrong answers back to the
+      caller. Issue #H-1 in v0.4.10 review. -->
+    {#key current.id}
+      {#if current.spec.kind === "ask"}
+        <Ask spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
+      {:else if current.spec.kind === "form"}
+        <Form spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
+      {:else if current.spec.kind === "confirm"}
+        <Confirm spec={current.spec} onsubmit={handleSubmit} oncancel={handleCancel} />
+      {:else}
+        <div class="stack">
+          <p class="title">{$_("dialog.unknown_kind", { values: { kind: current.spec.kind } })}</p>
+          <pre>{JSON.stringify(current.spec, null, 2)}</pre>
+          <div class="footer">
+            <button onclick={handleCancel}>{$_("dialog.close")}</button>
+          </div>
+        </div>
+      {/if}
+    {/key}
+  {:else}
+    <!-- Brief idle state — only visible during the few hundred ms
+         between window-show and the dialog:show event arriving. -->
+    <div class="idle"></div>
+  {/if}
+</main>
+
+<style>
+  .drag-region {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 28px;
+    z-index: 1;
+    /* Stay invisible — the macOS overlay title bar is already there;
+       this just guarantees the *interior* top stripe is grabbable too. */
+  }
+  .idle {
+    min-height: 80px;
+  }
+</style>

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -202,6 +202,12 @@
 </script>
 
 {#if status}
+  <!-- Drag region: invisible 28px strip at the very top so the user
+       can grab the window from anywhere along its top edge, not just
+       the platform-rendered title bar. Doesn't capture clicks on the
+       app-header below because the header sits *under* it in z-order
+       once a real interactive element is in place. -->
+  <div class="drag-region" data-tauri-drag-region></div>
   <div class="stack">
     <header class="app-header">
       <img src={iconUrl} alt="aiui" class="app-icon" />
@@ -817,6 +823,16 @@
     cursor: pointer;
   }
   .welcome-cta:hover { color: var(--fg); text-decoration: underline; }
+
+  /* --- drag region --- */
+  .drag-region {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 28px;
+    z-index: 1;
+  }
 
   /* --- modal (uninstall-done) --- */
   .modal-backdrop {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.24"
+version = "0.4.25"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

Single-window-with-two-views produced the 2026-04-29 hung-dialog bug: a stale dialog window registered hours earlier was hidden behind the user's open settings, blocking every subsequent render. Invisible to the user, structurally non-recoverable. Fix has to split them into actual separate windows.

Plus early-tester feedback that windows feel \"festgetackert\" — they couldn't be moved aside when an agent dropped a dialog over their work.

## What changes

| Layer | Change |
|---|---|
| Tauri config | static \`main\` window removed; both windows are built at runtime |
| \`lib.rs\` | \`build_setup_window()\` and \`ensure_dialog_window()\` helpers; close-event handler differentiates by label, only quits app when last visible window goes away |
| \`http.rs\` | render path builds/reuses dialog window via \`ensure_dialog_window\`; \`dialog:show\` and \`ui:ping\` use \`emit_to(DIALOG_WINDOW_LABEL, …)\` |
| \`App.svelte\` | branches on \`getCurrentWebviewWindow().label\`, renders \`<Settings />\` or \`<DialogShell />\` |
| New \`DialogShell.svelte\` | dialog-specific listeners + render |
| \`Settings.svelte\` + \`DialogShell.svelte\` | invisible 28 px \`data-tauri-drag-region\` strip on top |

## Multi-instance hardening (A from yesterday's plan)

HTTP-bind failure now \`exit(1)\` instead of leaving a zombie with no server. That zombie was the second half of the 2026-04-29 incident — fresh instance kept its settings window alive on top of an older instance's dialog. Tauri-plugin-single-instance handles the surface-existing path; we just need to *not* keep running half-dead.

## Test plan

- [x] \`cargo check\` + \`cargo test --lib\` — 49 passed
- [x] \`svelte-check\` — 0 errors
- [ ] CI green
- [ ] After merge: \`scripts/release.sh 0.4.25\`
- [ ] Smoke on Mac:
  - Open settings via Dock → setup window appears, draggable from top edge
  - Trigger \`/aiui:test-dialog\` → second window appears alongside, both movable independently
  - Close setup with X while dialog is open → only setup closes; dialog still works
  - Close dialog with X → dialog cancelled, app stays running
  - Close all windows → app quits; \`/aiui:test-dialog\` again → auto-resurrect, dialog window pops up

(B) – signaling existing instance over lifetime-socket before exit – not needed; the single-instance plugin already covers that path. Will reconsider only if A alone doesn't fully resolve the race.