### PR TITLE
fix: settings overlap + plain-language tooltip (v0.4.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.35] — 2026-05-04
+
+### Fixed
+
+- **Settings window's "Add remote" input no longer hides behind the
+  footer.** The 0.4.34 footer-overlap fix bumped `.container`'s
+  `padding-bottom` to 75 px globally, plus matching negative
+  `margin-bottom` on `.footer`. That was correct for Form.svelte
+  (which has many fields and benefits from the reservation), but
+  broke Settings.svelte: the "Neuen Remote hinzufügen" input
+  section sits right above the footer there and got pushed under
+  it. Reverted both globals to the original values (16 / -16 px)
+  and moved the height-reservation **into** Form.svelte as a local
+  `.form-footer-spacer` div placed immediately before the footer.
+  Settings stays untouched, Form keeps its scroll-end clearance.
+- **Resync-button tooltip in plain language.** The 0.4.34 string
+  ("Pin neu setzen + alte aiui-mcp-Subprozesse killen") was
+  implementation jargon. Now it's user-facing wording: "aiui-
+  Verbindung zu diesem Host erneuern" / "Refresh aiui connection
+  on this host". The button still does the same patch + kill
+  sequence; the user just doesn't have to know that.
+
 ## [0.4.34] — 2026-05-04
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.34"
+version = "0.4.35"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/app.css
+++ b/companion/src/app.css
@@ -179,14 +179,14 @@ label {
      boundary; 14 px gives visual breathing room without wasting
      vertical space.
 
-     Bottom padding is sized to the sticky-footer's combined height
-     (12 padding-top + ~32 button + 16 padding-bottom + 1 border ≈
-     61 px) plus a 14 px buffer so the last form field doesn't get
-     covered by the footer's opaque background when the content
-     scrolls to its end. The footer below uses a matching negative
-     margin-bottom to break out of this padding and sit flush with
-     the window edge. v0.4.34 footer-overlap fix. */
-  padding: 14px 20px 75px 20px;
+     Bottom padding kept at 16 px (matching the original layout). A
+     reservation for the sticky footer's height has to be local to
+     the component that uses it — Form.svelte adds a footer-spacer
+     before its `<div class="footer">`. The 0.4.34 attempt to bake
+     the reservation into `.container` here broke Settings.svelte's
+     "add remote" section by pushing it under the same footer's
+     overlap zone. v0.4.35 reverts that back. */
+  padding: 14px 20px 16px 20px;
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
@@ -233,16 +233,27 @@ label {
   border-top: 1px solid var(--border);
   /* Pull-out below the container's bottom padding so the border sits
      flush with the window edge while the buttons keep their breathing
-     room above. v0.4.34: bumped from -16 to -75 to match the
-     container's increased padding-bottom (footer-height reservation).
-     Without this match, the last form field would still get covered
-     by the sticky footer's opaque background at scroll-end. */
+     room above. (v0.4.35 reverted from -75 back to -16 — see the
+     container comment above.) */
   margin-left: -20px;
   margin-right: -20px;
   padding-left: 20px;
   padding-right: 20px;
-  margin-bottom: -75px;
+  margin-bottom: -16px;
   padding-bottom: 16px;
+}
+
+/* Form-local reservation for the sticky footer's height. Sits as
+   a sibling immediately before `<div class="footer">` in
+   Form.svelte. When the content overflows the container, this
+   spacer means scroll-end is ~70 px below the last real field, so
+   the footer's opaque background no longer overlaps it. When the
+   content fits, the spacer is invisible (no background, no
+   border) and `margin-top: auto` on the footer still pushes it
+   against the window edge. v0.4.35 form-overlap fix. */
+.form-footer-spacer {
+  height: 70px;
+  flex-shrink: 0;
 }
 
 code {

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -45,7 +45,7 @@
     "remotes.add.button": "Einrichten",
     "remotes.add.hint": "Trägt Reverse-Tunnel in ~/.ssh/config ein, kopiert den Auth-Token per scp zum Host und startet den Tunnel sofort.",
     "remotes.remove": "Entfernen",
-    "remotes.resync.tooltip": "Pin neu setzen + alte aiui-mcp-Subprozesse killen (auf Remote)",
+    "remotes.resync.tooltip": "aiui-Verbindung zu diesem Host erneuern",
     "log.title": "Zuletzt",
     "tunnel.connected": "verbunden",
     "tunnel.connected_shared": "verbunden (geteilter Forward)",

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -45,7 +45,7 @@
     "remotes.add.button": "Set up",
     "remotes.add.hint": "Adds the reverse tunnel to ~/.ssh/config, scp's the auth token to the host, and starts the tunnel.",
     "remotes.remove": "Remove",
-    "remotes.resync.tooltip": "Re-pin + kill stale aiui-mcp children (on remote)",
+    "remotes.resync.tooltip": "Refresh aiui connection on this host",
     "log.title": "Recent",
     "tunnel.connected": "connected",
     "tunnel.connected_shared": "connected (shared forward)",

--- a/companion/src/lib/widgets/Form.svelte
+++ b/companion/src/lib/widgets/Form.svelte
@@ -688,6 +688,11 @@
     {/each}
   </div>
 
+  <!-- Spacer reserves footer height inside the scroll flow so the
+       last form field never gets overlapped by the sticky footer at
+       scroll-end. Belongs to this component, not to .container —
+       Settings has its own footer-vs-content geometry. v0.4.35. -->
+  <div class="form-footer-spacer" aria-hidden="true"></div>
   <div class="footer">
     {#each actions as a}
       <button

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.34"
+version = "0.4.35"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Two regressions from 0.4.34, both root-fixed.

**1. Footer overlap was over-corrected.** 0.4.34 baked a 75 px reservation into `.container` globally — fine for Form.svelte (many fields), broke Settings.svelte (the 'Add remote' input got pushed under the footer). Reverted globals to 16/-16 and moved the reservation into Form.svelte as a local `.form-footer-spacer` div before its footer. Right place: whichever component owns the overflow problem.

**2. Resync-button tooltip is plain language now.** Was 'Pin neu setzen + alte aiui-mcp-Subprozesse killen' — implementation jargon. Now: 'aiui-Verbindung zu diesem Host erneuern' / 'Refresh aiui connection on this host'.

No code change to the resync command. Versions bumped to 0.4.35 (PyPI/Tauri lockstep).