### PR TITLE
fix: pin aiui-mcp version on remotes + auto-resync (v0.4.29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.29] — 2026-05-03
+
+### Fixed
+
+- **Remote `aiui-mcp` versions are kept in lockstep with the local
+  companion.** Until now, the companion's setup wrote
+  `args: ["aiui-mcp"]` into the remote's `~/.claude.json` without a
+  version pin. uvx then cached whatever version of `aiui-mcp` happened
+  to be installed first, indefinitely — no upgrade ever, even after
+  the local aiui app was updated dozens of times. This is what
+  produced the 2026-04-30 incident: a v0.4.27 companion talking to a
+  v0.3.1 mcp-stdio on `customer@macmini` because the pin was missing
+  and uvx clung to the originally-cached version. Slash-commands
+  added between 0.3.1 and 0.4.27 (e.g. `teach`) were therefore
+  invisible on the remote, even though they were live in the local
+  binary.
+
+  The fix is structural and entirely code-driven (no SSH commands the
+  user has to run by hand):
+
+  1. **Pin in `~/.claude.json`** — the companion now writes
+     `args: ["aiui-mcp==<companion-version>"]`. uvx is forced to
+     fetch the exact matching wheel before spawning. The patch script
+     is idempotent: if the pin is already correct (steady state), no
+     rewrite happens.
+  2. **Stale-mcp-stdio sweep** — when the pin is *changed*, the
+     companion sends `pkill -f 'aiui-mcp'` to the remote. Any
+     in-flight child running the old version is taken down so the
+     next tool call respawns cleanly against the new pin. Tool calls
+     that arrive in the brief replacement window get answered by the
+     soon-to-die child (still works) and the one after lands on the
+     fresh version.
+  3. **Resync on every aiui-app launch** — the setup phase iterates
+     all registered remotes in a non-blocking background task and
+     applies (1) + (2) per host. The user sees the setup window
+     immediately; the SSH round-trips happen out-of-band. Steady
+     state (all pins correct) costs ~200 ms per remote; an actual
+     update is ~600 ms per remote with a clean kill-sweep.
+
+  Net effect: every update of aiui.app on the user's Mac propagates
+  automatically to every registered remote on the next aiui-app
+  launch. No manual `uvx tool upgrade aiui-mcp` over SSH, no
+  Claude-Desktop restart instruction, no version drift.
+
 ## [0.4.28] — 2026-04-30
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.28"
+version = "0.4.29"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.28"
+version = "0.4.29"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -385,12 +385,22 @@ async fn add_remote(
     let skill_step = skill::install_to_remote(&host_alias);
     results.push(skill_step);
 
-    let config_step = setup::patch_claude_code_config_remote(
+    let (config_step, config_patch) = setup::patch_claude_code_config_remote(
         &host_alias,
         uvx_loc.as_ref().map(|l| l.uvx_path.as_str()),
+        env!("CARGO_PKG_VERSION"),
     );
     let config_ok = config_step.ok;
     results.push(config_step);
+    // Fresh add — there shouldn't be a running child yet, but a
+    // re-add (Remove + Add the same host) leaves stale ones; sweep
+    // them so the first tool call respawns clean against the new pin.
+    if matches!(config_patch, Some(setup::RemoteConfigPatch::Patched)) {
+        let sweep = setup::kill_remote_mcp_stdio(&host_alias);
+        if !sweep.ok {
+            results.push(sweep);
+        }
+    }
 
     if !(token_ok && config_ok) {
         // Don't persist the host or start a tunnel for a half-failed
@@ -823,6 +833,64 @@ pub fn run() {
                 for host in setup::load_remotes() {
                     let _ = setup::remove_ssh_forward(&host, port_for_start);
                     tm_for_start.ensure(host).await;
+                }
+            });
+
+            // Re-sync the aiui-mcp version pin in `~/.claude.json` on
+            // every registered remote. Without this a remote can drift
+            // arbitrarily far behind the local companion — uvx caches
+            // the once-installed version of `aiui-mcp` indefinitely
+            // unless we pin it. The 2026-04-30 incident: a v0.4.27
+            // companion talking to a v0.3.1 mcp-stdio on macmini
+            // because the pin was missing.
+            //
+            // We deliberately spawn this as a background task with a
+            // small per-host stagger: setup() returns straight to the
+            // UI without waiting on SSH round-trips. If the pin is
+            // already correct (steady state), the script reads it and
+            // exits without writing — the SSH cost is a single login +
+            // one Python invocation. When the pin needs updating, we
+            // also pkill any in-flight child so the next tool call
+            // respawns clean against the new version.
+            rt.spawn(async move {
+                let our_version = env!("CARGO_PKG_VERSION");
+                for host in setup::load_remotes() {
+                    let host_for_task = host.clone();
+                    let our_version_owned = our_version.to_string();
+                    // Each remote in its own blocking task — the
+                    // SSH/Python pipeline is sync. Ordering across
+                    // hosts is irrelevant; pin-syncs are independent.
+                    tokio::task::spawn_blocking(move || {
+                        let (step, patch) = setup::patch_claude_code_config_remote(
+                            &host_for_task,
+                            None,
+                            &our_version_owned,
+                        );
+                        if step.ok {
+                            logging::trace(&format!(
+                                "remote-pin: {host_for_task}: {} ({})",
+                                step.message,
+                                match patch {
+                                    Some(setup::RemoteConfigPatch::Patched) => "patched",
+                                    Some(setup::RemoteConfigPatch::AlreadyCurrent) => "current",
+                                    None => "unknown",
+                                }
+                            ));
+                            if matches!(patch, Some(setup::RemoteConfigPatch::Patched)) {
+                                let sweep = setup::kill_remote_mcp_stdio(&host_for_task);
+                                logging::trace(&format!(
+                                    "remote-pin: {host_for_task}: sweep {}",
+                                    if sweep.ok { "ok" } else { "failed" }
+                                ));
+                            }
+                        } else {
+                            logging::trace(&format!(
+                                "remote-pin: {host_for_task} sync failed: {} ({})",
+                                step.message,
+                                step.details.as_deref().unwrap_or("no details")
+                            ));
+                        }
+                    });
                 }
             });
 

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -647,10 +647,24 @@ pub fn remove_ssh_forward(host_alias: &str, port: u16) -> StepResult {
 /// while reporting success. Stdin avoids that whole class of shell-quoting
 /// trap, and we additionally check that the script printed "ok" so any
 /// future regression can't masquerade as success again.
+/// Outcome of a `~/.claude.json` patch run on a remote — tells the
+/// caller whether the file was actually rewritten or already carried
+/// the expected pin. The caller uses this to decide whether to also
+/// SIGTERM any in-flight mcp-stdio child on the remote (so the next
+/// tool call respawns with the freshly pinned version).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteConfigPatch {
+    /// File already carried the expected pin — no rewrite, no kill needed.
+    AlreadyCurrent,
+    /// File was rewritten — caller should sweep stale mcp-stdio children.
+    Patched,
+}
+
 pub fn patch_claude_code_config_remote(
     host_alias: &str,
     uvx_path: Option<&str>,
-) -> StepResult {
+    pinned_version: &str,
+) -> (StepResult, Option<RemoteConfigPatch>) {
     // If we know the absolute uvx path from the reachability probe, use
     // it. Otherwise fall back to the bare "uvx" name (which depends on
     // Claude-Code's process PATH being right at spawn time — fragile,
@@ -659,8 +673,19 @@ pub fn patch_claude_code_config_remote(
     // the Python script's string literal.
     let uvx_command_lit = serde_json::to_string(uvx_path.unwrap_or("uvx"))
         .unwrap_or_else(|_| "\"uvx\"".to_string());
+    // Pin to the exact aiui-mcp version that matches the local
+    // companion. Without the pin, uvx silently caches whichever version
+    // happened to be installed first on the remote — that's how a v0.3.1
+    // mcp-stdio kept talking to a v0.4.27 companion (incident
+    // 2026-04-30). With the pin, uvx is forced to fetch / install the
+    // matching wheel before spawning. Idempotent: if the pin is already
+    // correct, no rewrite happens (`ok:current`), and the caller skips
+    // the kill-sweep on the remote.
+    let pkg_spec = format!("aiui-mcp=={pinned_version}");
+    let pkg_spec_lit = serde_json::to_string(&pkg_spec)
+        .unwrap_or_else(|_| format!("\"{pkg_spec}\""));
     let script = format!(r#"
-import json, os, pathlib, shutil, time
+import json, pathlib, shutil, time
 p = pathlib.Path.home() / ".claude.json"
 data = {{}}
 if p.exists():
@@ -668,32 +693,88 @@ if p.exists():
         data = json.loads(p.read_text())
     except Exception:
         data = {{}}
-    ts = int(time.time())
-    shutil.copy(p, p.with_suffix(f".json.bak.{{ts}}"))
 servers = data.get("mcpServers") or {{}}
-servers["aiui"] = {{"command": {uvx_command_lit}, "args": ["aiui-mcp"]}}
+existing = servers.get("aiui") or {{}}
+expected = {{"command": {uvx_command_lit}, "args": [{pkg_spec_lit}]}}
+if (existing.get("command") == expected["command"]
+        and existing.get("args") == expected["args"]):
+    print("ok:current")
+    raise SystemExit(0)
+ts = int(time.time())
+if p.exists():
+    shutil.copy(p, p.with_suffix(f".json.bak.{{ts}}"))
+servers["aiui"] = expected
 data["mcpServers"] = servers
 p.parent.mkdir(parents=True, exist_ok=True)
 p.write_text(json.dumps(data, indent=2))
-print("ok")
+print("ok:patched")
 "#);
     let script = script.as_str();
-    run_remote_python(host_alias, script, "Patching ~/.claude.json", |stdout| {
-        let confirmed = stdout.trim() == "ok";
-        StepResult {
-            ok: confirmed,
-            message: if confirmed {
-                format!("aiui registered in ~/.claude.json on {host_alias}")
-            } else {
-                format!("Patching ~/.claude.json on {host_alias} did not confirm 'ok'")
-            },
-            details: if confirmed {
-                None
-            } else {
-                Some(format!("stdout: {}", stdout.trim()))
+    let mut patch: Option<RemoteConfigPatch> = None;
+    let step = run_remote_python(host_alias, script, "Patching ~/.claude.json", |stdout| {
+        let trimmed = stdout.trim();
+        match trimmed {
+            "ok:patched" => {
+                patch = Some(RemoteConfigPatch::Patched);
+                StepResult {
+                    ok: true,
+                    message: format!("aiui pinned to {pinned_version} in ~/.claude.json on {host_alias}"),
+                    details: None,
+                }
+            }
+            "ok:current" => {
+                patch = Some(RemoteConfigPatch::AlreadyCurrent);
+                StepResult {
+                    ok: true,
+                    message: format!("aiui in ~/.claude.json on {host_alias} already pinned to {pinned_version}"),
+                    details: None,
+                }
+            }
+            other => StepResult {
+                ok: false,
+                message: format!("Patching ~/.claude.json on {host_alias} did not confirm 'ok'"),
+                details: Some(format!("stdout: {other}")),
             },
         }
-    })
+    });
+    (step, patch)
+}
+
+/// SIGTERM any `aiui-mcp` child still running on `host_alias` — used
+/// after a pin update so Claude Desktop / Claude Code respawns the
+/// child against the freshly pinned version on its next tool call.
+/// Idempotent: succeeds silently when no matching process is running.
+///
+/// `pkill -f` on macOS / Linux exit-codes: 0 = killed at least one,
+/// 1 = nothing matched. Both are success from our perspective; only
+/// the SSH layer or shell-not-found counts as a real failure.
+pub fn kill_remote_mcp_stdio(host_alias: &str) -> StepResult {
+    let out = std::process::Command::new("ssh")
+        .args([
+            "-o",
+            "BatchMode=yes",
+            "--",
+            host_alias,
+            "pkill -f 'aiui-mcp' 2>/dev/null; true",
+        ])
+        .output();
+    match out {
+        Err(e) => StepResult {
+            ok: false,
+            message: format!("ssh {host_alias} konnte nicht gestartet werden"),
+            details: Some(e.to_string()),
+        },
+        Ok(o) if !o.status.success() => StepResult {
+            ok: false,
+            message: format!("Stale-mcp-stdio-Sweep auf {host_alias} fehlgeschlagen"),
+            details: Some(String::from_utf8_lossy(&o.stderr).to_string()),
+        },
+        Ok(_) => StepResult {
+            ok: true,
+            message: format!("Stale aiui-mcp children on {host_alias} swept"),
+            details: None,
+        },
+    }
 }
 
 /// Result of a successful reachability probe — carries the absolute

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.28"
+version = "0.4.29"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

uvx caches the once-installed version of `aiui-mcp` indefinitely unless we pin it. Until now, the companion wrote `args: [\"aiui-mcp\"]` into the remote's `~/.claude.json` — no version pin. uvx then clung to whatever version of aiui-mcp happened to be installed first, indefinitely. Local aiui.app could update dozens of times; the remote mcp-stdio stayed where it was.

2026-04-30 incident: companion v0.4.27 talking to mcp-stdio v0.3.1 on `customer@macmini`. Slash-commands added between 0.3.1 and 0.4.27 (e.g. `/aiui:teach`) were invisible on the remote, even though they were live in the local binary.

User constraint: this must be fixed in code, not by asking the user to SSH and run `uvx tool upgrade`. Released software shouldn't make end-users do that.

## Three layers of fix, all code-driven

| | What | Where |
|---|---|---|
| 1 | `patch_claude_code_config_remote` writes `args: [\"aiui-mcp==<companion-version>\"]`. Script is idempotent — if the pin matches, no rewrite. Returns a new `RemoteConfigPatch` enum so the caller knows whether the file actually changed. | `setup.rs::patch_claude_code_config_remote` |
| 2 | New `kill_remote_mcp_stdio(host)` SSH-pkill helper. Called only when (1) actually rewrote the file, so any in-flight stale child is taken down and the next tool call respawns clean against the new pin. | `setup.rs::kill_remote_mcp_stdio` |
| 3 | GUI setup-phase iterates all registered remotes in a non-blocking `tokio::spawn_blocking` per host. Setup window appears immediately; SSH round-trips happen out-of-band. | `lib.rs` setup() |

## Cost profile

- Steady state (pin already correct): ~200 ms / host SSH round-trip, no rewrite, no kill
- Update path (pin mismatched): ~600 ms / host with rewrite + kill sweep
- All in background — no blocking of the GUI startup

## What this does *not* do (yet)

- Doesn't probe for tunnel reachability (separate roadmap item — reactive, not periodic)
- Doesn't validate via HTTP version-header (planned as 3rd defense layer in a later PR — saves the 2 % of cases where pin + sweep miss)

These are deliberately separate; this PR is the structural fix for the version-drift problem.

## Test plan

- [x] `cargo check` — green
- [x] `cargo test --lib` — 52 passed
- [ ] CI green
- [ ] After release: install 0.4.29, observe trace log on next GUI start. Should see `remote-pin: <host>: ... (current|patched)` for each registered remote.
- [ ] Verify on stale remote (macmini): pin gets rewritten to `aiui-mcp==0.4.29`, stale subprocess swept, next tool call answers cleanly with `/aiui:teach` recognised