### PR TITLE
fix: window drag via native title bar + window-ready handshake (v0.4.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.30] — 2026-05-03
+
+### Fixed
+
+- **Window can finally be moved.** Replaced the previous setup of
+  `titleBarStyle: Overlay` + `hiddenTitle: true` + `data-tauri-drag-region`
+  overlay + `-webkit-app-region: drag` CSS — that combination was
+  unreliable on Tauri 2 + WKWebView (macOS 26): the Tauri attribute
+  drops mousedown depending on z-order, and `-webkit-app-region` is a
+  Chromium-only CSS property that WKWebView simply ignores. The
+  fix is structural: drop the overlay setup, use the standard native
+  visible title bar that macOS owns and drags itself. Slightly less
+  flush look, but a window the user can actually grab and reposition.
+  Tester reported this regression three times across 0.4.25 → 0.4.28;
+  this finally resolves it.
+- **First-render-of-session race resolved.** When the dialog window
+  was built fresh (first tool call of a session), the backend used
+  to emit `dialog:show` before the Svelte frontend had mounted +
+  registered its listeners — the event was lost, the 500 ms ack
+  timeout fired, the WebView reloaded, and depending on timing the
+  user could end up with a blank window for the entire 2-minute
+  Claude-Desktop tool-timeout. Reproduction in trace from
+  2026-05-03 18:05.
+
+  Window-ready handshake added: the dialog window's frontend
+  signals via a new `dialog_window_ready` Tauri command once both
+  `dialog:show` and `ui:ping` listeners are installed. The render
+  path waits on a `tokio::sync::watch<bool>` for that signal
+  *before* emitting (3 s timeout, falls back to existing ack
+  contract if the signal doesn't arrive). The reload-recovery path
+  resets the flag and re-waits after the WebView reload, so the
+  same race can't reappear after a recovery cycle.
+
+### Internal
+
+- `App.svelte` no longer carries the manual drag-region overlay.
+- `Settings.svelte` no longer carries `data-tauri-drag-region` /
+  `-webkit-app-region` styles on the header. Native title bar
+  handles dragging.
+- `app.css` `.container` top-padding reduced from 44 px to 14 px
+  (no overlay title bar to clear anymore).
+- New Tauri command `dialog_window_ready` and shared
+  `Arc<tokio::sync::watch::Sender<bool>>` for the handshake.
+
 ## [0.4.29] — 2026-05-03
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.29"
+version = "0.4.30"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.29"
+version = "0.4.30"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -514,8 +514,18 @@ async fn render(
     // still resets the idle clock even if the user closes the dialog.
     *state.last_render_at.lock().unwrap() = Instant::now();
 
-    // Surface the window from the main thread.
+    // Surface the window from the main thread. If the window is being
+    // built fresh (first render of this session, or after the user
+    // closed it), `ensure_dialog_window` reset the ready flag.
     surface_main_window(&state.app, &id);
+
+    // Window-ready handshake: wait until the frontend signals that
+    // its `dialog:show` listener is registered. Without this gate
+    // we'd race against Vite-bundle-load + Svelte-mount + tauri-listen,
+    // and on the first render of a session the emit would land before
+    // the listener — silent loss, 500 ms ack timeout, webview reload
+    // and a confused user staring at a blank window.
+    wait_for_dialog_ready(&state.app, "pre-emit").await;
 
     // Emit the dialog to the frontend.
     if let Err(e) = state
@@ -542,8 +552,22 @@ async fn render(
                 "render: no ack within {:?}; reloading webview and retrying",
                 DIALOG_ACK_TIMEOUT
             ));
+            // Reset ready flag — after reload the listeners need to
+            // re-register. We'll wait on the handshake again before
+            // re-emitting.
+            if let Some(tx) = state
+                .app
+                .try_state::<std::sync::Arc<tokio::sync::watch::Sender<bool>>>()
+            {
+                let _ = tx.inner().send(false);
+            }
             reload_main_webview(&state.app);
             tokio::time::sleep(RELOAD_SETTLE).await;
+
+            // Wait for the freshly-mounted Svelte to signal listeners
+            // are wired up again. Without this the same race that got
+            // us here would just repeat after reload.
+            wait_for_dialog_ready(&state.app, "post-reload").await;
 
             // After reload the previous ack receiver was consumed. We need a
             // fresh handshake on the same dialog id — register a new ack
@@ -642,6 +666,52 @@ async fn render(
         reason: result.reason,
     })
     .into_response()
+}
+
+/// Wait until the dialog window's frontend signals via the
+/// `dialog_window_ready` Tauri command that its `dialog:show` and
+/// `ui:ping` listeners are registered. Times out after
+/// `DIALOG_READY_TIMEOUT` and returns either way — the caller still
+/// emits, falling back to the existing ack/reload contract if the
+/// frontend turns out to be slower than expected.
+///
+/// Called twice in the render path: once before the initial emit
+/// (covers the cold-start race when the window is built fresh), once
+/// after a webview reload (covers the same race after the recovery
+/// path tears down the JS state).
+const DIALOG_READY_TIMEOUT: Duration = Duration::from_millis(3000);
+
+async fn wait_for_dialog_ready(app: &AppHandle, phase: &str) {
+    let Some(tx_state) = app.try_state::<std::sync::Arc<tokio::sync::watch::Sender<bool>>>()
+    else {
+        trace(&format!("render: dialog_ready_tx state missing ({phase})"));
+        return;
+    };
+    let mut rx = tx_state.inner().subscribe();
+    if *rx.borrow() {
+        trace(&format!("render: dialog already ready ({phase})"));
+        return;
+    }
+    let started = std::time::Instant::now();
+    let waited = tokio::time::timeout(DIALOG_READY_TIMEOUT, async {
+        while !*rx.borrow_and_update() {
+            if rx.changed().await.is_err() {
+                break;
+            }
+        }
+    })
+    .await;
+    if waited.is_ok() && *rx.borrow() {
+        trace(&format!(
+            "render: dialog ready ({phase}) after {:?}",
+            started.elapsed()
+        ));
+    } else {
+        trace(&format!(
+            "render: dialog-ready timeout ({phase}) after {:?} — proceeding anyway",
+            started.elapsed()
+        ));
+    }
 }
 
 /// Surface the dialog window for the incoming render. If the window

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -67,6 +67,21 @@ fn ui_pong(
     Ok(())
 }
 
+/// Frontend signals that the dialog window is mounted and its
+/// `dialog:show` / `ui:ping` listeners are registered. The render
+/// path on the Rust side waits on this watch *before* emitting, so
+/// a freshly-built dialog window never receives a `dialog:show`
+/// event before the listener is up. Without this handshake we hit
+/// the 500 ms ack timeout, reload the WebView, and lose the user's
+/// dialog (the failure mode reported on 2026-05-03).
+#[tauri::command]
+fn dialog_window_ready(
+    tx: tauri::State<'_, Arc<tokio::sync::watch::Sender<bool>>>,
+) -> Result<(), String> {
+    let _ = tx.send(true);
+    Ok(())
+}
+
 #[tauri::command]
 async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
     // The frontend calls this after a dialog submit/cancel. We *destroy*
@@ -538,9 +553,18 @@ pub(crate) fn build_setup_window(
     .max_inner_size(520.0, 640.0)
     .resizable(false)
     .center()
+    // Native, fully-visible title bar so macOS handles window-drag
+    // for us. Tauri's `data-tauri-drag-region` HTML attribute and
+    // Chromium's `-webkit-app-region: drag` CSS are *both* unreliable
+    // on Tauri 2 + WKWebView (macOS 26): the first sometimes drops
+    // mousedown depending on z-order, the second is a Chromium-only
+    // CSS property that WKWebView doesn't honour at all. The only
+    // robust path is to let macOS run its own title-bar drag, which
+    // means a visible title bar (the previous "Overlay + hiddenTitle"
+    // setup hid the title-bar pixels but kept its drag behaviour
+    // half-broken). We accept the slightly-less-flush look in
+    // exchange for a window the user can actually move.
     .decorations(true)
-    .title_bar_style(tauri::TitleBarStyle::Overlay)
-    .hidden_title(true)
     .disable_drag_drop_handler()
     .visible(true)
     .build()
@@ -563,6 +587,12 @@ pub(crate) fn ensure_dialog_window(
         let _ = win.unminimize();
         return Ok(win);
     }
+    // Window is being built fresh — its frontend listeners aren't up
+    // yet. Reset the ready flag so the render path waits for the
+    // `dialog_window_ready` signal before emitting `dialog:show`.
+    if let Some(tx) = app.try_state::<Arc<tokio::sync::watch::Sender<bool>>>() {
+        let _ = tx.inner().send(false);
+    }
     WebviewWindowBuilder::new(
         app,
         DIALOG_WINDOW_LABEL,
@@ -574,9 +604,18 @@ pub(crate) fn ensure_dialog_window(
     .max_inner_size(520.0, 640.0)
     .resizable(false)
     .center()
+    // Native, fully-visible title bar so macOS handles window-drag
+    // for us. Tauri's `data-tauri-drag-region` HTML attribute and
+    // Chromium's `-webkit-app-region: drag` CSS are *both* unreliable
+    // on Tauri 2 + WKWebView (macOS 26): the first sometimes drops
+    // mousedown depending on z-order, the second is a Chromium-only
+    // CSS property that WKWebView doesn't honour at all. The only
+    // robust path is to let macOS run its own title-bar drag, which
+    // means a visible title bar (the previous "Overlay + hiddenTitle"
+    // setup hid the title-bar pixels but kept its drag behaviour
+    // half-broken). We accept the slightly-less-flush look in
+    // exchange for a window the user can actually move.
     .decorations(true)
-    .title_bar_style(tauri::TitleBarStyle::Overlay)
-    .hidden_title(true)
     .disable_drag_drop_handler()
     .visible(true)
     .build()
@@ -658,6 +697,18 @@ pub fn run() {
     let http_error: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
 
+    // Window-ready handshake: the dialog window's frontend signals
+    // here (via the `dialog_window_ready` Tauri command) once its
+    // listeners are wired up. The render path *waits* on this watch
+    // before emitting `dialog:show`, so a freshly-built dialog window
+    // never receives an event before its listener is registered. The
+    // 0.4.30 fix — without it, a 500 ms ack timeout could fire before
+    // the WebView even finished mounting Svelte (especially on the
+    // very first render of a session, when the window is built fresh
+    // and Vite has to load the bundle).
+    let (dialog_ready_tx, _dialog_ready_rx) = tokio::sync::watch::channel(false);
+    let dialog_ready_tx = Arc::new(dialog_ready_tx);
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -710,11 +761,13 @@ pub fn run() {
         .manage(lifetime_stats.clone())
         .manage(tunnel_mgr.clone())
         .manage(http_error.clone())
+        .manage(dialog_ready_tx.clone())
         .invoke_handler(tauri::generate_handler![
             dialog_submit,
             dialog_cancel,
             dialog_received,
             ui_pong,
+            dialog_window_ready,
             close_window,
             surface_for_dialog,
             status,

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/App.svelte
+++ b/companion/src/App.svelte
@@ -59,19 +59,11 @@
   });
 </script>
 
-<!-- Window-drag overlay along the top edge.
-     Two redundant mechanisms because Tauri 2's `data-tauri-drag-region`
-     attribute alone has been unreliable on macOS 26 / WebKit in our
-     testing — `-webkit-app-region: drag` is the WebKit-native way
-     and works as a fallback. The traffic-light buttons capture
-     their own clicks even with this overlay above them. Container
-     padding (44 px top) keeps content off the drag zone. -->
-<div class="drag-region" data-tauri-drag-region></div>
-
-<!-- Container provides the Apple-HIG-compliant 44 px top breathing
-     room so content never collides with the traffic-light buttons,
-     plus side padding and scroll behaviour. Both setup and dialog
-     windows share this chrome. -->
+<!-- No drag overlay needed: the window now uses macOS' native title
+     bar (lib.rs::build_setup_window / ensure_dialog_window dropped
+     `titleBarStyle: Overlay` + `hiddenTitle: true` in v0.4.30). The
+     OS handles window-drag from the title bar itself, which is the
+     only path that actually works in Tauri 2 + WKWebView. -->
 <main class="container">
   {#if label === "setup"}
     <Settings />
@@ -82,18 +74,3 @@
        than guess wrong. Tauri sets the label synchronously, so this
        lasts only one micro-task. -->
 </main>
-
-<style>
-  .drag-region {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 36px;
-    z-index: 1;
-    /* WebKit-native drag fallback. The Tauri data-attribute above is
-       the cross-platform path; this is the belt-and-braces version
-       that actually works on macOS 26. */
-    -webkit-app-region: drag;
-  }
-</style>

--- a/companion/src/app.css
+++ b/companion/src/app.css
@@ -165,7 +165,11 @@ label {
 }
 
 .container {
-  padding: 44px 20px 16px 20px;
+  /* Native title bar handles the top-of-window real estate now (see
+     v0.4.30 drag fix). Content can sit close to the title-bar
+     boundary; 14 px gives visual breathing room without wasting
+     vertical space. */
+  padding: 14px 20px 16px 20px;
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;

--- a/companion/src/lib/DialogShell.svelte
+++ b/companion/src/lib/DialogShell.svelte
@@ -18,7 +18,7 @@
     // replaces the need for any background UI heartbeat. Backend emits
     // this event with `emit_to("dialog", ...)`, so the setup window
     // never sees it.
-    const unDialog = listen<DialogReq>("dialog:show", (e) => {
+    const dialogPromise = listen<DialogReq>("dialog:show", (e) => {
       current = e.payload;
       void invoke("dialog_received", { id: e.payload.id });
     });
@@ -26,15 +26,27 @@
     // UI ping from Rust (used by /health to verify the event loop). We
     // pong back synchronously — the Rust side has a 100 ms timeout and
     // a missed pong is what flips /health to `degraded`.
-    const unPing = listen<string>("ui:ping", (e) => {
+    const pingPromise = listen<string>("ui:ping", (e) => {
       void invoke("ui_pong", { id: e.payload });
     });
 
     window.addEventListener("keydown", onKey);
 
+    // Window-ready handshake (v0.4.30): tell the Rust render path
+    // that our `dialog:show` listener is installed and we can safely
+    // receive events. Without this, the backend would emit before
+    // Tauri actually wired up the listener — the very-first render of
+    // a fresh window would lose its event, hit the 500 ms ack timeout,
+    // and the user would see a blank window. We await both subscribe
+    // promises to ensure the listeners are *really* up before
+    // signalling, not just queued.
+    void Promise.all([dialogPromise, pingPromise]).then(() => {
+      void invoke("dialog_window_ready");
+    });
+
     return async () => {
-      (await unDialog)();
-      (await unPing)();
+      (await dialogPromise)();
+      (await pingPromise)();
       window.removeEventListener("keydown", onKey);
     };
   });

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -203,13 +203,7 @@
 
 {#if status}
   <div class="stack">
-    <!-- Header acts as a second drag region — the 36 px App.svelte
-      overlay only covers the OS title-bar zone. The header below
-      it (logo + status text + version chip) has no click targets
-      worth protecting, so the whole row picks up window-drag. The
-      `header-action` button (skill repair, only visible when the
-      skill is missing) opts out via -webkit-app-region: no-drag. -->
-    <header class="app-header" data-tauri-drag-region>
+    <header class="app-header">
       <img src={iconUrl} alt="aiui" class="app-icon" />
       <div class="header-meta">
         <div class="header-status-line">
@@ -494,23 +488,11 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    /* `.container` already pads 44 px down from the window edge for the
-     * macOS traffic-light buttons; we only add a hair of breathing room
-     * here so the logo doesn't ride directly against the title-area
-     * gradient line. */
-    padding: 8px 0 12px 0;
+    /* Native title bar (v0.4.30) supplies its own height; container
+       already pads 14 px on top. A small inner padding here lets the
+       header content breathe without pressing against the title bar. */
+    padding: 4px 0 12px 0;
     border-bottom: 1px solid var(--border);
-    /* Whole header acts as a window-drag handle. Children inherit
-       this via the universal selector below; interactive children
-       (today: only `.header-action`) opt out explicitly. */
-    -webkit-app-region: drag;
-  }
-  .app-header > *,
-  .app-header :global(*) {
-    -webkit-app-region: drag;
-  }
-  .app-header :global(.header-action) {
-    -webkit-app-region: no-drag;
   }
   .app-header .app-icon {
     /* 80×80 — well past 2× the original 32 px. Tester noted that

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.29"
+version = "0.4.30"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

Tester report: window can't be moved (third regression in a row), and a fresh dialog window stays blank for 2 minutes after the first tool call of a session. Trace from 2026-05-03 18:05 confirmed both issues independently.

## Drag fix — done structurally this time

Previous attempts in 0.4.25 / 0.4.28:

| Layer | What I tried | Why it failed |
|---|---|---|
| `titleBarStyle: Overlay` + `hiddenTitle: true` | Apple-flush look, transparent title-bar with traffic-light buttons | Tauri 2 + WKWebView doesn't fully wire up window-drag in this mode |
| `data-tauri-drag-region` overlay | Tauri's HTML attribute for explicit drag zones | Drops mousedown depending on z-order, unreliable on macOS 26 |
| `-webkit-app-region: drag` CSS | Chromium-native drag CSS as fallback | WKWebView (Tauri's macOS engine) ignores it entirely — Chromium-only |

This release drops the whole stack and uses the **standard native visible title bar**. macOS owns the title-bar drag itself and there's no WebKit/WKWebView gap to bridge. Slightly less flush look (visible \"aiui\" label in title bar), but a window the user can actually grab and reposition.

## Window-ready handshake

When the dialog window is built fresh (first tool call of a session), the timeline used to be:

1. Backend emits \`dialog:show\` (T+0)
2. Tauri delivers event into the WebView
3. Svelte hasn't mounted + registered listener yet → event is lost
4. 500 ms ack timeout fires (T+500)
5. Reload-recovery triggers
6. After reload, same race can repeat
7. User stares at blank window until Claude Desktop tool-timeout (~2 min)

The fix:

1. New Tauri command `dialog_window_ready`. Frontend invokes it after both `dialog:show` and `ui:ping` listeners are installed.
2. Backend uses a shared `Arc<tokio::sync::watch::Sender<bool>>`. `ensure_dialog_window` resets it to `false` when building a new window.
3. Render path calls `wait_for_dialog_ready()` *before* `emit_to(...dialog:show)` — waits up to 3 s for the signal, then proceeds.
4. Reload-recovery path resets the flag and waits again before re-emitting, so the same race can't recur.

Existing ack contract stays as the second line of defence.

## Test plan

- [x] `cargo check` — green
- [x] `svelte-check` — 0 errors
- [ ] CI green
- [ ] Tester: install 0.4.30, drag the setup window from the title bar (visible label \"aiui\"). Drag the dialog window from its title bar.
- [ ] Tester: trigger first ask/form of a session. Trace should show `dialog ready (pre-emit) after Xms` before `emitted dialog:show`. No 500 ms ack timeout, no \"reloading webview\".