### PR TITLE
fix: window drag actually works + logo actually 80 px (v0.4.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.28] — 2026-04-30
+
+### Fixed
+
+- **Window can actually be dragged.** The 0.4.25 attempt at making
+  the window movable (`data-tauri-drag-region` overlay) didn't
+  produce a working drag in Tauri 2.10 + macOS 26 — and likely
+  blocked the native title-bar drag on top of it. The fix uses
+  *both* mechanisms: the Tauri attribute for cross-platform
+  correctness, and `-webkit-app-region: drag` as the WebKit-native
+  fallback that actually works on this OS/runtime combo. Drag-zone
+  also extends across the setup window's full header (logo, status
+  text, version chip — none of those are click targets), with the
+  Skill-repair button opting out via `no-drag`. Tester reproduced
+  the failure on 0.4.27; this release fixes it for real.
+- **Setup-window logo is genuinely larger now.** The 0.4.27 bump
+  to 64×64 didn't visibly enlarge the rendered icon — the selector
+  `.app-header img.app-icon` apparently didn't beat whatever was
+  squishing the inline image. Switched to `.app-header .app-icon`
+  with `display: block` and explicit `min-width`/`min-height`,
+  bumped to 80×80, border-radius proportional. The brand mark now
+  carries actual visual weight in the chrome.
+
 ## [0.4.27] — 2026-04-30
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.27"
+version = "0.4.28"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -59,12 +59,13 @@
   });
 </script>
 
-<!-- The drag-region sits at the very top, OVER the macOS overlay
-     title bar. Tauri lets the traffic-light buttons capture clicks
-     even when our region overlaps them, so the user can grab the
-     window from anywhere along the top edge except directly on the
-     buttons. Position fixed so it doesn't push container content
-     down. -->
+<!-- Window-drag overlay along the top edge.
+     Two redundant mechanisms because Tauri 2's `data-tauri-drag-region`
+     attribute alone has been unreliable on macOS 26 / WebKit in our
+     testing — `-webkit-app-region: drag` is the WebKit-native way
+     and works as a fallback. The traffic-light buttons capture
+     their own clicks even with this overlay above them. Container
+     padding (44 px top) keeps content off the drag zone. -->
 <div class="drag-region" data-tauri-drag-region></div>
 
 <!-- Container provides the Apple-HIG-compliant 44 px top breathing
@@ -88,7 +89,11 @@
     top: 0;
     left: 0;
     right: 0;
-    height: 28px;
+    height: 36px;
     z-index: 1;
+    /* WebKit-native drag fallback. The Tauri data-attribute above is
+       the cross-platform path; this is the belt-and-braces version
+       that actually works on macOS 26. */
+    -webkit-app-region: drag;
   }
 </style>

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -203,7 +203,13 @@
 
 {#if status}
   <div class="stack">
-    <header class="app-header">
+    <!-- Header acts as a second drag region — the 36 px App.svelte
+      overlay only covers the OS title-bar zone. The header below
+      it (logo + status text + version chip) has no click targets
+      worth protecting, so the whole row picks up window-drag. The
+      `header-action` button (skill repair, only visible when the
+      skill is missing) opts out via -webkit-app-region: no-drag. -->
+    <header class="app-header" data-tauri-drag-region>
       <img src={iconUrl} alt="aiui" class="app-icon" />
       <div class="header-meta">
         <div class="header-status-line">
@@ -494,14 +500,30 @@
      * gradient line. */
     padding: 8px 0 12px 0;
     border-bottom: 1px solid var(--border);
+    /* Whole header acts as a window-drag handle. Children inherit
+       this via the universal selector below; interactive children
+       (today: only `.header-action`) opt out explicitly. */
+    -webkit-app-region: drag;
   }
-  .app-header img.app-icon {
-    /* 64×64 — at least 2× the original 32 px so the brand mark
-       actually carries weight in the chrome. The header-meta column
-       grows in line height to match, status lines breathe. */
-    width: 64px;
-    height: 64px;
-    border-radius: 14px;
+  .app-header > *,
+  .app-header :global(*) {
+    -webkit-app-region: drag;
+  }
+  .app-header :global(.header-action) {
+    -webkit-app-region: no-drag;
+  }
+  .app-header .app-icon {
+    /* 80×80 — well past 2× the original 32 px. Tester noted that
+       the previous 64×80 attempt did not visibly enlarge the icon
+       in the rendered window; using `display:block` + explicit
+       min-width/min-height defends against inline-image layout
+       quirks that can squish the rendered size below the spec. */
+    display: block;
+    width: 80px;
+    height: 80px;
+    min-width: 80px;
+    min-height: 80px;
+    border-radius: 18px;
     box-shadow: var(--shadow-sm);
     flex-shrink: 0;
   }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.27"
+version = "0.4.28"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

Tester report on 0.4.27: window still can't be moved (\"No-Go\"), and the icon isn't visibly larger.

## Drag fix

The 0.4.25 attempt put a `data-tauri-drag-region` overlay at the top edge. On Tauri 2.10 + macOS 26 this attribute alone doesn't reliably trigger window-drag — and the overlay was likely *blocking* the native title-bar drag on top of it.

Now uses both mechanisms in parallel:
- `data-tauri-drag-region` attribute — cross-platform Tauri path
- `-webkit-app-region: drag` CSS — WebKit-native fallback that actually works on this OS/runtime combo

Drag-zone extends across the full setup-window header (logo + status text + version chip — none are click targets). The Skill-repair button (only visible when skill is missing) opts out via `-webkit-app-region: no-drag`.

## Logo fix

0.4.27 had `.app-header img.app-icon { width: 64px; height: 64px; }`. Tester confirmed the rendered icon didn't visibly grow. Suspect: scoping/specificity quirk, or inline-image layout squishing the rendered size below the spec.

New CSS:
- Selector tightened to `.app-header .app-icon` (no `img` qualifier)
- `display: block` + explicit `min-width` / `min-height` defends against inline-image quirks
- Bumped to 80 × 80 (well past the original 2× target of 64 px)
- Border-radius proportional (18 px)

## Test plan

- [x] `cargo check` — green
- [x] `svelte-check` — 0 errors
- [ ] CI green
- [ ] Manual on tester's Mac: window drags from anywhere along top 36 px AND across the header row; rendered icon clearly larger than before