### PR TITLE
fix: mcp-stdio detects in-memory-vs-on-disk binary mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ All notable changes to this project are documented here.
   state the user can act on. Less vertical real estate, more density
   for the remotes list below.
 
+### Fixed
+
+- **Stale `mcp-stdio` subprocess detects itself across in-place `.app`
+  replacement.** macOS keeps the previous binary's code-pages alive in
+  any already-running process even after the on-disk file is replaced
+  by the in-app updater or a manual DMG drop. Claude Desktop holds its
+  spawned `aiui --mcp-stdio` child alive across the update, so it ends
+  up answering tool calls with stale logic. Symptom on 2026-04-30: a
+  Form tool call crashed the in-memory binary 2 ms after receipt with
+  no stderr output, while a fresh aiui v0.4.26 sat unused on disk.
+  The GUI-side sweep couldn't catch this because the executable path
+  matched. New behaviour: `run_mcp_stdio_only` reads
+  `CFBundleShortVersionString` from the on-disk `Info.plist` two
+  directories up from `argv[0]` and compares it with our compile-time
+  `CARGO_PKG_VERSION`. Mismatch → `exit(0)`. Claude Desktop sees the
+  broken pipe and respawns against the freshly installed binary.
+  Self-healing — no user-facing dialog, no doc note, no manual
+  Claude-Desktop restart needed after future updates.
+
 ## [0.4.26] — 2026-04-29
 
 ### Fixed

--- a/companion/src-tauri/src/housekeeping.rs
+++ b/companion/src-tauri/src/housekeeping.rs
@@ -7,10 +7,26 @@
 //! v0.2.5) or otherwise incompatible, so the user ends up with a stale MCP
 //! server that refuses to reconnect to the new GUI.
 //!
-//! On every GUI startup we therefore scan for `aiui --mcp-stdio` processes
-//! whose executable path differs from ours and SIGTERM them. Claude Desktop
-//! will respawn them against the freshly patched config — pointing at the
-//! new binary.
+//! Two complementary mechanisms exist:
+//!
+//!  1. **GUI-side sweep** (`kill_stale_mcp_stdio_children`): on every GUI
+//!     startup we scan for `aiui --mcp-stdio` processes whose executable
+//!     path differs from ours and SIGTERM them. This only catches the case
+//!     where the *path* changed — useless when the user dragged a new
+//!     `aiui.app` over the old one in place.
+//!
+//!  2. **Subprocess-side self-check** (`disk_version_if_stale`): every
+//!     `--mcp-stdio` invocation reads `CFBundleShortVersionString` from
+//!     the on-disk `Info.plist` two directories up from `argv[0]` and
+//!     compares it with `CARGO_PKG_VERSION` baked in at compile time. If
+//!     they disagree, the in-memory binary is stale — the bundle on disk
+//!     was replaced after this process loaded — and we exit so Claude
+//!     Desktop respawns us against the fresh binary.
+//!
+//! Together those two layers catch the in-place-replace scenario that
+//! produced the 2026-04-30 form-tool-call crash: a Claude-Desktop-spawned
+//! mcp-stdio child kept the previous version in memory across an
+//! updater-driven replacement of `/Applications/aiui.app`.
 //!
 //! macOS-specific: we use `ps -axo pid=,command=` to enumerate processes
 //! (there is no /proc on macOS). The executable path is the first whitespace-
@@ -23,6 +39,7 @@
 //! a no-op.
 
 use crate::logging::trace;
+use std::path::PathBuf;
 use std::process::Command;
 
 /// A stale `aiui --mcp-stdio` process that should be terminated.
@@ -112,6 +129,52 @@ pub fn kill_stale_mcp_stdio_children(current_exe_path: &str) -> usize {
         ));
     }
     stale.len()
+}
+
+/// Pure decision: given our compile-time version string and the version
+/// string read from the on-disk `Info.plist`, return `true` when this
+/// in-memory binary is stale (i.e. should exit so it can be respawned).
+///
+/// Empty / whitespace `disk` is treated as "unknown" → not stale: better
+/// to keep running than abort a working subprocess on a transient
+/// `plutil` glitch.
+pub(crate) fn is_disk_version_stale(own: &str, disk: &str) -> bool {
+    let disk = disk.trim();
+    !disk.is_empty() && disk != own
+}
+
+/// True iff the bundle on disk (one bundle level up from `argv[0]`)
+/// reports a `CFBundleShortVersionString` that differs from our own
+/// compile-time `CARGO_PKG_VERSION`. Returns the on-disk version when
+/// stale so the caller can log it; `None` when fresh, when running
+/// outside an `.app` bundle (dev build, `cargo run`), or when the
+/// lookup itself fails (no `Info.plist`, `plutil` missing, …).
+///
+/// Self-detection at the subprocess side is what closes the gap that
+/// the path-based GUI sweep can't see: an in-place `.app` replacement
+/// leaves the running child with stale code at the unchanged path.
+pub fn disk_version_if_stale() -> Option<String> {
+    let own = env!("CARGO_PKG_VERSION");
+    let exe = std::env::current_exe().ok()?;
+    // .../aiui.app/Contents/MacOS/aiui  →  .../aiui.app/Contents/Info.plist
+    let plist: PathBuf = exe.parent()?.parent()?.join("Info.plist");
+    if !plist.exists() {
+        return None;
+    }
+    let out = Command::new("/usr/bin/plutil")
+        .args(["-extract", "CFBundleShortVersionString", "raw", "-o", "-"])
+        .arg(&plist)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let disk = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if is_disk_version_stale(own, &disk) {
+        Some(disk)
+    } else {
+        None
+    }
 }
 
 /// Find every `aiui --mcp-stdio` process regardless of executable path,
@@ -225,6 +288,31 @@ mod tests {
     fn skips_own_pid_even_if_path_differs() {
         let ps = "12345 /old/path/aiui --mcp-stdio\n";
         assert!(find_stale(ps, CURRENT, 12345).is_empty());
+    }
+
+    #[test]
+    fn disk_version_check_treats_match_as_fresh() {
+        assert!(!is_disk_version_stale("0.4.26", "0.4.26"));
+        // Trailing whitespace from `plutil` output is normal.
+        assert!(!is_disk_version_stale("0.4.26", "0.4.26\n"));
+        assert!(!is_disk_version_stale("0.4.26", "  0.4.26  "));
+    }
+
+    #[test]
+    fn disk_version_check_treats_mismatch_as_stale() {
+        assert!(is_disk_version_stale("0.4.25", "0.4.26"));
+        assert!(is_disk_version_stale("0.4.26", "0.4.27"));
+        assert!(is_disk_version_stale("0.4.26", "1.0.0"));
+    }
+
+    #[test]
+    fn disk_version_check_treats_empty_disk_as_unknown_not_stale() {
+        // If `plutil` returns nothing — bundle missing, dev build,
+        // permissions issue — we'd rather keep running than abort.
+        // The GUI-side sweep is the safety net for that path.
+        assert!(!is_disk_version_stale("0.4.26", ""));
+        assert!(!is_disk_version_stale("0.4.26", "   "));
+        assert!(!is_disk_version_stale("0.4.26", "\n\n"));
     }
 
     #[test]

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -591,6 +591,33 @@ fn is_auto_launch() -> bool {
 /// attaches to the GUI process via the lifetime socket so the GUI knows we're
 /// alive (and can self-terminate when we die).
 pub fn run_mcp_stdio_only() {
+    // Stale-binary self-check (runs before any state is touched). On
+    // macOS, an in-place `.app` replacement (in-app updater, manual DMG
+    // drop) leaves any already-running mcp-stdio child holding the
+    // *previous* binary in memory while the on-disk path now points at
+    // the new one. The GUI-side sweep can't see that: the path matches.
+    // Result: stale logic answering tool calls until Claude Desktop
+    // restarts, manifesting as silent crashes during dispatch.
+    //
+    // We compare our compile-time `CARGO_PKG_VERSION` with the bundle's
+    // on-disk `CFBundleShortVersionString`. Mismatch → exit so Claude
+    // Desktop respawns us against the fresh binary. Investigated
+    // 2026-04-30: Claude-Desktop child kept v0.4.25 logic alive across
+    // a v0.4.26 update, then crashed silently on a Form tool call.
+    if let Some(disk_version) = housekeeping::disk_version_if_stale() {
+        eprintln!(
+            "[aiui] mcp-stdio: in-memory binary v{} != on-disk v{}; \
+             exiting so Claude Desktop respawns the fresh build.",
+            env!("CARGO_PKG_VERSION"),
+            disk_version
+        );
+        // No `logging::trace` here — the trace path itself might have
+        // been moved by the new bundle. eprintln lands in
+        // `~/Library/Logs/Claude/mcp-server-aiui.log` exactly where the
+        // user is most likely to look.
+        std::process::exit(0);
+    }
+
     let cfg = Arc::new(config::AppConfig::load_or_init().expect("config init"));
     logging::trace(&format!(
         "mcp-stdio: entering run loop, token_path={}",


### PR DESCRIPTION
## Why

User report 2026-04-30: a Form tool call crashed the aiui mcp-stdio subprocess **2 ms after receipt** with no stderr output, while a fresh aiui v0.4.26 sat unused on disk. The user had updated the .app via the in-app updater, but Claude Desktop kept the previous binary's mcp-stdio child alive — `ps -eo lstart` confirmed a subprocess that started 15 hours before the GUI ran for the first time.

macOS keeps the previous binary's code-pages alive in any already-running process even after the on-disk file is replaced. The GUI-side sweep in `kill_stale_mcp_stdio_children` couldn't catch this because the executable path matched — only the file behind it had changed.

## What

At the very top of `run_mcp_stdio_only`, before any state is touched:

1. Read `CFBundleShortVersionString` from `Info.plist` (two directories up from `argv[0]`) using `plutil -extract … raw`.
2. Compare with our compile-time `env!(\"CARGO_PKG_VERSION\")`.
3. On mismatch: `eprintln!` a one-liner explaining the situation (lands in `~/Library/Logs/Claude/mcp-server-aiui.log`) and `exit(0)`.

Claude Desktop sees the broken pipe and respawns against the fresh binary. The user notices nothing.

The decision lives in `housekeeping.rs` alongside the existing path-based sweep — same module, same lifecycle role. Pure decision function `is_disk_version_stale(own, disk)` is testable; the I/O wrapper `disk_version_if_stale()` does the `plutil` round-trip.

## Tests

Three new units in `housekeeping::tests`, covering:
- match → fresh
- mismatch → stale
- empty / whitespace disk version → unknown (stay running rather than abort on transient `plutil` glitch)

`cargo test --lib housekeeping` — 11 passed.

## Why no version bump

Separate PR per request; coordinates with the open #105 (setup-header-rework, also bumps to 0.4.27). Whoever merges first gets 0.4.27, the second one rebases onto 0.4.28. No version state in this branch keeps both options open.

## Test plan

- [x] `cargo check` — green
- [x] `cargo test --lib housekeeping` — 11 passed (3 new)
- [ ] CI green
- [ ] Manual on Mac: install older aiui, run a tool call (capture lstart of subprocess), in-place replace with newer aiui via DMG, run a second tool call → subprocess should exit and respawn cleanly, second tool call should succeed
- [ ] After release: confirm stale subprocess scenarios (updater path, manual DMG drop) self-heal without user action