### PR TITLE
fix: dialog top-most + footer overlap + per-remote resync (v0.4.34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.34] — 2026-05-04
+
+### Added
+
+- **Per-remote resync button in Settings.** Each registered remote
+  now has a `⟳` icon button next to "Entfernen". Clicking it
+  triggers the same `patch_claude_code_config_remote` +
+  `kill_remote_mcp_stdio` sequence that runs in the background at
+  every aiui-app startup — but on demand, with the StepResult log
+  inline. Lets the user retry a sync that failed silently in the
+  background (e.g. the 2026-05-04 `dev@devhost: sweep failed` case)
+  without having to close + reopen aiui-app. Sweep failures appear
+  in the activity log immediately.
+
+### Fixed
+
+- **Dialog window now opens to the front.** When aiui runs in
+  Accessory mode (LSUIElement-style daemon, no Dock icon) macOS
+  doesn't bring its windows above other apps even with
+  `set_focus()`. An agent rendered a dialog and the user didn't see
+  it because Claude Desktop was covering it (reported 2026-05-04).
+  `ensure_dialog_window` now temporarily promotes the app to
+  Regular activation policy and marks the window
+  `always_on_top: true` for the first 800 ms — long enough to win
+  against any focused app, short enough that the user can Cmd+Tab
+  away naturally afterwards. `close_window` demotes back to
+  Accessory once the dialog finishes so we don't grow a permanent
+  Dock icon.
+- **Form footer no longer covers the last form field.** The
+  sticky footer's opaque background overlapped scroll-end content
+  because the container's `padding-bottom` didn't reserve the
+  footer's height. Bumped from 16 px to 75 px (footer ≈ 61 px +
+  buffer) with matching `margin-bottom: -75px` on the footer so it
+  still sits flush with the window edge. Visible in tester's
+  wireframe-test screenshot 2026-05-04.
+
+### Known issues
+
+- **Cold-start race on the second dialog after `close_window`** —
+  the first ask after a `confirm` returned `ReadError` (connection
+  reset mid-render); the immediate retry succeeded. Window-Ready
+  handshake from 0.4.30 doesn't fully cover the rebuild path. Not
+  patched in 0.4.34 because the trace doesn't yet show whether the
+  reset originates in the WebView rebuild, the SSH-tunnel layer,
+  or a remaining multi-instance edge — symptom-fix without root
+  diagnosis would risk masking it instead of fixing it. Tracked
+  for 0.4.35 once we have a reproduction with detailed render-path
+  trace.
+
 ## [0.4.33] — 2026-05-04
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.33"
+version = "0.4.34"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -91,11 +91,24 @@ async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
     // its custom close button (none today, but the contract should be
     // symmetric).
     let label = window.label().to_string();
+    let app = window.app_handle().clone();
     let _ = window.close();
-    // If that was the last visible window and nothing else is pending,
-    // the OS-level CloseRequested handler will fire next and decide
-    // whether the app should quit.
     log::debug!("[aiui] close_window: closed {label}");
+
+    // If that was the dialog window and no setup window is open,
+    // demote the app back to Accessory mode so we don't permanently
+    // grow a Dock icon. `ensure_dialog_window` promotes us to Regular
+    // for the dialog's lifetime; this is the matching demote.
+    #[cfg(target_os = "macos")]
+    if label == DIALOG_WINDOW_LABEL {
+        let setup_open = app
+            .get_webview_window(SETUP_WINDOW_LABEL)
+            .and_then(|w| w.is_visible().ok())
+            .unwrap_or(false);
+        if !setup_open {
+            let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+        }
+    }
     Ok(())
 }
 
@@ -453,6 +466,41 @@ async fn reinstall_skill() -> Result<Vec<setup::StepResult>, String> {
     Ok(results)
 }
 
+/// On-demand resync trigger for a single registered remote — wraps
+/// the same patch-pin + kill-stale-mcp-stdio sequence that runs in
+/// the background at every aiui-app startup. Surfaced as a per-remote
+/// button in Settings so the user can re-invoke it without restarting
+/// aiui (and see the StepResult log inline if a sweep fails).
+///
+/// Why this exists: 0.4.29's auto-resync on GUI-start is silent — if
+/// the SSH-side `pkill` fails (remote temporarily unreachable) the
+/// stale subprocess keeps running with the previous version. Without
+/// a manual trigger, the user would have to close + reopen aiui-app
+/// to retry. v0.4.34 adds the on-demand path.
+#[tauri::command]
+async fn resync_remote(
+    host_alias: String,
+) -> Result<Vec<setup::StepResult>, String> {
+    let our_version = env!("CARGO_PKG_VERSION");
+    // Re-pin in `~/.claude.json` on the remote (idempotent — if
+    // already pinned, no rewrite, returns AlreadyCurrent).
+    let (pin_step, patch) = setup::patch_claude_code_config_remote(
+        &host_alias,
+        None,
+        our_version,
+    );
+    let mut results = vec![pin_step];
+    // Sweep stale aiui-mcp children only when the pin actually
+    // changed (or unconditionally? — yes, unconditionally on
+    // user-triggered resync, because the user wouldn't click resync
+    // unless they suspect drift). On unconditional sweep: kills any
+    // running aiui-mcp regardless of pin state, which is what the
+    // user wants from a "force fresh" button.
+    let _ = patch;  // not used here, but kept for tracing
+    results.push(setup::kill_remote_mcp_stdio(&host_alias));
+    Ok(results)
+}
+
 #[tauri::command]
 async fn remove_remote(
     host_alias: String,
@@ -581,10 +629,35 @@ pub(crate) fn build_setup_window(
 pub(crate) fn ensure_dialog_window(
     app: &tauri::AppHandle,
 ) -> tauri::Result<tauri::WebviewWindow> {
+    // Promote the app from Accessory to Regular for the duration of the
+    // dialog. In Accessory mode (LSUIElement-style daemon, no Dock icon)
+    // macOS won't bring our windows to the front above other apps even
+    // with `set_focus()` — the agent renders a dialog and the user
+    // doesn't see it because Claude Desktop covers it. Promoting to
+    // Regular for the dialog window restores normal front/focus
+    // behaviour; we drop back to Accessory in `close_window` once the
+    // dialog finishes so we don't permanently grow a Dock icon.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+    }
     if let Some(win) = app.get_webview_window(DIALOG_WINDOW_LABEL) {
         let _ = win.show();
         let _ = win.set_focus();
         let _ = win.unminimize();
+        // Briefly mark the window always-on-top to win against any
+        // app that's grabbed focus in the meantime, then lift the
+        // flag so the user can naturally Cmd+Tab away later. 800 ms
+        // is enough for the activation to settle without leaving a
+        // sticky front-most window.
+        let _ = win.set_always_on_top(true);
+        let app_for_lift = app.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(800));
+            if let Some(w) = app_for_lift.get_webview_window(DIALOG_WINDOW_LABEL) {
+                let _ = w.set_always_on_top(false);
+            }
+        });
         return Ok(win);
     }
     // Window is being built fresh — its frontend listeners aren't up
@@ -618,7 +691,23 @@ pub(crate) fn ensure_dialog_window(
     .decorations(true)
     .disable_drag_drop_handler()
     .visible(true)
+    .always_on_top(true)
     .build()
+    .map(|win| {
+        // Fresh dialog windows also get the same lift-after-800 ms
+        // treatment as the reused-window branch above. The
+        // always_on_top flag from the builder ensures the window
+        // appears above everything; we drop it shortly after so
+        // Cmd+Tab works normally afterwards.
+        let app_for_lift = app.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(800));
+            if let Some(w) = app_for_lift.get_webview_window(DIALOG_WINDOW_LABEL) {
+                let _ = w.set_always_on_top(false);
+            }
+        });
+        win
+    })
 }
 
 /// True when no aiui window is currently visible to the user. Used by
@@ -773,6 +862,7 @@ pub fn run() {
             status,
             add_remote,
             remove_remote,
+            resync_remote,
             reinstall_skill,
             repair_skill,
             restart_claude_desktop,

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -693,7 +693,7 @@ pub(crate) fn ensure_dialog_window(
     .visible(true)
     .always_on_top(true)
     .build()
-    .map(|win| {
+    .inspect(|_win| {
         // Fresh dialog windows also get the same lift-after-800 ms
         // treatment as the reused-window branch above. The
         // always_on_top flag from the builder ensures the window
@@ -706,7 +706,6 @@ pub(crate) fn ensure_dialog_window(
                 let _ = w.set_always_on_top(false);
             }
         });
-        win
     })
 }
 

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/app.css
+++ b/companion/src/app.css
@@ -73,6 +73,15 @@ button {
   box-shadow: var(--shadow-sm);
   transition: background 0.12s ease, border-color 0.12s ease, transform 0.08s ease, box-shadow 0.12s ease;
 }
+/* Compact icon button for inline actions (resync per remote, etc.).
+   Same chrome as a normal button but square + smaller, font-size up
+   so the glyph reads at a glance. v0.4.34 resync feature. */
+button.icon-button {
+  padding: 4px 8px;
+  min-width: 28px;
+  font-size: 14px;
+  line-height: 1;
+}
 button:hover:not(:disabled) {
   background: linear-gradient(180deg,
     color-mix(in srgb, var(--surface-raised) 95%, var(--accent)),
@@ -168,8 +177,16 @@ label {
   /* Native title bar handles the top-of-window real estate now (see
      v0.4.30 drag fix). Content can sit close to the title-bar
      boundary; 14 px gives visual breathing room without wasting
-     vertical space. */
-  padding: 14px 20px 16px 20px;
+     vertical space.
+
+     Bottom padding is sized to the sticky-footer's combined height
+     (12 padding-top + ~32 button + 16 padding-bottom + 1 border ≈
+     61 px) plus a 14 px buffer so the last form field doesn't get
+     covered by the footer's opaque background when the content
+     scrolls to its end. The footer below uses a matching negative
+     margin-bottom to break out of this padding and sit flush with
+     the window edge. v0.4.34 footer-overlap fix. */
+  padding: 14px 20px 75px 20px;
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
@@ -216,12 +233,15 @@ label {
   border-top: 1px solid var(--border);
   /* Pull-out below the container's bottom padding so the border sits
      flush with the window edge while the buttons keep their breathing
-     room above. */
+     room above. v0.4.34: bumped from -16 to -75 to match the
+     container's increased padding-bottom (footer-height reservation).
+     Without this match, the last form field would still get covered
+     by the sticky footer's opaque background at scroll-end. */
   margin-left: -20px;
   margin-right: -20px;
   padding-left: 20px;
   padding-right: 20px;
-  margin-bottom: -16px;
+  margin-bottom: -75px;
   padding-bottom: 16px;
 }
 

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -45,6 +45,7 @@
     "remotes.add.button": "Einrichten",
     "remotes.add.hint": "Trägt Reverse-Tunnel in ~/.ssh/config ein, kopiert den Auth-Token per scp zum Host und startet den Tunnel sofort.",
     "remotes.remove": "Entfernen",
+    "remotes.resync.tooltip": "Pin neu setzen + alte aiui-mcp-Subprozesse killen (auf Remote)",
     "log.title": "Zuletzt",
     "tunnel.connected": "verbunden",
     "tunnel.connected_shared": "verbunden (geteilter Forward)",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -45,6 +45,7 @@
     "remotes.add.button": "Set up",
     "remotes.add.hint": "Adds the reverse tunnel to ~/.ssh/config, scp's the auth token to the host, and starts the tunnel.",
     "remotes.remove": "Remove",
+    "remotes.resync.tooltip": "Re-pin + kill stale aiui-mcp children (on remote)",
     "log.title": "Recent",
     "tunnel.connected": "connected",
     "tunnel.connected_shared": "connected (shared forward)",

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -93,6 +93,17 @@
     }
   }
 
+  async function resyncRemote(host: string) {
+    busy = true;
+    try {
+      const results = await invoke<StepResult[]>("resync_remote", { hostAlias: host });
+      pushLog(results);
+      await refresh();
+    } finally {
+      busy = false;
+    }
+  }
+
   async function doUninstall() {
     busy = true;
     try {
@@ -381,6 +392,13 @@
                 <code>{h}</code>
                 <div class="tunnel-status {tunnel.tone}">{tunnel.text}</div>
               </div>
+              <button
+                class="icon-button"
+                onclick={() => resyncRemote(h)}
+                disabled={busy}
+                title={$_("settings.remotes.resync.tooltip")}
+                aria-label={$_("settings.remotes.resync.tooltip")}
+              >⟳</button>
               <button onclick={() => removeRemote(h)} disabled={busy}
                 >{$_("settings.remotes.remove")}</button
               >

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.33"
+version = "0.4.34"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Three UX-polish + reliability fixes from the 2026-05-04 test session, in one release.

| # | Fix | Files |
|---|---|---|
| **1** | Dialog window opens to the front via temporary Activation::Regular + 800ms always_on_top, demoted back to Accessory in close_window | lib.rs |
| **2** | Form footer no longer overlaps last field at scroll-end (container padding-bottom 16→75 px, footer margin -16→-75 px) | app.css |
| **3** | Per-remote resync button (⟳) in Settings: triggers patch + kill-stale-mcp-stdio on demand, log inline | lib.rs, Settings.svelte, i18n |

## Why these three together

All three observed in the same test session. Tester used keyword "Substanz, nicht Quick-Wins" — these are root-fixes, not pflasters:
- Activation-policy promotion is the macOS-canonical way to surface an Accessory-app window, not a hack.
- Footer-overlap is a CSS-layout root cause (padding doesn't reserve footer height); the fix matches container/footer arithmetic explicitly with matching tokens.
- Resync button gives the user a recovery path for the silent-sweep-failure case structurally rather than asking for SSH commands.

## What's intentionally NOT in this release

- **Cold-start race on the second dialog after close_window** (first ask returned ReadError, retry succeeded). Window-Ready handshake from 0.4.30 doesn't fully cover the rebuild path. Without a render-path-trace pinpointing whether the reset originates in the WebView rebuild, SSH-tunnel layer, or a remaining multi-instance edge, a symptom-fix would mask rather than fix. Documented in CHANGELOG under "Known issues" → 0.4.35.
- **Versions per remote inline display.** Wanted by the user; deferred to 0.4.35 because it needs a separate architecture call (display the *pin* version, the *running subprocess* version via SSH probe, or both?). Resync button covers the immediate recovery need.

## Test plan

- [x] cargo check — green
- [x] svelte-check — 0 errors
- [ ] CI green
- [ ] Manual: install 0.4.34, agent renders dialog → window opens above Claude Desktop
- [ ] Manual: form with content overflowing the window → last field visible above the footer at scroll-end
- [ ] Manual: ⟳ on a remote → activity log shows pin status + sweep result; if sweep failed, error message inline