### PR TITLE
feat: setup-header polish — 64 px logo, skill status inline (v0.4.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.27] — 2026-04-30
+
+### Changed
+
+- **Setup-Window-Header polish.** The aiui logo doubles in size (32 →
+  64 px) to actually carry the brand mark instead of being a thumb-
+  nail next to text. The Skill-installed indicator moves out of its
+  own full-width row up into the header status stack, sharing the
+  dot+label visual with the Claude-Desktop connection line. Repair
+  button only appears when the skill is missing — that's the only
+  state the user can act on. Less vertical real estate, more density
+  for the remotes list below.
+
 ## [0.4.26] — 2026-04-29
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.26"
+version = "0.4.27"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -214,6 +214,24 @@
             {$_("app.status.not_connected")}
           {/if}
         </div>
+        <!-- Skill status sits next to the connection status: both are
+          "is aiui plumbed in correctly?" signals, both are dot+text, and
+          neither needs a full-width row. Repair button only surfaces
+          when the skill is actually missing — which is the only time
+          the user can act on it. -->
+        <div class="header-status-line">
+          <span class="status-dot" class:ok={status.skill_installed}></span>
+          <span>
+            {status.skill_installed
+              ? $_("settings.skill.status.ok")
+              : $_("settings.skill.status.miss")}
+          </span>
+          {#if !status.skill_installed}
+            <button class="header-action" onclick={repairSkill} disabled={busy}>
+              {$_("settings.skill.repair")}
+            </button>
+          {/if}
+        </div>
         <!-- Reassures the user that closing this window doesn't kill aiui:
           mcp_attach's auto-resurrect path relaunches the GUI on next demand.
           Single dim line, Apple-style, no command-flow vocabulary. -->
@@ -341,19 +359,11 @@
       </section>
     {/if}
 
-    <!-- Skill status row. Replaces the old "Skill installieren" button which
-      suggested optionality — the skill is mandatory and auto-installed on
-      every GUI launch, so the only meaningful UI is "is it there?" plus a
-      repair button when it isn't. -->
-    <section class="status-row" class:err={!status.skill_installed}>
-      <span class="dot {status.skill_installed ? 'ok' : 'err'}"></span>
-      <span class="status-text">
-        {status.skill_installed ? $_("settings.skill.status.ok") : $_("settings.skill.status.miss")}
-      </span>
-      {#if !status.skill_installed}
-        <button onclick={repairSkill} disabled={busy}>{$_("settings.skill.repair")}</button>
-      {/if}
-    </section>
+    <!-- Skill status moved into the header (`.header-status-line`)
+      alongside the connection dot. Both are "is aiui correctly
+      plumbed?" signals; presenting them side-by-side instead of in a
+      full-width row keeps the chrome compact and saves a row of
+      vertical scroll for the remotes list. -->
 
     <section>
       <span class="section-label">{$_("settings.remotes.title")}</span>
@@ -486,11 +496,22 @@
     border-bottom: 1px solid var(--border);
   }
   .app-header img.app-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 7px;
+    /* 64×64 — at least 2× the original 32 px so the brand mark
+       actually carries weight in the chrome. The header-meta column
+       grows in line height to match, status lines breathe. */
+    width: 64px;
+    height: 64px;
+    border-radius: 14px;
     box-shadow: var(--shadow-sm);
     flex-shrink: 0;
+  }
+  .header-action {
+    /* Inline action that only surfaces when a status line needs
+       fixing (today: skill repair). Smaller than a full button so it
+       fits in the header-status-line without reflowing the column. */
+    margin-left: 6px;
+    padding: 2px 8px;
+    font-size: 11px;
   }
   .header-meta {
     flex: 1;
@@ -540,19 +561,8 @@
     letter-spacing: 0.04em;
   }
 
-  .status-row {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 6px 10px;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    background: var(--surface-raised);
-    box-shadow: var(--shadow-sm);
-    font-size: 12.5px;
-  }
-  .status-row.err { border-color: var(--danger); }
-  .status-row .status-text { flex: 1; }
+  /* `.status-row` styles removed — the skill status moved into the
+     header-status-line stack. Kept the comment for future-history. */
 
   .remote-row {
     display: flex;

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.26"
+version = "0.4.27"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

Tester feedback after 0.4.26: the setup window's brand mark is barely visible (32 px next to text), and the \`Skill installiert\` row eats a full window width despite carrying the same kind of \"is aiui plumbed in?\" signal as the connection line right above it.

## What

| Change | Detail |
|---|---|
| Logo size | 32 px → 64 px (≥ 2× as requested) |
| Skill status | moved from its own full-width row into the header's status stack, dot+text alongside the connection line |
| Repair button | inline next to the skill text, only when skill is missing |
| Removed | `.status-row` CSS in Settings.svelte (no other consumers) |

## Test plan

- [x] \`svelte-check\` — 0 errors
- [x] \`cargo check\` — green
- [ ] CI green
- [ ] User reviews layout in screenshot before release
- [ ] Release with \`scripts/release.sh 0.4.27\` after sign-off

No release pulled — version bumped to 0.4.27 across Cargo.toml, tauri.conf.json, pyproject.toml so the merged main is release-ready when you give the green light.