### PR TITLE
fix: render slot is single-occupancy; concurrent calls get 409 (v0.4.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here.
 
 ### Fixed
 
+- **Concurrent renders now reject with a 409 instead of evicting the
+  in-flight dialog.** `DialogState::register` ran a sweep + hard-cap
+  eviction before inserting, so a second `/render` call while a user
+  was still answering the first dialog would push the first entry's
+  oneshot to "evicted" *while the user was still looking at it* — and
+  the new dialog overlaid the same single window. That manifested as
+  a confused user, an evict-cancelled prior call, and a second
+  unexplained dialog. The new `try_register` rejects with a `BusyInfo`
+  carrying `pending_count` + `oldest_age_secs`; `/render` returns
+  `409 Conflict` with that body; `mcp.rs` translates the 409 into a
+  structured tool-call result that lists the three realistic causes
+  (multi-call-per-turn, stale window, parallel session) with
+  retry-vs-tell-user guidance for each. The companion now serves at
+  most one dialog at a time, structurally.
 - **Dialog submit no longer kills the GUI process.** A successful
   form submit destroyed the dialog window via `close_window`, which
   triggered the multi-window `CloseRequested` handler from 0.4.25.

--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -58,6 +58,16 @@ pub struct DialogStats {
     pub oldest_age_secs: Option<u64>,
 }
 
+/// Returned by `try_register` when a dialog is already in flight.
+/// Surfaced via /render as a 409 so the calling agent can distinguish
+/// "companion not reachable" from "companion is busy with someone
+/// else's dialog right now". v0.4.36.
+#[derive(Debug, Clone, Copy)]
+pub struct BusyInfo {
+    pub pending_count: usize,
+    pub oldest_age_secs: u64,
+}
+
 impl DialogState {
     pub fn new() -> Self {
         Self {
@@ -72,6 +82,13 @@ impl DialogState {
     /// Performs an opportunistic sweep before insert: TTL-expired entries
     /// are cancelled and removed, and if the hard cap would be exceeded
     /// the oldest entry is evicted. No background reaper is needed.
+    ///
+    /// As of v0.4.36 the production /render path uses `try_register`
+    /// instead, which rejects rather than evicts when a dialog is
+    /// already in flight. `register` is retained as the
+    /// hard-cap-defense fallback for tests and any future call site
+    /// that legitimately wants eviction semantics.
+    #[allow(dead_code)]
     pub fn register(
         &self,
     ) -> (
@@ -168,6 +185,74 @@ impl DialogState {
         }
     }
 
+    /// Like `register` but rejects with `BusyInfo` if a dialog is already
+    /// in flight after the TTL sweep. Used by `/render` so that two
+    /// parallel callers (multiple aiui calls in one assistant turn,
+    /// two Claude sessions hitting the same companion, a stale window
+    /// from a previous timeout) can't silently overlay each other —
+    /// the second caller gets a clear conflict response instead of
+    /// having its predecessor's dialog evicted underfoot. v0.4.36.
+    ///
+    /// `register` is kept for tests and for any future call site that
+    /// genuinely wants the eviction-based behaviour, but the
+    /// production /render path uses `try_register` exclusively.
+    pub fn try_register(
+        &self,
+    ) -> Result<
+        (
+            String,
+            oneshot::Receiver<DialogResult>,
+            oneshot::Receiver<()>,
+        ),
+        BusyInfo,
+    > {
+        let mut map = self.pending.lock().unwrap();
+
+        // Sweep TTL-expired entries first — those don't count as
+        // "in flight" any more. Same logic as `register`.
+        let now = Instant::now();
+        let expired: Vec<String> = map
+            .iter()
+            .filter(|(_, e)| now.duration_since(e.created_at) > DIALOG_TTL)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for stale_id in expired {
+            if let Some(entry) = map.remove(&stale_id) {
+                let _ = entry.result_tx.send(DialogResult {
+                    id: stale_id,
+                    cancelled: true,
+                    result: serde_json::Value::Null,
+                    reason: Some("ttl_expired".into()),
+                });
+            }
+        }
+
+        if !map.is_empty() {
+            let oldest_age_secs = map
+                .values()
+                .map(|e| now.duration_since(e.created_at).as_secs())
+                .max()
+                .unwrap_or(0);
+            return Err(BusyInfo {
+                pending_count: map.len(),
+                oldest_age_secs,
+            });
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let (result_tx, result_rx) = oneshot::channel();
+        let (ack_tx, ack_rx) = oneshot::channel();
+        map.insert(
+            id.clone(),
+            PendingEntry {
+                result_tx,
+                ack_tx: Some(ack_tx),
+                created_at: now,
+            },
+        );
+        Ok((id, result_rx, ack_rx))
+    }
+
     /// Snapshot for `/health` / diagnostics. Cheap: one mutex acquire.
     pub fn stats(&self) -> DialogStats {
         let map = self.pending.lock().unwrap();
@@ -227,6 +312,33 @@ mod tests {
         ack.blocking_recv().expect("first ack must arrive");
         // Second ack on the same id is a silent no-op.
         s.ack(&id);
+    }
+
+    #[test]
+    fn try_register_succeeds_when_empty() {
+        let s = DialogState::new();
+        let res = s.try_register();
+        assert!(res.is_ok());
+        assert_eq!(s.stats().orphan_count, 1);
+    }
+
+    #[test]
+    fn try_register_rejects_when_pending() {
+        let s = DialogState::new();
+        let (_id, _rx, _ack) = s.try_register().expect("first try_register");
+        let busy = s.try_register().expect_err("second try_register must be busy");
+        assert_eq!(busy.pending_count, 1);
+        // Registry still holds the original entry.
+        assert_eq!(s.stats().orphan_count, 1);
+    }
+
+    #[test]
+    fn try_register_succeeds_after_complete() {
+        let s = DialogState::new();
+        let (id, _rx, _ack) = s.try_register().expect("first");
+        s.complete(&id, serde_json::json!({"ok": true}));
+        let res = s.try_register();
+        assert!(res.is_ok());
     }
 
     #[test]

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -474,7 +474,34 @@ async fn render(
     // See companion/src-tauri/src/imageresolve.rs for failure modes.
     crate::imageresolve::resolve_image_srcs(&mut req.spec).await;
 
-    let (id, result_rx, ack_rx) = state.dialog.register();
+    // v0.4.36: try_register rejects when a dialog is already in flight
+    // instead of evicting the existing one. Two parallel callers — multi-
+    // call-per-turn, two Claude sessions, or a stale window from a prior
+    // timeout — would otherwise overlay each other in the single dialog
+    // window, with the older request's `oneshot` resolving as `evicted`
+    // exactly while the user was still looking at it. The 409 response
+    // gives the second caller a structured "busy" answer so the agent
+    // can choose to retry or tell the user the dialog is held by
+    // something else. Setup-window-driven UI calls don't go through
+    // /render at all, so this only governs agent dialog traffic.
+    let (id, result_rx, ack_rx) = match state.dialog.try_register() {
+        Ok(triple) => triple,
+        Err(busy) => {
+            trace(&format!(
+                "render: rejected — companion busy (pending={}, oldest_age={}s)",
+                busy.pending_count, busy.oldest_age_secs
+            ));
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": "busy",
+                    "pending_count": busy.pending_count,
+                    "oldest_age_secs": busy.oldest_age_secs,
+                })),
+            )
+                .into_response();
+        }
+    };
     trace(&format!("render: registered id={}", id));
     let dr = DialogRequest {
         id: id.clone(),

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -450,55 +450,61 @@ async fn tools_call(
     }
 
     let outcome = match name.as_str() {
-        "confirm" => render_dialog(
-            json!({
-                "kind": "confirm",
-                "title": args.get("title"),
-                "message": args.get("message"),
-                "header": args.get("header"),
-                "destructive": args.get("destructive").and_then(|v| v.as_bool()).unwrap_or(false),
-                "confirmLabel": args.get("confirm_label"),
-                "cancelLabel": args.get("cancel_label"),
-                "image": args.get("image")
-            }),
-            cfg,
-            http,
-        )
-        .await
-        .map(format_confirm_result),
+        "confirm" => dispatch_render(
+            render_dialog(
+                json!({
+                    "kind": "confirm",
+                    "title": args.get("title"),
+                    "message": args.get("message"),
+                    "header": args.get("header"),
+                    "destructive": args.get("destructive").and_then(|v| v.as_bool()).unwrap_or(false),
+                    "confirmLabel": args.get("confirm_label"),
+                    "cancelLabel": args.get("cancel_label"),
+                    "image": args.get("image")
+                }),
+                cfg,
+                http,
+            )
+            .await,
+            format_confirm_result,
+        ),
 
-        "ask" => render_dialog(
-            json!({
-                "kind": "ask",
-                "question": args.get("question"),
-                "header": args.get("header"),
-                "options": args.get("options"),
-                "multiSelect": args.get("multi_select").and_then(|v| v.as_bool()).unwrap_or(false),
-                "allowOther": args.get("allow_other").and_then(|v| v.as_bool()).unwrap_or(false)
-            }),
-            cfg,
-            http,
-        )
-        .await
-        .map(format_dialog_result),
+        "ask" => dispatch_render(
+            render_dialog(
+                json!({
+                    "kind": "ask",
+                    "question": args.get("question"),
+                    "header": args.get("header"),
+                    "options": args.get("options"),
+                    "multiSelect": args.get("multi_select").and_then(|v| v.as_bool()).unwrap_or(false),
+                    "allowOther": args.get("allow_other").and_then(|v| v.as_bool()).unwrap_or(false)
+                }),
+                cfg,
+                http,
+            )
+            .await,
+            format_dialog_result,
+        ),
 
-        "form" => render_dialog(
-            json!({
-                "kind": "form",
-                "title": args.get("title"),
-                "description": args.get("description"),
-                "header": args.get("header"),
-                "fields": args.get("fields"),
-                "tabs": args.get("tabs"),
-                "actions": args.get("actions"),
-                "submitLabel": args.get("submit_label"),
-                "cancelLabel": args.get("cancel_label")
-            }),
-            cfg,
-            http,
-        )
-        .await
-        .map(format_dialog_result),
+        "form" => dispatch_render(
+            render_dialog(
+                json!({
+                    "kind": "form",
+                    "title": args.get("title"),
+                    "description": args.get("description"),
+                    "header": args.get("header"),
+                    "fields": args.get("fields"),
+                    "tabs": args.get("tabs"),
+                    "actions": args.get("actions"),
+                    "submitLabel": args.get("submit_label"),
+                    "cancelLabel": args.get("cancel_label")
+                }),
+                cfg,
+                http,
+            )
+            .await,
+            format_dialog_result,
+        ),
 
         "aiui_health" => get_json(http, cfg, "/health").await.map(value_to_tool_text),
         "version" => get_json(http, cfg, "/version").await.map(value_to_tool_text),
@@ -535,12 +541,30 @@ fn base_url(cfg: &AppConfig) -> String {
     format!("http://127.0.0.1:{}", cfg.http_port)
 }
 
+/// Per-call dialog rendering can fail in two structurally different
+/// ways. v0.4.36 splits them so the tool dispatcher can convert
+/// `Busy` into a structured tool result (with retry-vs-tell-user
+/// guidance) instead of bubbling it up as a generic transport error
+/// the way "render http 409" used to.
+enum RenderError {
+    /// The companion answered 409 — another dialog is already in
+    /// flight. Carries the diagnostic counts the HTTP layer reported.
+    Busy {
+        pending_count: u64,
+        oldest_age_secs: u64,
+    },
+    /// Transport, parse, status-other-than-409, or token failures.
+    /// Surfaced as a generic "aiui tool error" to the agent, since
+    /// these are conditions the user actually has to act on.
+    Transport(String),
+}
+
 async fn render_dialog(
     spec: Value,
     cfg: &AppConfig,
     http: &reqwest::Client,
-) -> Result<Value, String> {
-    let token = load_token(cfg)?;
+) -> Result<Value, RenderError> {
+    let token = load_token(cfg).map_err(RenderError::Transport)?;
     let url = format!("{}/render", base_url(cfg));
     // Resolve any absolute / `~/`-rooted file paths in `src` /
     // `thumbnail` to `data:` URLs *here* — at the bridge — because
@@ -559,13 +583,80 @@ async fn render_dialog(
         .json(&body)
         .send()
         .await
-        .map_err(|e| format!("POST /render: {e}"))?;
+        .map_err(|e| RenderError::Transport(format!("POST /render: {e}")))?;
+    if resp.status() == reqwest::StatusCode::CONFLICT {
+        // Body shape from http::render: { error, pending_count, oldest_age_secs }.
+        let body = resp.json::<Value>().await.unwrap_or(Value::Null);
+        return Err(RenderError::Busy {
+            pending_count: body
+                .get("pending_count")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(1),
+            oldest_age_secs: body
+                .get("oldest_age_secs")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+        });
+    }
     if !resp.status().is_success() {
-        return Err(format!("render http {}", resp.status()));
+        return Err(RenderError::Transport(format!(
+            "render http {}",
+            resp.status()
+        )));
     }
     resp.json::<Value>()
         .await
-        .map_err(|e| format!("parse /render: {e}"))
+        .map_err(|e| RenderError::Transport(format!("parse /render: {e}")))
+}
+
+/// Tool-call response signaling that the companion is alive but
+/// already serving another dialog (multi-call-per-turn, second Claude
+/// session, stale window). Phrased as agent-facing guidance, parallel
+/// to `aiui_unreachable_result`.
+fn aiui_busy_result(pending_count: u64, oldest_age_secs: u64) -> Value {
+    let text = format!(
+        "aiui companion is busy serving another dialog right now \
+         (pending={pending_count}, oldest_age={oldest_age_secs}s).\n\
+         \n\
+         The companion intentionally serves only one dialog at a time. \
+         The other dialog is one of:\n\
+         1. **Your previous aiui call in this same assistant turn.** Tools \
+            in one turn run sequentially and the prior dialog hasn't been \
+            answered yet. Wait until the user answers, then issue the next \
+            call. Do not retry rapidly.\n\
+         2. **A stale dialog window from an earlier session** that the \
+            user never answered. Tell the user: \"please answer or close \
+            the leftover aiui dialog on your Mac, then I'll retry.\" The \
+            companion will sweep it automatically after 5 minutes.\n\
+         3. **A parallel Claude session is currently using aiui.** Either \
+            wait briefly and retry, or tell the user the other session \
+            holds the dialog right now.\n\
+         \n\
+         Do not relay this entire message to the user verbatim — pick the \
+         likely cause and phrase it plainly."
+    );
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": true
+    })
+}
+
+/// Dispatch a `render_dialog` outcome into a tool-call result. `Busy`
+/// becomes a successful tool call with `isError: true` and diagnostic
+/// guidance; `Transport` becomes an `Err` that `tools_call` then
+/// renders as the generic "aiui tool error: …" path.
+fn dispatch_render(
+    res: Result<Value, RenderError>,
+    formatter: fn(Value) -> Value,
+) -> Result<Value, String> {
+    match res {
+        Ok(v) => Ok(formatter(v)),
+        Err(RenderError::Busy {
+            pending_count,
+            oldest_age_secs,
+        }) => Ok(aiui_busy_result(pending_count, oldest_age_secs)),
+        Err(RenderError::Transport(s)) => Err(s),
+    }
 }
 
 async fn get_json(


### PR DESCRIPTION
## Summary

Companion of PR #116 in the same 0.4.36 cycle — completes the window-lifecycle bundle from this morning's hand-off.

The companion now serves **at most one dialog at a time, structurally.** A second `/render` call while another dialog is in flight gets a `409 Conflict` instead of evicting the live dialog underfoot.

- `dialog.rs`: new `try_register` returns `BusyInfo { pending_count, oldest_age_secs }` after the TTL sweep if any entry is still pending. The legacy `register` (eviction-based) is kept behind `#[allow(dead_code)]` for the `hard_cap_evicts_oldest` defense-in-depth test.
- `http.rs`: `/render` switches to `try_register` and translates `Err(BusyInfo)` into 409 + JSON body.
- `mcp.rs`: split `render_dialog` errors into `RenderError::Busy { … }` vs `RenderError::Transport(String)`. New `aiui_busy_result` returns an agent-facing `isError` result with three diagnostic causes (multi-call-per-turn, stale window, parallel session) and retry-vs-tell-user guidance for each. `dispatch_render` keeps the dispatch table at the call site readable.

This was Fix #3 from the original hand-off — the user remembered after PR #116 was already merged but before tagging 0.4.36, so it lands in the same release.

## Test plan

- [x] `cargo test --lib dialog::` — 3 new tests + existing 5 pass; `register` retained for the hard-cap test.
- [x] `cargo check` clean (no warnings after `#[allow(dead_code)]` on `register`).
- [ ] Local: trigger two `confirm` calls back-to-back from one assistant turn — second call returns the structured busy message, first dialog stays on screen until user answers.
- [ ] Local: leave a dialog unanswered, kick off a second aiui call from a parallel `claude` session — second session gets the busy message naming "parallel Claude session" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)