### PR TITLE
fix: dialog-close keeps GUI alive + diagnostic unreachable message (v0.4.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.36] — 2026-05-04
+
+### Fixed
+
+- **Dialog submit no longer kills the GUI process.** A successful
+  form submit destroyed the dialog window via `close_window`, which
+  triggered the multi-window `CloseRequested` handler from 0.4.25.
+  That handler quit the app whenever no other window was visible —
+  and after a typical agent flow the setup window is closed, so the
+  dialog window *was* the last visible window. Result: the GUI died
+  ~20 ms after `got response` (trace 2026-05-04 16:11:42.197 "GUI is
+  gone, will relaunch"). The follow-up tool call then sat 8 s in
+  `wait_for_aiui` waiting for the auto-resurrect path to bring the
+  HTTP server back, and frequently timed out before that succeeded.
+  The dialog window is now *never* a quit trigger — it is a
+  per-call ephemeral surface, recreated on demand. The setup window
+  retains the original quit behaviour but additionally checks the
+  attached-MCP-children counter, so the GUI stays alive headless as
+  long as any MCP-stdio child is connected over the lifetime
+  socket.
+- **`aiui not reachable` tool-call response now diagnostic.** When
+  `wait_for_aiui` times out, the response previously said only "not
+  reachable on localhost:7777, open aiui from /Applications" —
+  unhelpful for the dominant real causes (multiple aiui calls in
+  one assistant turn, stale dialog window from a prior session,
+  parallel Claude session holding the dialog). The agent then
+  relayed that text verbatim and the user re-opened an aiui that
+  was already running. The new message lists the four realistic
+  causes in priority order, hints at retry-vs-tell-the-user for
+  each, and detects local-vs-remote-host context so the SSH-tunnel
+  branch only appears on remotes. Phrased as agent-facing guidance
+  with an explicit "do not relay this verbatim" instruction.
+
 ## [0.4.35] — 2026-05-04
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.35"
+version = "0.4.36"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -1061,34 +1061,45 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| {
-            // Multi-window lifecycle (v0.4.25):
+            // Multi-window lifecycle (v0.4.25, revised v0.4.36):
             //
             // The setup window and the dialog window are independent.
             // Closing one shouldn't kill the other — and definitely
-            // shouldn't kill an in-flight dialog the agent is still
-            // waiting on.
+            // shouldn't kill the GUI process while the lifetime
+            // socket still has attached MCP-stdio children depending
+            // on it.
             //
-            //  • Red X on setup window: setup goes away. If a dialog is
-            //    visible *or* something is pending, the app stays alive.
-            //    Otherwise the app quits, and `mcp_attach`'s
+            //  • Red X on setup window: setup goes away. If no other
+            //    window is visible AND no MCP-stdio children are
+            //    attached, the app quits and `mcp_attach`'s
             //    auto-resurrect path brings it back on the next tool
-            //    call. Same UX promise as before, just without the
-            //    cross-window damage.
+            //    call. As long as a child is attached, we stay alive
+            //    headless — the lifetime grace timer (60s after the
+            //    last child detaches) is the only legitimate
+            //    "nobody needs aiui anymore" signal.
             //  • Red X on dialog window: the dialog is treated as
-            //    cancelled (the frontend's CloseRequested-listener fires
-            //    `dialog_cancel` first; this branch runs after).
-            //    Otherwise identical to setup-window close.
+            //    cancelled (the frontend's CloseRequested-listener
+            //    fires `dialog_cancel` first; this branch runs after).
+            //    NEVER quits the app, regardless of any-visible state.
+            //    The dialog window is per-call ephemeral — destroyed
+            //    after every submit/cancel by `close_window`. Quitting
+            //    the GUI here would tear down the HTTP server while
+            //    the agent's tool call is still parsing the response,
+            //    producing the 8s `wait_for_aiui` timeouts the user
+            //    saw on 2026-05-04 (trace 16:11:42.197 "GUI is gone"
+            //    20 ms after a successful form submit).
             if let tauri::WindowEvent::CloseRequested { .. } = event {
                 let app = window.app_handle();
                 let closed_label = window.label().to_string();
-                // Tauri lets the close proceed unless we set
-                // api.prevent_close(); we want the close to happen.
-                // Schedule the quit-check on the next tick so it runs
-                // *after* this window is actually destroyed.
+                if closed_label == DIALOG_WINDOW_LABEL {
+                    log::debug!(
+                        "[aiui] dialog window closed — staying alive for further tool calls"
+                    );
+                    return;
+                }
+                // Setup window: quit only if nothing else needs us.
                 let app_for_check = app.clone();
                 let _ = app.run_on_main_thread(move || {
-                    // Filter out the just-closed window — at this point
-                    // it may still appear in the registry briefly.
                     let any_visible = app_for_check
                         .webview_windows()
                         .iter()
@@ -1096,14 +1107,18 @@ pub fn run() {
                             label.as_str() != closed_label
                                 && w.is_visible().unwrap_or(false)
                         });
-                    if !any_visible {
+                    let attached = app_for_check
+                        .try_state::<Arc<lifetime::LifetimeStats>>()
+                        .map(|s| s.child_count())
+                        .unwrap_or(0);
+                    if !any_visible && attached == 0 {
                         log::info!(
-                            "[aiui] last visible window ({closed_label}) closed — quitting; auto-resurrect will bring us back on next tool call"
+                            "[aiui] setup window closed and no MCP-stdio children attached — quitting; auto-resurrect will bring us back on next tool call"
                         );
                         app_for_check.exit(0);
                     } else {
                         log::debug!(
-                            "[aiui] {closed_label} closed, but other windows still visible — staying alive"
+                            "[aiui] setup window closed, staying alive (visible_others={any_visible}, attached_children={attached})"
                         );
                     }
                 });

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -381,19 +381,50 @@ async fn wait_for_aiui(http: &reqwest::Client, cfg: &AppConfig) -> bool {
     }
 }
 
-/// Tool-call response signaling that the local aiui companion isn't
-/// reachable. Phrased as user-facing guidance rather than a raw error
-/// because Claude tends to relay this verbatim to the user.
+/// Tool-call response signaling that the local aiui companion didn't
+/// answer `/ping` within `COLDSTART_WAIT`. Differentiates the realistic
+/// causes so the calling agent can choose between "retry once" and
+/// "tell the user something useful". v0.4.36 rewrite: the previous
+/// generic "not reachable on localhost:7777" was relayed verbatim by
+/// Claude even when the actual cause was contention (parallel session,
+/// stale dialog window, multiple aiui calls in one assistant turn) —
+/// none of which the user can fix by re-opening aiui.
 fn aiui_unreachable_result() -> Value {
+    let local = crate::lifetime::is_interactive_session();
+    let context_line = if local {
+        "You are running on the user's local Mac (no SSH session detected)."
+    } else {
+        "You are running on a remote dev host. aiui reaches the user's Mac \
+         via an SSH-reverse-tunnel on port 7777."
+    };
+    let text = format!(
+        "aiui companion did not answer /ping on localhost:7777 within 8 seconds.\n\
+         \n\
+         {context_line}\n\
+         \n\
+         Likely causes (in order of frequency):\n\
+         1. **Multiple aiui calls in one assistant turn.** The previous call \
+            held the dialog window; the second one raced ahead before the \
+            companion freed the slot. Retry the failing call once after a \
+            short wait — usually succeeds.\n\
+         2. **Stale dialog window from an earlier session.** A previous \
+            agent's dialog timed out or was orphaned and is still pinning \
+            the companion. Tell the user: \"please close any leftover aiui \
+            dialog windows on your Mac and try again.\"\n\
+         3. **A parallel Claude session is using aiui right now.** Two \
+            agents on the same Mac share one companion; only one dialog at \
+            a time. Either retry shortly or tell the user the other session \
+            is currently holding the dialog.\n\
+         4. **aiui is genuinely not running** (cold-start path). If you are \
+            on the user's Mac, ask them to open aiui from /Applications. If \
+            on a remote host, the SSH-reverse-tunnel may be down — point \
+            them to aiui Settings → Connections.\n\
+         \n\
+         Do not relay this entire message to the user verbatim — pick the \
+         likely cause and phrase it plainly."
+    );
     json!({
-        "content": [{
-            "type": "text",
-            "text": "aiui companion is not reachable on localhost:7777. \
-                     If you're on the local machine: open aiui from /Applications. \
-                     If you're on a remote dev host: the SSH-reverse-tunnel to your \
-                     Mac is down — check that aiui is running there and the tunnel \
-                     in aiui Settings shows 'connected'."
-        }],
+        "content": [{ "type": "text", "text": text }],
         "isError": true
     })
 }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.35"
+version = "0.4.36"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- **Fix #1 — App-killer at dialog submit.** A successful form submit destroyed the dialog window via `close_window`, which triggered the multi-window `CloseRequested` handler from 0.4.25. That handler quit the app whenever no other window was visible, which after a normal agent flow meant the dialog window itself. Trace 2026-05-04 16:11:42 shows the GUI dying ~20 ms after `got response`. The follow-up tool call then sat 8 s in `wait_for_aiui` and frequently timed out before auto-resurrect could rebind the port. The dialog window is now never a quit trigger; the setup window additionally checks `LifetimeStats.child_count` so the GUI stays alive headless while any MCP-stdio child is attached.
- **Fix #2 — `aiui not reachable` response now diagnostic.** When `wait_for_aiui` times out, the response previously said only "not reachable on localhost:7777, open aiui from /Applications" — unhelpful for the dominant real causes (multiple aiui calls in one assistant turn, stale dialog window from a prior session, parallel Claude session holding the dialog). The agent then relayed that text verbatim and the user reopened an aiui that was already running. The new message lists the four realistic causes in priority order, hints at retry-vs-tell-the-user for each, detects local-vs-remote-host context so the SSH-tunnel branch only appears on remotes, and explicitly tells the agent not to relay the message verbatim.

After Fix #1 the `aiui_unreachable_result` path becomes a rare edge case (cold-start during user-driven X-close, multi-instance race), so Fix #2 is mostly future-proofing — but the user already saw the unhelpful message during 0.4.34/0.4.35 testing.

## Test plan

- [ ] Local build: `(cd companion && npx tauri build --target aarch64-apple-darwin)` — release build clean, `Info.plist` reports 0.4.36.
- [ ] Run a `confirm` then immediately a `form` from the same agent turn — both render, GUI process stays alive throughout (no "GUI is gone" line in `/tmp/aiui-trace.log`).
- [ ] Submit a form, wait 5 s, run another aiui call — succeeds within normal latency, no 8 s `wait_for_aiui` block.
- [ ] Close setup window with no MCP-stdio child attached → app quits as before; close it while a child is attached → app stays alive.
- [ ] Force `wait_for_aiui` to time out (kill aiui process during a tool call) — response text matches new diagnostic format with the 4-cause list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)