### PR TITLE
fix: multi-instance race + shared-forward false-positive (v0.4.33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.33] — 2026-05-04
+
+### Fixed
+
+- **Multi-instance race that produced empty-message connection
+  resets is structurally tied off.** Trace from 2026-05-04 13:06
+  showed two aiui-app processes alive at the same time: one bound
+  the lifetime socket + HTTP port :7777, the other competed for
+  every `ssh -NTR` and fell into shared-forward mode talking to
+  itself. Tool calls landed on whichever happened to answer first;
+  on every transition the in-flight one reset its connection
+  (`RemoteProtocolError("")`). The 0.4.31 fix made that error
+  diagnosable; this fix makes it not happen.
+
+  Three structural changes, none of them quick-wins:
+
+  1. **`/probe` carries identity now.** Response includes our pid
+     and `AIUI_GIT_SHA` alongside `aiui: true`. The
+     tunnel-manager's strict-match decision (new
+     `probe_response_is_self`) treats *any* response that doesn't
+     carry our own pid + sha as foreign — even if it's a valid
+     aiui that just happens to share our token. Foreign responses
+     no longer trigger the shared-forward poll mode that hijacked
+     tool calls onto the wrong instance.
+  2. **Lifetime socket is single-instance-strict.** When the GUI
+     starts up and the socket path already accepts connections
+     (= another aiui owns it), we exit cleanly with `app.exit(1)`
+     instead of `remove_file`'ing the live owner's listener out
+     from under it. Stale leftovers (post-crash sockets that don't
+     accept) are detected by a connect-probe and only then
+     removed. The probe + bind path also exits on bind-failure
+     (race-condition coverage). Mirrors the v0.4.25 hardening that
+     already exists for HTTP :7777.
+  3. **Tunnel-manager dedup confirmed.** `TunnelManager::ensure`
+     was already idempotent per host (HashMap key check); reviewed
+     and verified in this fix to confirm there's no second path
+     for spawning duplicate `ssh -NTR` tasks.
+
+  Six new unit tests cover `probe_response_is_self`: self-match,
+  pid-mismatch, sha-mismatch, legacy responses without pid/sha,
+  `aiui: false`, invalid JSON. All 58 lib tests green.
+
 ## [0.4.32] — 2026-05-04
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.32"
+version = "0.4.33"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.32"
+version = "0.4.33"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -200,9 +200,14 @@ async fn ping() -> &'static str {
 /// Authenticated probe used by the tunnel-manager's shared-forward
 /// detection. Unlike /ping, this requires the bearer token, so it
 /// distinguishes "another aiui with our token is forwarding the port"
-/// from "some random process on :7777 is answering". Without this
-/// distinction a malicious squatter could mask a port-takeover by
-/// answering "pong" and aiui would keep showing connected-shared.
+/// from "some random process on :7777 is answering".
+///
+/// Since 0.4.33: response carries `pid` and `build_sha` so the calling
+/// tunnel-manager can verify *its own* aiui is on the other end vs. a
+/// concurrent second aiui-app instance with the same token (the case
+/// that produced the 2026-05-04 connection-reset incident — two
+/// companions, both with the user's token, indistinguishable from
+/// `aiui: true` alone).
 async fn probe(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -217,6 +222,8 @@ async fn probe(
     Json(serde_json::json!({
         "aiui": true,
         "version": env!("CARGO_PKG_VERSION"),
+        "pid": std::process::id(),
+        "build_sha": env!("AIUI_GIT_SHA"),
     }))
     .into_response()
 }

--- a/companion/src-tauri/src/lifetime.rs
+++ b/companion/src-tauri/src/lifetime.rs
@@ -47,12 +47,50 @@ impl LifetimeStats {
 /// grace period once all clients are gone. Increments/decrements the shared
 /// `conns` counter on every connect/disconnect so `/health` can report the
 /// live child count without polling.
+///
+/// Multi-instance hardening (since 0.4.33): if the socket path already
+/// answers a connection, another aiui-app is alive and we are the
+/// duplicate — exit immediately rather than racing for ownership. The
+/// previous behaviour (`remove_file` then `bind`) silently tore the
+/// existing instance's listener out from under it on every dup-launch,
+/// which is how the 2026-05-04 dual-companion incident produced reset
+/// connections in the first place.
 pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
-    let _ = std::fs::remove_file(&sock);
+    if sock.exists() {
+        // Probe whether the existing socket is live (another aiui is
+        // listening) or a stale leftover from a crashed previous run.
+        // A live listener accepts the connection; a stale path returns
+        // ENOENT / ECONNREFUSED.
+        match tokio::net::UnixStream::connect(&sock).await {
+            Ok(stream) => {
+                drop(stream);
+                trace(&format!(
+                    "lifetime: another aiui already serves {} — exiting (multi-instance)",
+                    sock.display()
+                ));
+                let app_for_exit = app.clone();
+                let _ = app
+                    .run_on_main_thread(move || app_for_exit.exit(1));
+                return;
+            }
+            Err(_) => {
+                // Stale; safe to remove and re-bind.
+                let _ = std::fs::remove_file(&sock);
+            }
+        }
+    }
     let listener = match UnixListener::bind(&sock) {
         Ok(l) => l,
         Err(e) => {
-            trace(&format!("lifetime: bind {} failed: {e}", sock.display()));
+            // Bind failed despite the existence check above — race
+            // condition, another instance grabbed it between our probe
+            // and our bind. Same conclusion: we're the duplicate, exit.
+            trace(&format!(
+                "lifetime: bind {} failed: {e} — exiting (multi-instance race)",
+                sock.display()
+            ));
+            let app_for_exit = app.clone();
+            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
             return;
         }
     };

--- a/companion/src-tauri/src/tunnel.rs
+++ b/companion/src-tauri/src/tunnel.rs
@@ -121,15 +121,24 @@ impl TunnelManager {
 /// aren't ssh-ing per second.
 const SHARED_FORWARD_POLL_SECS: u64 = 30;
 
-/// Ask the remote whether localhost:`port` is already answering `/ping` from
-/// aiui. Returns Some(true) only when an *authenticated* probe to the
-/// remote-side port confirms a same-token aiui is responding (the typical
-/// stale-sshd-sess case where our reverse-forward keeps tunneling to *our*
-/// aiui through a zombie session). Returns Some(false) on a clean "port
-/// is empty" or "answering process isn't aiui or has wrong token".
-/// Returns None when ssh itself failed to connect at all (different
-/// failure mode than "port unreachable") so the retry loop can stay
-/// patient instead of flipping state on every blip.
+/// Ask the remote whether localhost:`port` is already answering `/probe`
+/// from *our own* aiui. Returns:
+///
+/// - `Some(true)` only when the responder is identifiably *us* — same
+///   pid + same compile-time `build_sha`. That's the only legitimate
+///   shared-forward case (stale-sshd-sess that's still tunneling back
+///   to our process).
+/// - `Some(false)` for any other outcome a tunnel-manager can act on
+///   immediately:
+///   * port empty / curl 4xx (no aiui at all)
+///   * a *different* aiui instance answered (different pid or sha) —
+///     this is the multi-instance race; we mustn't accept it as
+///     "shared", or the second companion's tool calls would silently
+///     route to the first
+///   * some other authed-but-unrelated service answered
+/// - `None` when ssh itself failed to connect at all — different
+///   failure mode than "port unreachable", so the retry loop stays
+///   patient instead of flipping state on every blip.
 ///
 /// Token source: `~/.config/aiui/token` on the *remote* host (scp'd
 /// there at remote-registration time). If the file is missing on the
@@ -140,7 +149,7 @@ async fn probe_remote_shared_forward(host: &str, port: u16) -> Option<bool> {
     // Read the token *on the remote* and auth-bind the curl in one shell
     // command so the token never appears in our local argv. -f makes curl
     // return non-zero on 4xx/5xx (so 401 = not-shared); -m 3 caps total
-    // time; --json-out marker makes the success body easy to recognize.
+    // time.
     let cmd = format!(
         "T=$(cat ~/.config/aiui/token 2>/dev/null) && \
          [ -n \"$T\" ] && \
@@ -160,11 +169,8 @@ async fn probe_remote_shared_forward(host: &str, port: u16) -> Option<bool> {
         .await;
     match out {
         Ok(o) if o.status.success() => {
-            // Body must be JSON containing `"aiui":true` — otherwise some
-            // other authed-but-unrelated service answered. (Defensive:
-            // /probe is ours, but be paranoid.)
             let body = String::from_utf8_lossy(&o.stdout);
-            Some(body.contains("\"aiui\":true") || body.contains("\"aiui\": true"))
+            Some(probe_response_is_self(&body))
         }
         Ok(o) => {
             // ssh ran, but the remote command failed (curl 401, port
@@ -179,6 +185,29 @@ async fn probe_remote_shared_forward(host: &str, port: u16) -> Option<bool> {
         }
         Err(_) => None,
     }
+}
+
+/// Pure decision: given the raw `/probe` response body, decide whether
+/// it came from *this* aiui instance (same pid + same build SHA). Any
+/// other valid aiui response (different pid, different sha, or an old
+/// version that doesn't ship pid/sha at all) is treated as foreign —
+/// the caller will not switch to shared-forward poll mode for it.
+///
+/// Pulled out as a pure function so it can be unit-tested without
+/// running ssh.
+fn probe_response_is_self(body: &str) -> bool {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    if !parsed.get("aiui").and_then(|v| v.as_bool()).unwrap_or(false) {
+        return false;
+    }
+    let body_pid = parsed.get("pid").and_then(|v| v.as_u64());
+    let body_sha = parsed.get("build_sha").and_then(|v| v.as_str());
+    let our_pid = std::process::id() as u64;
+    let our_sha = env!("AIUI_GIT_SHA");
+    matches!(body_pid, Some(p) if p == our_pid)
+        && matches!(body_sha, Some(s) if s == our_sha)
 }
 
 async fn run_tunnel(
@@ -346,5 +375,78 @@ async fn shared_forward_poll_loop(
                 return PollOutcome::Cancelled;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// We can't easily mock `std::process::id()` or `env!("AIUI_GIT_SHA")`,
+    /// so we read them through the same channel the function uses and
+    /// build the test body to match. Asymmetric cases (different pid /
+    /// sha) just plug in known-bogus values.
+    fn our_pid() -> u32 {
+        std::process::id()
+    }
+    fn our_sha() -> &'static str {
+        env!("AIUI_GIT_SHA")
+    }
+
+    #[test]
+    fn probe_self_match_returns_true() {
+        let body = format!(
+            r#"{{"aiui": true, "version": "0.4.x", "pid": {}, "build_sha": "{}"}}"#,
+            our_pid(),
+            our_sha()
+        );
+        assert!(probe_response_is_self(&body));
+    }
+
+    #[test]
+    fn probe_different_pid_returns_false() {
+        let bogus_pid = our_pid().wrapping_add(1);
+        let body = format!(
+            r#"{{"aiui": true, "pid": {}, "build_sha": "{}"}}"#,
+            bogus_pid,
+            our_sha()
+        );
+        assert!(!probe_response_is_self(&body));
+    }
+
+    #[test]
+    fn probe_different_sha_returns_false() {
+        let body = format!(
+            r#"{{"aiui": true, "pid": {}, "build_sha": "0000000000000000000000000000000000000000"}}"#,
+            our_pid()
+        );
+        assert!(!probe_response_is_self(&body));
+    }
+
+    #[test]
+    fn probe_legacy_response_without_pid_sha_returns_false() {
+        // Old aiui versions (≤ 0.4.32) ship the body without pid /
+        // build_sha. The strict matcher must treat those as foreign —
+        // we can't prove they're us, so we won't claim them as
+        // shared-forward owners. Otherwise a v0.4.32 zombie + v0.4.33
+        // primary would still race.
+        let body = r#"{"aiui": true, "version": "0.4.32"}"#;
+        assert!(!probe_response_is_self(body));
+    }
+
+    #[test]
+    fn probe_aiui_false_returns_false() {
+        let body = format!(
+            r#"{{"aiui": false, "pid": {}, "build_sha": "{}"}}"#,
+            our_pid(),
+            our_sha()
+        );
+        assert!(!probe_response_is_self(&body));
+    }
+
+    #[test]
+    fn probe_invalid_json_returns_false() {
+        assert!(!probe_response_is_self("not json"));
+        assert!(!probe_response_is_self(""));
     }
 }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.32"
+version = "0.4.33"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Closes the 2026-05-04 dual-companion race that produced empty-string `RemoteProtocolError`s.

## Three structural fixes (no quick-wins, per the brief)

1. **`/probe` response now carries identity** — `pid` + `AIUI_GIT_SHA` alongside `aiui: true`. New `probe_response_is_self` strict-match treats anything else as foreign, including legacy `v0.4.32` responders that don't ship the new fields. Foreign responses no longer trigger shared-forward poll mode.
2. **Lifetime socket is single-instance-strict.** Probes the socket path on startup; if a live owner accepts, we `exit(1)` instead of `remove_file`'ing them out from under us. Stale paths get cleaned up only after the connect-probe confirms no live owner. Bind-failure path also exits. Mirrors the v0.4.25 HTTP-port hardening.
3. **Tunnel-manager dedup confirmed** — `TunnelManager::ensure` was already idempotent per host. Reviewed in this PR with no code change needed; comment trail in CHANGELOG so a future reader doesn't 'fix' what's already correct.

## Tests

Six new unit tests on `probe_response_is_self`: self-match, pid-mismatch, sha-mismatch, legacy response without pid/sha, `aiui:false` body, invalid JSON. `cargo test --lib` — 58/58 green.

## Why these three together

The trace showed all three vectors active simultaneously: socket race (Address-already-in-use), token-only probe match (shared-forward false positive), and the resulting per-instance reset chain. Fixing one without the others would shift the symptom rather than eliminate it. The three together make the multi-instance state structurally impossible to enter.