### PR TITLE
fix: restore Apple-HIG title-bar padding (v0.4.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.26] — 2026-04-29
+
+### Fixed
+
+- **Window content no longer overlaps the macOS traffic-light buttons.**
+  The 0.4.25 multi-window refactor accidentally dropped the
+  `<main class="container">` wrapper from `App.svelte` — that's the
+  element that supplies the 44 px Apple-HIG top padding so content
+  starts below the title-bar buttons. Settings.svelte rendered
+  straight into the body, so the aiui logo collided with the traffic
+  lights. Wrapper and the drag region now live in `App.svelte`,
+  shared by both windows; Settings.svelte and DialogShell.svelte
+  render directly into it.
+
 ## [0.4.25] — 2026-04-29
 
 ### Changed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.25"
+version = "0.4.26"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -59,12 +59,36 @@
   });
 </script>
 
-{#if label === "setup"}
-  <Settings />
-{:else if label === "dialog"}
-  <DialogShell />
-{:else}
+<!-- The drag-region sits at the very top, OVER the macOS overlay
+     title bar. Tauri lets the traffic-light buttons capture clicks
+     even when our region overlaps them, so the user can grab the
+     window from anywhere along the top edge except directly on the
+     buttons. Position fixed so it doesn't push container content
+     down. -->
+<div class="drag-region" data-tauri-drag-region></div>
+
+<!-- Container provides the Apple-HIG-compliant 44 px top breathing
+     room so content never collides with the traffic-light buttons,
+     plus side padding and scroll behaviour. Both setup and dialog
+     windows share this chrome. -->
+<main class="container">
+  {#if label === "setup"}
+    <Settings />
+  {:else if label === "dialog"}
+    <DialogShell />
+  {/if}
   <!-- During the first paint label is null — render nothing rather
        than guess wrong. Tauri sets the label synchronously, so this
        lasts only one micro-task. -->
-{/if}
+</main>
+
+<style>
+  .drag-region {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 28px;
+    z-index: 1;
+  }
+</style>

--- a/companion/src/lib/DialogShell.svelte
+++ b/companion/src/lib/DialogShell.svelte
@@ -65,13 +65,9 @@
   }
 </script>
 
-<!-- Drag region: invisible 28px strip at the very top, lets the user
-     pick the window up by anywhere not covered by an interactive
-     control. Tauri reads `data-tauri-drag-region` on every event. -->
-<div class="drag-region" data-tauri-drag-region></div>
-
-<main class="container">
-  {#if current}
+<!-- App.svelte provides the outer container with Apple-HIG title-bar
+     padding and the drag region. We render straight into it. -->
+{#if current}
     <!-- {#key current.id} forces a fresh widget instance for every new
       dialog, even when two consecutive renders are the same kind (e.g.
       two `confirm`s). Without it, Svelte recycles the component and
@@ -95,24 +91,13 @@
         </div>
       {/if}
     {/key}
-  {:else}
-    <!-- Brief idle state — only visible during the few hundred ms
-         between window-show and the dialog:show event arriving. -->
-    <div class="idle"></div>
-  {/if}
-</main>
+{:else}
+  <!-- Brief idle state — only visible during the few hundred ms
+       between window-show and the dialog:show event arriving. -->
+  <div class="idle"></div>
+{/if}
 
 <style>
-  .drag-region {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 28px;
-    z-index: 1;
-    /* Stay invisible — the macOS overlay title bar is already there;
-       this just guarantees the *interior* top stripe is grabbable too. */
-  }
   .idle {
     min-height: 80px;
   }

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -202,12 +202,6 @@
 </script>
 
 {#if status}
-  <!-- Drag region: invisible 28px strip at the very top so the user
-       can grab the window from anywhere along its top edge, not just
-       the platform-rendered title bar. Doesn't capture clicks on the
-       app-header below because the header sits *under* it in z-order
-       once a real interactive element is in place. -->
-  <div class="drag-region" data-tauri-drag-region></div>
   <div class="stack">
     <header class="app-header">
       <img src={iconUrl} alt="aiui" class="app-icon" />
@@ -823,16 +817,6 @@
     cursor: pointer;
   }
   .welcome-cta:hover { color: var(--fg); text-decoration: underline; }
-
-  /* --- drag region --- */
-  .drag-region {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 28px;
-    z-index: 1;
-  }
 
   /* --- modal (uninstall-done) --- */
   .modal-backdrop {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.25"
+version = "0.4.26"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
0.4.25 dropped the container wrapper that supplied the 44 px top padding for the macOS title-bar area. Settings logo collided with the traffic-light buttons. Wrapper restored in App.svelte, shared by both windows.