### PR TITLE
feat: Windows port — Phase 1 (platform-clean Rust core) + Phase 2a (CI/NSIS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,20 @@ concurrency:
 
 jobs:
   companion:
-    name: Tauri companion (Rust + Svelte)
-    runs-on: macos-14
+    name: Tauri companion (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: aarch64-apple-darwin
+            label: macOS arm64
+            build_bundle: false
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            label: Windows x86_64
+            build_bundle: true
     steps:
       - uses: actions/checkout@v4
 
@@ -28,11 +40,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: companion/src-tauri -> target
+          key: ${{ matrix.target }}
 
       - name: Install frontend deps
         working-directory: companion
@@ -48,11 +61,38 @@ jobs:
 
       - name: Cargo check
         working-directory: companion/src-tauri
-        run: cargo check --release --target aarch64-apple-darwin
+        run: cargo check --release --target ${{ matrix.target }}
+
+      - name: Cargo test
+        working-directory: companion/src-tauri
+        run: cargo test --lib --release --target ${{ matrix.target }}
 
       - name: Cargo clippy
         working-directory: companion/src-tauri
-        run: cargo clippy --release --target aarch64-apple-darwin -- -D warnings
+        run: cargo clippy --release --target ${{ matrix.target }} -- -D warnings
+
+      # Windows-only: produce a real NSIS installer so we can hand the
+      # `.exe` to a tester or run it on a Windows VM. Mac CI stays
+      # bundle-less — releases are still cut manually via scripts/release.sh.
+      - name: Install Tauri CLI
+        if: matrix.build_bundle
+        run: npm install --global @tauri-apps/cli@^2
+
+      - name: Tauri build (NSIS)
+        if: matrix.build_bundle
+        working-directory: companion
+        run: tauri build --target ${{ matrix.target }} --bundles nsis
+
+      - name: Upload NSIS installer
+        if: matrix.build_bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: aiui-windows-x86_64-nsis
+          path: |
+            companion/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+            companion/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.sig
+          if-no-files-found: error
+          retention-days: 14
 
   mcp:
     name: aiui-mcp (Python)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,19 +78,25 @@ jobs:
         if: matrix.build_bundle
         run: npm install --global @tauri-apps/cli@^2
 
-      - name: Tauri build (NSIS)
+      # `tauri.conf.json` has `createUpdaterArtifacts: true` and a
+      # minisign pubkey, so Tauri normally expects `TAURI_SIGNING_PRIVATE_KEY`
+      # at build time to produce the signed `.nsis.zip` updater bundle.
+      # Phase 2a is about validating the cross-compile and producing a
+      # runnable installer for manual E2E — the signed-updater path is
+      # Phase 4. The override file disables updater artifacts for CI
+      # builds; release builds (run manually with secrets present) keep
+      # the default tauri.conf.json with updater artifacts on.
+      - name: Tauri build (NSIS, no updater bundle)
         if: matrix.build_bundle
         working-directory: companion
-        run: tauri build --target ${{ matrix.target }} --bundles nsis
+        run: tauri build --target ${{ matrix.target }} --bundles nsis --config src-tauri/tauri.ci.conf.json
 
       - name: Upload NSIS installer
         if: matrix.build_bundle
         uses: actions/upload-artifact@v4
         with:
           name: aiui-windows-x86_64-nsis
-          path: |
-            companion/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
-            companion/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.sig
+          path: companion/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,173 @@
+# Windows release pipeline for aiui — companion side only.
+#
+# Why a separate workflow: macOS releases still run through
+# `scripts/release.sh` locally (Apple-signing keys + notarytool live in
+# the maintainer's keychain, not in CI). Windows has no such anchor —
+# CI is the only practical place to produce a signed NSIS installer.
+#
+# This workflow is **manually triggered** (`workflow_dispatch`) against
+# a tag the maintainer already created with `scripts/release.sh`. That
+# script publishes the macOS GitHub release plus the initial
+# `latest.json`; this workflow then attaches the Windows installer +
+# updater bundle to the same release and rewrites `latest.json` to add
+# the `windows-x86_64` platform entry.
+#
+# One-time setup (see also: scripts/release.sh header):
+#
+#   1. Repo → Settings → Secrets and variables → Actions:
+#        - TAURI_SIGNING_PRIVATE_KEY        (literal content of the
+#                                            minisign private key — not
+#                                            a path)
+#        - TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+#                                           (empty string if the key has
+#                                            no password)
+#
+#   2. The release for `vX.Y.Z` must already exist on GitHub (created
+#      by `scripts/release.sh X.Y.Z` from the maintainer's machine).
+#
+# Usage:
+#
+#   GitHub UI → Actions → "release-windows" → Run workflow → enter tag
+#   `v0.5.0` → Run.
+#
+# What the run produces:
+#
+#   - aiui_<version>_x64-setup.exe                attached to release
+#   - aiui_<version>_x64-setup.nsis.zip           attached to release
+#   - aiui_<version>_x64-setup.nsis.zip.sig       attached to release
+#   - latest.json patched in-place with the new windows-x86_64 entry
+#
+# Code signing for the `.exe` itself (Authenticode / SmartScreen) is
+# explicitly NOT done here — the v1 plan calls for unsigned shipping
+# with SmartScreen-Nag accepted (see plan-doc Phase 4). Adding an EV
+# cert later is a separate concern that touches the `tauri build`
+# invocation only; the rest of this workflow stays unchanged.
+
+name: release-windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.5.0). Must already exist on GitHub."
+        required: true
+        type: string
+
+permissions:
+  contents: write   # needed for `gh release upload` + the latest.json edit
+
+concurrency:
+  group: release-windows-${{ inputs.tag }}
+  cancel-in-progress: false   # never cancel a release midway
+
+jobs:
+  build-and-attach:
+    name: Build signed Windows installer + attach to release
+    runs-on: windows-latest
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: companion/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: companion/src-tauri -> target
+          key: x86_64-pc-windows-msvc-release
+
+      - name: Install frontend deps
+        working-directory: companion
+        run: npm ci
+
+      - name: Vite build
+        working-directory: companion
+        run: npm run build
+
+      - name: Install Tauri CLI
+        run: npm install --global @tauri-apps/cli@^2
+
+      # Use the production tauri.conf.json — `createUpdaterArtifacts:
+      # true` is correct here, the secrets are present, the produced
+      # `.nsis.zip` + `.sig` go into the release alongside the `.exe`.
+      - name: Tauri build (NSIS + updater bundle)
+        working-directory: companion
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: tauri build --target x86_64-pc-windows-msvc --bundles nsis
+
+      - name: Locate produced bundle files
+        id: bundle
+        shell: pwsh
+        working-directory: companion/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis
+        run: |
+          $exe = Get-ChildItem -Filter *.exe | Select-Object -First 1
+          $zip = Get-ChildItem -Filter *.nsis.zip | Select-Object -First 1
+          $sig = Get-ChildItem -Filter *.nsis.zip.sig | Select-Object -First 1
+          if (-not $exe) { throw "no .exe produced" }
+          if (-not $zip) { throw "no .nsis.zip produced — check TAURI_SIGNING_PRIVATE_KEY" }
+          if (-not $sig) { throw "no .sig produced — check TAURI_SIGNING_PRIVATE_KEY" }
+          "exe=$($exe.FullName)"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "zip=$($zip.FullName)"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "sig=$($sig.FullName)"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "version=$($exe.BaseName -replace '^aiui_' -replace '_x64-setup$','')" `
+                                     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Attach installer + updater bundle to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ inputs.tag }}" `
+            "${{ steps.bundle.outputs.exe }}" `
+            "${{ steps.bundle.outputs.zip }}" `
+            "${{ steps.bundle.outputs.sig }}" `
+            --repo "${{ github.repository }}" `
+            --clobber
+
+      # Patch the existing latest.json to add the windows-x86_64 entry,
+      # then upload it back to the release (overwriting the macOS-only
+      # version that scripts/release.sh produced earlier).
+      - name: Update latest.json with windows-x86_64 entry
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.bundle.outputs.version }}
+          SIG_PATH: ${{ steps.bundle.outputs.sig }}
+        run: |
+          # Pull the current latest.json from the release.
+          gh release download "$env:TAG" --repo "$env:REPO" --pattern "latest.json" --output latest.json --clobber
+
+          $sig = Get-Content -Raw -Path "$env:SIG_PATH"
+          $url = "https://github.com/$env:REPO/releases/download/$env:TAG/aiui_${env:VERSION}_x64-setup.nsis.zip"
+
+          $json = Get-Content -Raw -Path latest.json | ConvertFrom-Json
+          if (-not $json.platforms) { $json | Add-Member -NotePropertyName platforms -NotePropertyValue (New-Object PSObject) }
+          $json.platforms | Add-Member -Force -NotePropertyName "windows-x86_64" -NotePropertyValue ([PSCustomObject]@{
+            signature = $sig
+            url       = $url
+          })
+          $json | ConvertTo-Json -Depth 10 | Set-Content -Path latest.json -NoNewline
+
+          gh release upload "$env:TAG" latest.json --repo "$env:REPO" --clobber
+
+      - name: Verification summary
+        run: |
+          echo "Windows release for ${{ inputs.tag }} attached." >> $env:GITHUB_STEP_SUMMARY
+          echo "" >> $env:GITHUB_STEP_SUMMARY
+          echo "Artifacts:" >> $env:GITHUB_STEP_SUMMARY
+          echo "- aiui_${{ steps.bundle.outputs.version }}_x64-setup.exe" >> $env:GITHUB_STEP_SUMMARY
+          echo "- aiui_${{ steps.bundle.outputs.version }}_x64-setup.nsis.zip" >> $env:GITHUB_STEP_SUMMARY
+          echo "- aiui_${{ steps.bundle.outputs.version }}_x64-setup.nsis.zip.sig" >> $env:GITHUB_STEP_SUMMARY
+          echo "- latest.json (patched with windows-x86_64)" >> $env:GITHUB_STEP_SUMMARY

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -21,11 +21,13 @@
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tauri-apps/cli": "^2.10.1",
         "@tsconfig/svelte": "^5.0.8",
-        "appdmg": "^0.6.6",
         "svelte": "^5.55.4",
         "svelte-check": "^4.4.6",
         "typescript": "^6.0.3",
         "vite": "^8.0.9"
+      },
+      "optionalDependencies": {
+        "appdmg": "^0.6.6"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1164,8 +1166,8 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
       "integrity": "sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -1202,8 +1204,8 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
@@ -1218,8 +1220,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.2.0.tgz",
       "integrity": "sha512-cHFU8XeRyx0GgmoWi5qHMCVRiqU6J3MHWxVgun7jggCBUpVzm1Ir7M9dYr2whjSNc3tFeXfQ/oZjQu/4u55h9A==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "to-data-view": "^1.1.0"
       }
@@ -1228,8 +1230,8 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
       "integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "stream-buffers": "~2.2.0"
       }
@@ -1307,7 +1309,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==",
-      "dev": true
+      "optional": true
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -1337,8 +1339,8 @@
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
       "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -1921,8 +1923,8 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
       "integrity": "sha512-kY21M6Lz+76OS3bnCzjdsJSF7LBpLYGCVfavW8TgQD2XkcqIZ86W0y9qUDZu6fp7SIZzqosMDW2zi7zVFfv4hw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bplist-creator": "~0.0.3",
         "macos-alias": "~0.2.5",
@@ -1933,15 +1935,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2056,8 +2058,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -2102,8 +2104,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
       "integrity": "sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "imul": "^1.0.0"
       }
@@ -2112,8 +2114,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
       "integrity": "sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "random-path": "^0.1.0"
       }
@@ -2122,9 +2124,9 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.3.1.tgz",
       "integrity": "sha512-UVqkrEW0GfDabw4C3HOrFlxKfx0eeigfRne69FxSBdHIP8Qt5Sq6Pu3RM9KmMlkygtC4pPKkj5CiPO5USnj2GA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "!win32"
       ],
@@ -2151,8 +2153,8 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.2"
       }
@@ -2161,8 +2163,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -2171,8 +2173,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -2214,8 +2216,8 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
       "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -2227,8 +2229,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2258,15 +2260,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
       "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-my-json-valid": {
       "version": "2.20.6",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
       "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -2285,8 +2287,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
@@ -2301,8 +2303,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2311,15 +2313,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2676,9 +2678,9 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.12.tgz",
       "integrity": "sha512-yiLHa7cfJcGRFq4FrR4tMlpNHb4Vy4mWnpajlSSIFM5k4Lv8/7BbbDLzCAVogWNl0LlLhizRp1drXv0hK9h0Yw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -2771,8 +2773,8 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2802,8 +2804,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
       "integrity": "sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "encode-utf8": "^1.0.3",
         "fmix": "^0.1.0",
@@ -2814,8 +2816,8 @@
       "version": "2.26.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
       "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2846,15 +2848,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "path-key": "^2.0.0"
       },
@@ -2877,8 +2879,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2887,8 +2889,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -2903,8 +2905,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
       "integrity": "sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "~0.5.0"
       }
@@ -2919,8 +2921,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2929,8 +2931,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -3021,8 +3023,8 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -3032,8 +3034,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.2.tgz",
       "integrity": "sha512-4jY0yoEaQ5v9StCl5kZbNIQlg1QheIDBrdkDn53EynpPb9FgO6//p3X/tgMnrC45XN6QZCzU1Xz/+pSSsJBpRw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base32-encode": "^0.1.0 || ^1.0.0",
         "murmur-32": "^0.1.0 || ^0.2.0"
@@ -3057,8 +3059,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3143,8 +3145,8 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -3153,8 +3155,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -3166,8 +3168,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3176,8 +3178,8 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3193,8 +3195,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
-      "dev": true,
       "license": "Unlicense",
+      "optional": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -3203,8 +3205,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3749,8 +3751,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
       "integrity": "sha512-DbplOfQFkqG5IHcDyyrs/lkvSr3mPUVsFf/RbDppOshs22yTPnSJWEe6FkYd1txAwU/zcnR905ar2fi4kwF29w==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "unorm": "^1.4.1"
       },
@@ -3762,8 +3764,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
       "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
@@ -3810,8 +3812,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
       "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "dev": true,
       "license": "MIT or GPL-2.0",
+      "optional": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -3980,8 +3982,8 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3993,15 +3995,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/companion/package.json
+++ b/companion/package.json
@@ -16,11 +16,13 @@
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tauri-apps/cli": "^2.10.1",
     "@tsconfig/svelte": "^5.0.8",
-    "appdmg": "^0.6.6",
     "svelte": "^5.55.4",
     "svelte-check": "^4.4.6",
     "typescript": "^6.0.3",
     "vite": "^8.0.9"
+  },
+  "optionalDependencies": {
+    "appdmg": "^0.6.6"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.10.1",

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -2484,6 +2485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4324,6 +4334,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,7 +4391,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4456,7 +4479,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4683,7 +4706,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4708,7 +4731,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5589,10 +5612,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -5613,7 +5636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5665,6 +5688,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5687,12 +5720,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -5704,8 +5749,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -5724,9 +5769,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5764,6 +5831,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6292,7 +6368,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -21,6 +21,12 @@ tauri-build = { version = "2.5.6", features = [] }
 chrono = "0.4"
 
 [dependencies]
+# `macos-private-api` is the feature that enables `set_activation_policy`
+# (LSUIElement Accessory ↔ Regular toggle). It must stay listed here
+# unconditionally because Tauri's build-script cross-checks it against
+# `app.macOSPrivateApi: true` in tauri.conf.json. On non-macOS targets
+# the feature compiles as a no-op, so leaving it always-on costs nothing
+# on Windows and keeps the build-script happy.
 tauri = { version = "2.10.3", features = ["macos-private-api"] }
 tauri-plugin-log = "2"
 tauri-plugin-single-instance = "2"
@@ -51,3 +57,7 @@ socket2 = "0.5"
 # `data:` URLs so the WebView can render them under the strict img-src
 # CSP. See companion/src-tauri/src/imageresolve.rs.
 base64 = "0.22"
+# Cross-platform process enumeration. Replaces the macOS-only
+# `ps -axo pid=,command=` shell-out in housekeeping.rs so the
+# stale-mcp-stdio-child sweep also works on Windows (no /proc, no `ps`).
+sysinfo = { version = "0.32", default-features = false, features = ["system"] }

--- a/companion/src-tauri/src/config.rs
+++ b/companion/src-tauri/src/config.rs
@@ -11,12 +11,29 @@ pub struct AppConfig {
     pub http_port: u16,
 }
 
+/// Returns the OS-appropriate aiui config directory.
+///
+/// - macOS / Linux: `~/.config/aiui` (XDG-style — kept on macOS deliberately
+///   so existing v0.4.x installs keep their token without migration).
+/// - Windows: `%APPDATA%\aiui` (Roaming) — resolved via `dirs::config_dir()`.
+pub fn config_dir() -> io::Result<PathBuf> {
+    #[cfg(windows)]
+    {
+        let base = dirs::config_dir()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no %APPDATA%"))?;
+        Ok(base.join("aiui"))
+    }
+    #[cfg(not(windows))]
+    {
+        let home = dirs::home_dir()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no home dir"))?;
+        Ok(home.join(".config").join("aiui"))
+    }
+}
+
 impl AppConfig {
     pub fn load_or_init() -> io::Result<Self> {
-        let config_dir = dirs::home_dir()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no home dir"))?
-            .join(".config")
-            .join("aiui");
+        let config_dir = config_dir()?;
         fs::create_dir_all(&config_dir)?;
 
         let token_path = config_dir.join("token");

--- a/companion/src-tauri/src/housekeeping.rs
+++ b/companion/src-tauri/src/housekeeping.rs
@@ -210,6 +210,13 @@ pub fn kill_all_mcp_stdio_children() -> usize {
 /// Empty / whitespace `disk` is treated as "unknown" → not stale: better
 /// to keep running than abort a working subprocess on a transient
 /// `plutil` glitch.
+///
+/// On Windows the helper is unused at runtime — `disk_version_if_stale`
+/// short-circuits to `None` because there is no `Info.plist` to read —
+/// but the unit tests still validate the pure decision logic on every
+/// platform, so we keep the function compiled and silence dead-code on
+/// non-macOS.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn is_disk_version_stale(own: &str, disk: &str) -> bool {
     let disk = disk.trim();
     !disk.is_empty() && disk != own

--- a/companion/src-tauri/src/housekeeping.rs
+++ b/companion/src-tauri/src/housekeeping.rs
@@ -1,9 +1,9 @@
 //! Kill stale `aiui --mcp-stdio` children left over from older app versions.
 //!
 //! Context: Claude Desktop spawns `aiui --mcp-stdio` once and keeps it alive
-//! for the whole Claude Desktop session. If the user drags a new `aiui.app`
-//! over the old one, those already-spawned children keep running — with the
-//! *old* binary. Their lifetime-socket logic may be pre-auto-resurrect (≤
+//! for the whole Claude Desktop session. If the user updates the aiui binary
+//! while a session is live, those already-spawned children keep running with
+//! the *old* code. Their lifetime-channel logic may be pre-auto-resurrect (≤
 //! v0.2.5) or otherwise incompatible, so the user ends up with a stale MCP
 //! server that refuses to reconnect to the new GUI.
 //!
@@ -11,115 +11,160 @@
 //!
 //!  1. **GUI-side sweep** (`kill_stale_mcp_stdio_children`): on every GUI
 //!     startup we scan for `aiui --mcp-stdio` processes whose executable
-//!     path differs from ours and SIGTERM them. This only catches the case
-//!     where the *path* changed — useless when the user dragged a new
-//!     `aiui.app` over the old one in place.
+//!     path differs from ours and signal them to terminate. This catches the
+//!     case where the *path* changed — useless when the user replaced the
+//!     binary in place.
 //!
-//!  2. **Subprocess-side self-check** (`disk_version_if_stale`): every
-//!     `--mcp-stdio` invocation reads `CFBundleShortVersionString` from
+//!  2. **Subprocess-side self-check** (`disk_version_if_stale`, macOS only):
+//!     every `--mcp-stdio` invocation reads `CFBundleShortVersionString` from
 //!     the on-disk `Info.plist` two directories up from `argv[0]` and
-//!     compares it with `CARGO_PKG_VERSION` baked in at compile time. If
-//!     they disagree, the in-memory binary is stale — the bundle on disk
-//!     was replaced after this process loaded — and we exit so Claude
-//!     Desktop respawns us against the fresh binary.
+//!     compares it with `CARGO_PKG_VERSION` baked in at compile time. If they
+//!     disagree, the in-memory binary is stale — the bundle on disk was
+//!     replaced after this process loaded — and we exit so Claude Desktop
+//!     respawns us against the fresh binary.
 //!
-//! Together those two layers catch the in-place-replace scenario that
-//! produced the 2026-04-30 form-tool-call crash: a Claude-Desktop-spawned
-//! mcp-stdio child kept the previous version in memory across an
-//! updater-driven replacement of `/Applications/aiui.app`.
+//!     On Windows there is no analog of `Info.plist`. The Windows path-based
+//!     sweep (mechanism 1) covers the NSIS-update case because NSIS replaces
+//!     files at the install path while old children continue running from a
+//!     temporary copy under their original PID — sysinfo's `exe()` reports
+//!     the original path, which differs from `current_exe()` for the freshly
+//!     spawned GUI.
 //!
-//! macOS-specific: we use `ps -axo pid=,command=` to enumerate processes
-//! (there is no /proc on macOS). The executable path is the first whitespace-
-//! delimited token of `command`.
+//! Cross-platform via `sysinfo`: both sweeps enumerate processes with the
+//! same API, no `ps`/`tasklist` shell-out, no /proc assumption.
 //!
 //! Safety: we never kill our own pid. If the current binary path can't be
-//! determined, we skip the sweep entirely.
+//! determined, we skip the path-based sweep entirely.
 //!
-//! Idempotent: called once per GUI startup. Running it on a clean system is
-//! a no-op.
+//! Idempotent: running on a clean system is a no-op.
 
 use crate::logging::trace;
+use sysinfo::{ProcessRefreshKind, RefreshKind, Signal, System};
+
+#[cfg(target_os = "macos")]
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::process::Command;
 
-/// A stale `aiui --mcp-stdio` process that should be terminated.
-#[derive(Debug, PartialEq, Eq)]
+/// A stale `aiui --mcp-stdio` process discovered during the sweep.
+#[derive(Debug, PartialEq, Eq, Clone)]
 struct StaleChild {
     pid: u32,
     exe: String,
 }
 
-/// Parse `ps -axo pid=,command=` output and return the stale-child candidates
-/// — processes running `aiui --mcp-stdio` under any executable path other
-/// than `current_exe_path`, excluding `own_pid`.
-fn find_stale(ps_stdout: &str, current_exe_path: &str, own_pid: u32) -> Vec<StaleChild> {
-    let mut out = Vec::new();
-    for line in ps_stdout.lines() {
-        let line = line.trim_start();
-        let Some((pid_str, rest)) = line.split_once(char::is_whitespace) else {
-            continue;
-        };
-        let Ok(pid) = pid_str.parse::<u32>() else {
-            continue;
-        };
-        if pid == own_pid {
-            continue;
-        }
-        let rest = rest.trim_start();
-        if !rest.contains("--mcp-stdio") {
-            continue;
-        }
-        let exe = rest.split_whitespace().next().unwrap_or("");
-        // Narrow to our binary family — any path ending in /aiui that's
-        // running with --mcp-stdio. This skips random unrelated processes
-        // that happen to mention "--mcp-stdio" in their argv.
-        if !exe.ends_with("/aiui") && exe != "aiui" {
-            continue;
-        }
-        if exe == current_exe_path {
-            continue;
-        }
-        out.push(StaleChild {
-            pid,
-            exe: exe.to_string(),
-        });
-    }
-    out
+/// Lightweight snapshot of one process — what we need for both filters.
+#[derive(Debug, Clone)]
+struct ProcSnap {
+    pid: u32,
+    exe: String,
+    args: Vec<String>,
 }
 
-/// Scan for stale `aiui --mcp-stdio` processes and SIGTERM the ones whose
-/// executable path differs from `current_exe_path`. Returns the number of
-/// processes killed.
+/// Enumerate every running process via `sysinfo` and return a snapshot.
+/// Cross-platform: identical behaviour on macOS, Linux, and Windows.
+fn snapshot_processes() -> Vec<ProcSnap> {
+    let sys = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::everything()),
+    );
+    sys.processes()
+        .iter()
+        .map(|(pid, p)| {
+            let exe = p
+                .exe()
+                .map(|e| e.to_string_lossy().to_string())
+                .unwrap_or_else(|| {
+                    p.cmd()
+                        .first()
+                        .map(|s| s.to_string_lossy().to_string())
+                        .unwrap_or_default()
+                });
+            let args = p
+                .cmd()
+                .iter()
+                .map(|s| s.to_string_lossy().to_string())
+                .collect();
+            ProcSnap {
+                pid: pid.as_u32(),
+                exe,
+                args,
+            }
+        })
+        .collect()
+}
+
+/// True iff `exe` looks like our aiui binary — last path component is
+/// `aiui` (Unix) or `aiui.exe` (Windows). The path-based filter is what
+/// keeps us from accidentally signalling a Python script that happens to
+/// have `--mcp-stdio` in its argv.
+fn is_aiui_binary(exe: &str) -> bool {
+    let leaf = exe
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(exe)
+        .to_ascii_lowercase();
+    leaf == "aiui" || leaf == "aiui.exe"
+}
+
+/// True iff `args` contains the `--mcp-stdio` flag anywhere.
+fn has_mcp_stdio_flag(args: &[String]) -> bool {
+    args.iter().any(|a| a == "--mcp-stdio")
+}
+
+/// Filter: stale (different path) `aiui --mcp-stdio` children, excluding
+/// `own_pid`. Pure function over a snapshot, kept testable.
+fn find_stale(snap: &[ProcSnap], current_exe_path: &str, own_pid: u32) -> Vec<StaleChild> {
+    snap.iter()
+        .filter(|p| p.pid != own_pid)
+        .filter(|p| has_mcp_stdio_flag(&p.args))
+        .filter(|p| is_aiui_binary(&p.exe))
+        .filter(|p| p.exe != current_exe_path)
+        .map(|p| StaleChild {
+            pid: p.pid,
+            exe: p.exe.clone(),
+        })
+        .collect()
+}
+
+/// Filter: every `aiui --mcp-stdio` child regardless of executable path,
+/// excluding `own_pid`. Used for the uninstall flow.
+fn find_all_children(snap: &[ProcSnap], own_pid: u32) -> Vec<StaleChild> {
+    snap.iter()
+        .filter(|p| p.pid != own_pid)
+        .filter(|p| has_mcp_stdio_flag(&p.args))
+        .filter(|p| is_aiui_binary(&p.exe))
+        .map(|p| StaleChild {
+            pid: p.pid,
+            exe: p.exe.clone(),
+        })
+        .collect()
+}
+
+/// Cross-platform process termination via sysinfo. Sends SIGTERM on Unix
+/// and the equivalent terminate-by-handle on Windows.
+fn terminate_pid(pid: u32) {
+    let sys = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::everything()),
+    );
+    if let Some(p) = sys.process(sysinfo::Pid::from_u32(pid)) {
+        let _ = p.kill_with(Signal::Term).unwrap_or_else(|| p.kill());
+    }
+}
+
+/// Scan for stale `aiui --mcp-stdio` processes and terminate the ones
+/// whose executable path differs from `current_exe_path`. Returns the
+/// number of processes killed.
 pub fn kill_stale_mcp_stdio_children(current_exe_path: &str) -> usize {
     let own_pid = std::process::id();
-
-    let out = match Command::new("ps").args(["-axo", "pid=,command="]).output() {
-        Ok(o) if o.status.success() => o,
-        Ok(o) => {
-            trace(&format!(
-                "housekeeping: ps exited {:?} ({} bytes stderr)",
-                o.status.code(),
-                o.stderr.len()
-            ));
-            return 0;
-        }
-        Err(e) => {
-            trace(&format!("housekeeping: ps failed to start: {e}"));
-            return 0;
-        }
-    };
-
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let stale = find_stale(&stdout, current_exe_path, own_pid);
+    let snap = snapshot_processes();
+    let stale = find_stale(&snap, current_exe_path, own_pid);
 
     for child in &stale {
         trace(&format!(
             "housekeeping: killing stale mcp-stdio child pid={} exe={}",
             child.pid, child.exe
         ));
-        // SIGTERM (15). Claude Desktop notices the broken pipe and respawns
-        // with the current config, which now points at our binary.
-        let _ = Command::new("kill").arg(child.pid.to_string()).output();
+        terminate_pid(child.pid);
     }
 
     if !stale.is_empty() {
@@ -131,9 +176,36 @@ pub fn kill_stale_mcp_stdio_children(current_exe_path: &str) -> usize {
     stale.len()
 }
 
+/// Sibling of `kill_stale_mcp_stdio_children` that doesn't filter by
+/// executable path — every running `aiui --mcp-stdio` (other than our
+/// own pid) gets terminated. Bound to the uninstall flow (#72): without
+/// this, the auto-resurrect loop in `mcp_attach` would relaunch the GUI
+/// the moment we call `app.exit(0)`.
+pub fn kill_all_mcp_stdio_children() -> usize {
+    let own_pid = std::process::id();
+    let snap = snapshot_processes();
+    let children = find_all_children(&snap, own_pid);
+
+    for child in &children {
+        trace(&format!(
+            "housekeeping: killing mcp-stdio child pid={} exe={} (uninstall sweep)",
+            child.pid, child.exe
+        ));
+        terminate_pid(child.pid);
+    }
+
+    if !children.is_empty() {
+        trace(&format!(
+            "housekeeping: terminated {} mcp-stdio child(ren) for uninstall",
+            children.len()
+        ));
+    }
+    children.len()
+}
+
 /// Pure decision: given our compile-time version string and the version
-/// string read from the on-disk `Info.plist`, return `true` when this
-/// in-memory binary is stale (i.e. should exit so it can be respawned).
+/// string read from the on-disk bundle, return `true` when this in-memory
+/// binary is stale (i.e. should exit so it can be respawned).
 ///
 /// Empty / whitespace `disk` is treated as "unknown" → not stale: better
 /// to keep running than abort a working subprocess on a transient
@@ -143,16 +215,22 @@ pub(crate) fn is_disk_version_stale(own: &str, disk: &str) -> bool {
     !disk.is_empty() && disk != own
 }
 
-/// True iff the bundle on disk (one bundle level up from `argv[0]`)
-/// reports a `CFBundleShortVersionString` that differs from our own
-/// compile-time `CARGO_PKG_VERSION`. Returns the on-disk version when
-/// stale so the caller can log it; `None` when fresh, when running
-/// outside an `.app` bundle (dev build, `cargo run`), or when the
-/// lookup itself fails (no `Info.plist`, `plutil` missing, …).
+/// True iff the bundle on disk reports a version that differs from our
+/// own compile-time `CARGO_PKG_VERSION`. Returns the on-disk version when
+/// stale so the caller can log it; `None` when fresh, when running outside
+/// a packaged install (dev build, `cargo run`), or when the lookup itself
+/// fails.
 ///
-/// Self-detection at the subprocess side is what closes the gap that
-/// the path-based GUI sweep can't see: an in-place `.app` replacement
-/// leaves the running child with stale code at the unchanged path.
+/// Self-detection at the subprocess side is what closes the gap that the
+/// path-based GUI sweep can't see: an in-place bundle replacement leaves
+/// the running child with stale code at the unchanged path.
+///
+/// Implemented for macOS (reads `CFBundleShortVersionString` from
+/// `Info.plist`); on Windows there is no in-bundle version stamp accessible
+/// without pulling a Win32 resource-parsing crate, so we return `None` and
+/// rely on the path-based GUI sweep to catch updates after the user
+/// restarts Claude Desktop.
+#[cfg(target_os = "macos")]
 pub fn disk_version_if_stale() -> Option<String> {
     let own = env!("CARGO_PKG_VERSION");
     let exe = std::env::current_exe().ok()?;
@@ -177,117 +255,48 @@ pub fn disk_version_if_stale() -> Option<String> {
     }
 }
 
-/// Find every `aiui --mcp-stdio` process regardless of executable path,
-/// excluding `own_pid`. Used for the uninstall flow where we want to take
-/// down ALL children — keeping any of them alive would re-launch the GUI
-/// via `mcp_attach`'s auto-resurrect path the moment we exit, defeating
-/// the whole point of "uninstall + drag .app to trash".
-fn find_all_children(ps_stdout: &str, own_pid: u32) -> Vec<StaleChild> {
-    let mut out = Vec::new();
-    for line in ps_stdout.lines() {
-        let line = line.trim_start();
-        let Some((pid_str, rest)) = line.split_once(char::is_whitespace) else {
-            continue;
-        };
-        let Ok(pid) = pid_str.parse::<u32>() else {
-            continue;
-        };
-        if pid == own_pid {
-            continue;
-        }
-        let rest = rest.trim_start();
-        if !rest.contains("--mcp-stdio") {
-            continue;
-        }
-        let exe = rest.split_whitespace().next().unwrap_or("");
-        if !exe.ends_with("/aiui") && exe != "aiui" {
-            continue;
-        }
-        out.push(StaleChild {
-            pid,
-            exe: exe.to_string(),
-        });
-    }
-    out
-}
-
-/// Sibling of `kill_stale_mcp_stdio_children` that doesn't filter by
-/// executable path — every running `aiui --mcp-stdio` (other than our
-/// own pid) gets SIGTERM'd. Bound to the uninstall flow (#72): without
-/// this, the auto-resurrect loop in `mcp_attach` would relaunch the GUI
-/// the moment we call `app.exit(0)`.
-pub fn kill_all_mcp_stdio_children() -> usize {
-    let own_pid = std::process::id();
-
-    let out = match Command::new("ps").args(["-axo", "pid=,command="]).output() {
-        Ok(o) if o.status.success() => o,
-        Ok(o) => {
-            trace(&format!(
-                "housekeeping: ps exited {:?} ({} bytes stderr)",
-                o.status.code(),
-                o.stderr.len()
-            ));
-            return 0;
-        }
-        Err(e) => {
-            trace(&format!("housekeeping: ps failed to start: {e}"));
-            return 0;
-        }
-    };
-
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let children = find_all_children(&stdout, own_pid);
-
-    for child in &children {
-        trace(&format!(
-            "housekeeping: killing mcp-stdio child pid={} exe={} (uninstall sweep)",
-            child.pid, child.exe
-        ));
-        let _ = Command::new("kill").arg(child.pid.to_string()).output();
-    }
-
-    if !children.is_empty() {
-        trace(&format!(
-            "housekeeping: terminated {} mcp-stdio child(ren) for uninstall",
-            children.len()
-        ));
-    }
-    children.len()
+#[cfg(not(target_os = "macos"))]
+pub fn disk_version_if_stale() -> Option<String> {
+    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(windows)]
+    const CURRENT: &str = r"C:\Program Files\aiui\aiui.exe";
+    #[cfg(not(windows))]
     const CURRENT: &str = "/Applications/aiui.app/Contents/MacOS/aiui";
 
-    #[test]
-    fn skips_empty_and_garbage_lines() {
-        assert!(find_stale("", CURRENT, 1).is_empty());
-        assert!(find_stale("  \n\t\n", CURRENT, 1).is_empty());
-        assert!(find_stale("not a pid line", CURRENT, 1).is_empty());
+    fn snap(pid: u32, exe: &str, args: &[&str]) -> ProcSnap {
+        ProcSnap {
+            pid,
+            exe: exe.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+        }
     }
 
     #[test]
     fn skips_unrelated_processes() {
-        let ps = "\
-          12345 /usr/bin/python3 some_script.py --mcp-stdio\n\
-          23456 /opt/homebrew/bin/uv tool uvx aiui-mcp\n\
-          34567 /bin/zsh -c echo hello\n\
-        ";
-        assert!(find_stale(ps, CURRENT, 1).is_empty());
+        let s = vec![
+            snap(12345, "/usr/bin/python3", &["python3", "some_script.py", "--mcp-stdio"]),
+            snap(23456, "/opt/homebrew/bin/uv", &["uv", "tool", "uvx", "aiui-mcp"]),
+            snap(34567, "/bin/zsh", &["zsh", "-c", "echo hello"]),
+        ];
+        assert!(find_stale(&s, CURRENT, 1).is_empty());
     }
 
     #[test]
     fn skips_current_binary() {
-        let ps = format!("99999 {CURRENT} --mcp-stdio\n");
-        assert!(find_stale(&ps, CURRENT, 1).is_empty());
+        let s = vec![snap(99999, CURRENT, &[CURRENT, "--mcp-stdio"])];
+        assert!(find_stale(&s, CURRENT, 1).is_empty());
     }
 
     #[test]
     fn skips_own_pid_even_if_path_differs() {
-        let ps = "12345 /old/path/aiui --mcp-stdio\n";
-        assert!(find_stale(ps, CURRENT, 12345).is_empty());
+        let s = vec![snap(12345, "/old/path/aiui", &["/old/path/aiui", "--mcp-stdio"])];
+        assert!(find_stale(&s, CURRENT, 12345).is_empty());
     }
 
     #[test]
@@ -307,8 +316,8 @@ mod tests {
 
     #[test]
     fn disk_version_check_treats_empty_disk_as_unknown_not_stale() {
-        // If `plutil` returns nothing — bundle missing, dev build,
-        // permissions issue — we'd rather keep running than abort.
+        // If the on-disk lookup returns nothing — bundle missing, dev
+        // build, permissions issue — we'd rather keep running than abort.
         // The GUI-side sweep is the safety net for that path.
         assert!(!is_disk_version_stale("0.4.26", ""));
         assert!(!is_disk_version_stale("0.4.26", "   "));
@@ -317,11 +326,11 @@ mod tests {
 
     #[test]
     fn finds_stale_child_with_different_path() {
-        let ps = "\
-          12345 /old/path/aiui --mcp-stdio\n\
-          23456 /Applications/aiui.app/Contents/MacOS/aiui --mcp-stdio\n\
-        ";
-        let stale = find_stale(ps, CURRENT, 1);
+        let s = vec![
+            snap(12345, "/old/path/aiui", &["/old/path/aiui", "--mcp-stdio"]),
+            snap(23456, CURRENT, &[CURRENT, "--mcp-stdio"]),
+        ];
+        let stale = find_stale(&s, CURRENT, 1);
         assert_eq!(
             stale,
             vec![StaleChild {
@@ -333,12 +342,12 @@ mod tests {
 
     #[test]
     fn finds_multiple_stale_children() {
-        let ps = "\
-          100 /a/aiui --mcp-stdio\n\
-          200 /b/aiui --mcp-stdio --extra\n\
-          300 /Applications/aiui.app/Contents/MacOS/aiui --mcp-stdio\n\
-        ";
-        let stale = find_stale(ps, CURRENT, 1);
+        let s = vec![
+            snap(100, "/a/aiui", &["/a/aiui", "--mcp-stdio"]),
+            snap(200, "/b/aiui", &["/b/aiui", "--mcp-stdio", "--extra"]),
+            snap(300, CURRENT, &[CURRENT, "--mcp-stdio"]),
+        ];
+        let stale = find_stale(&s, CURRENT, 1);
         assert_eq!(stale.len(), 2);
         assert_eq!(stale[0].pid, 100);
         assert_eq!(stale[1].pid, 200);
@@ -348,16 +357,20 @@ mod tests {
     fn ignores_aiui_gui_processes_without_mcp_stdio_flag() {
         // The GUI process itself runs the same binary but without
         // `--mcp-stdio`. Must not be killed.
-        let ps = format!("42 {CURRENT}\n43 /old/path/aiui\n");
-        assert!(find_stale(&ps, CURRENT, 1).is_empty());
+        let s = vec![
+            snap(42, CURRENT, &[CURRENT]),
+            snap(43, "/old/path/aiui", &["/old/path/aiui"]),
+        ];
+        assert!(find_stale(&s, CURRENT, 1).is_empty());
     }
 
     #[test]
-    fn tolerates_leading_whitespace_from_ps() {
-        // ps pads pid column with leading spaces.
-        let ps = "    12345 /old/path/aiui --mcp-stdio\n";
-        let stale = find_stale(ps, CURRENT, 1);
-        assert_eq!(stale.len(), 1);
-        assert_eq!(stale[0].pid, 12345);
+    fn windows_exe_extension_is_recognized() {
+        // On Windows, `is_aiui_binary` must accept `aiui.exe` regardless of
+        // case. Verify here cross-platform — the leaf check is OS-agnostic.
+        assert!(is_aiui_binary(r"C:\Program Files\aiui\aiui.exe"));
+        assert!(is_aiui_binary(r"C:\Program Files\aiui\AIUI.EXE"));
+        assert!(is_aiui_binary("/Applications/aiui.app/Contents/MacOS/aiui"));
+        assert!(!is_aiui_binary("/usr/bin/python3"));
     }
 }

--- a/companion/src-tauri/src/imageresolve.rs
+++ b/companion/src-tauri/src/imageresolve.rs
@@ -173,7 +173,27 @@ fn looks_like_local_path(s: &str) -> bool {
     if s.starts_with("data:") || s.starts_with("http://") || s.starts_with("https://") {
         return false;
     }
-    s.starts_with('/') || s.starts_with('~')
+    if s.starts_with('/') || s.starts_with('~') {
+        return true;
+    }
+    // Windows drive-letter absolute paths: `C:\foo`, `D:/bar`, including
+    // long-path prefixes `\\?\C:\…` and UNC `\\server\share\…`. Strict
+    // enough to avoid catching strings like `data:image/...` which never
+    // reach here anyway because of the early `data:` exit above.
+    if cfg!(windows) {
+        let bytes = s.as_bytes();
+        if bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && (bytes[2] == b'\\' || bytes[2] == b'/')
+        {
+            return true;
+        }
+        if s.starts_with(r"\\") {
+            return true;
+        }
+    }
+    false
 }
 
 fn expand_tilde(s: &str) -> Option<PathBuf> {

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -276,9 +276,25 @@ fn open_url(url: String) -> Result<(), String> {
             .spawn()
             .map_err(|e| format!("open {url}: {e}"))?;
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
     {
-        let _ = url; // silence unused on non-macos until ports land
+        // `cmd /C start "" <url>` is the canonical way to open a URL with
+        // the user's default browser on Windows. The empty `""` argument
+        // is the window-title placeholder — without it `start` interprets
+        // a quoted URL as the title and refuses to launch.
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", &url])
+            .spawn()
+            .map_err(|e| format!("start {url}: {e}"))?;
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        // Linux / BSD fallback for completeness — aiui is not officially
+        // shipped there, but the build should compile and behave sanely.
+        std::process::Command::new("xdg-open")
+            .arg(&url)
+            .spawn()
+            .map_err(|e| format!("xdg-open {url}: {e}"))?;
     }
     Ok(())
 }
@@ -524,6 +540,24 @@ async fn remove_remote(
     Ok(results)
 }
 
+/// Uninstall hint shown after the cleanup sweep — tells the user how to
+/// remove the app bundle itself, which aiui can't do for itself
+/// (a running process can't delete its own binary on either OS).
+fn uninstall_app_removal_hint() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "Verschiebe /Applications/aiui.app in den Papierkorb, um auch die App zu entfernen."
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Deinstalliere aiui über \"Apps & Features\" in den Windows-Einstellungen, um auch die App zu entfernen."
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        "Entferne das aiui-Binary manuell, um auch die App zu entfernen."
+    }
+}
+
 #[tauri::command]
 async fn uninstall_all(
     cfg: tauri::State<'_, Arc<config::AppConfig>>,
@@ -549,10 +583,7 @@ async fn uninstall_all(
             "Lokale Dateien entfernt: {}",
             cfg.config_dir.display()
         ),
-        details: Some(
-            "Verschiebe /Applications/aiui.app in den Papierkorb, um auch die App zu entfernen."
-                .into(),
-        ),
+        details: Some(uninstall_app_removal_hint().into()),
     });
     Ok(results)
 }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -91,6 +91,9 @@ async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
     // its custom close button (none today, but the contract should be
     // symmetric).
     let label = window.label().to_string();
+    // App handle only needed for the macOS dock-demote path below; bind
+    // it inside that cfg-block so Windows builds don't see it as unused.
+    #[cfg(target_os = "macos")]
     let app = window.app_handle().clone();
     let _ = window.close();
     log::debug!("[aiui] close_window: closed {label}");
@@ -1157,13 +1160,24 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error building tauri application")
-        .run(|app, event| {
+        .run(|_app, _event| {
             // macOS: Dock-Klick, "open" bei laufender App, File-Assoc etc.
-            // → Settings-Fenster nach vorn holen.
-            if let tauri::RunEvent::Reopen { .. } = event {
-                show_settings_window(app);
-            }
-            // Cmd-Q and window-close both just let the app terminate;
+            // → Settings-Fenster nach vorn holen. `RunEvent::Reopen` is
+            // a Mac-only variant, so this whole branch is gated.
+            //
+            // Windows has no analogous "reopen" semantics — clicking the
+            // installed `.exe` while it's already running is handled by
+            // tauri-plugin-single-instance, which surfaces the existing
+            // window through its own callback (wired up at plugin init,
+            // not here).
+            //
+            // Cmd-Q / window-close both just let the app terminate;
             // auto-resurrect in mcp_attach brings aiui back when needed.
+            #[cfg(target_os = "macos")]
+            {
+                if let tauri::RunEvent::Reopen { .. } = _event {
+                    show_settings_window(_app);
+                }
+            }
         });
 }

--- a/companion/src-tauri/src/lifetime.rs
+++ b/companion/src-tauri/src/lifetime.rs
@@ -1,12 +1,18 @@
 //! Lifetime coupling between the GUI process and MCP-stdio children.
 //!
-//! The GUI hosts a Unix domain socket at `<config>/gui.sock`. Each
-//! `aiui --mcp-stdio` child connects on startup and holds the stream open.
-//! When the child exits (Claude Desktop closes it), the OS tears down the
-//! stream and the GUI observes an EOF. Once the last client disconnects the
-//! GUI starts a 60s grace timer and exits if nobody re-connects.
+//! The GUI hosts a per-user channel — a Unix domain socket on macOS/Linux,
+//! a Windows named pipe on Windows — and each `aiui --mcp-stdio` child
+//! connects on startup and holds the stream open. When the child exits
+//! (Claude Desktop closes it), the OS tears down the stream and the GUI
+//! observes an EOF. Once the last client disconnects the GUI starts a 60s
+//! grace timer and exits if nobody re-connects.
 //!
 //! Event-driven, no polling.
+//!
+//! Cross-platform note: the public surface (`socket_path`, `gui_serve`,
+//! `mcp_attach`, `LifetimeStats`) is identical on both OSes. The only
+//! per-OS code lives behind `cfg` blocks below — the rest of the program
+//! treats the channel as an opaque handshake.
 
 use crate::logging::trace;
 use std::path::PathBuf;
@@ -15,13 +21,38 @@ use std::sync::Arc;
 use std::time::Duration;
 use tauri::AppHandle;
 use tokio::io::AsyncReadExt;
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{
+    ClientOptions, NamedPipeClient, NamedPipeServer, ServerOptions,
+};
 use tokio::sync::Notify;
 
 pub const SHUTDOWN_GRACE_SECS: u64 = 60;
 
+/// Returns the per-OS handle the GUI listens on and MCP-stdio children
+/// connect to.
+///
+/// - Unix: a real filesystem path under the aiui config dir
+///   (`<config>/gui.sock`) — its existence on disk doubles as a stale-leftover
+///   indicator after a crash.
+/// - Windows: a named-pipe address `\\.\pipe\aiui-gui` — Windows pipes are
+///   namespaced, not filesystem objects, so the same `PathBuf` carries the
+///   pipe name as a path-like string.
 pub fn socket_path(config_dir: &std::path::Path) -> PathBuf {
-    config_dir.join("gui.sock")
+    #[cfg(unix)]
+    {
+        config_dir.join("gui.sock")
+    }
+    #[cfg(windows)]
+    {
+        // We don't rely on the filesystem on Windows — the pipe name is a
+        // namespace lookup, not a file. The `config_dir` arg is unused but
+        // kept for API symmetry with the Unix branch.
+        let _ = config_dir;
+        PathBuf::from(r"\\.\pipe\aiui-gui")
+    }
 }
 
 /// Live counter of currently-attached MCP-stdio children. Owned by the Tauri
@@ -43,19 +74,30 @@ impl LifetimeStats {
     }
 }
 
-/// GUI-side: bind the socket, accept connections, and self-terminate after a
+/// GUI-side: bind the channel, accept connections, and self-terminate after a
 /// grace period once all clients are gone. Increments/decrements the shared
 /// `conns` counter on every connect/disconnect so `/health` can report the
 /// live child count without polling.
 ///
-/// Multi-instance hardening (since 0.4.33): if the socket path already
+/// Multi-instance hardening (since 0.4.33): if the channel already
 /// answers a connection, another aiui-app is alive and we are the
 /// duplicate — exit immediately rather than racing for ownership. The
-/// previous behaviour (`remove_file` then `bind`) silently tore the
-/// existing instance's listener out from under it on every dup-launch,
-/// which is how the 2026-05-04 dual-companion incident produced reset
-/// connections in the first place.
+/// previous behaviour silently tore the existing instance's listener
+/// out from under it on every dup-launch, which is how the 2026-05-04
+/// dual-companion incident produced reset connections in the first place.
 pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
+    #[cfg(unix)]
+    {
+        gui_serve_unix(sock, app, conns).await;
+    }
+    #[cfg(windows)]
+    {
+        gui_serve_windows(sock, app, conns).await;
+    }
+}
+
+#[cfg(unix)]
+async fn gui_serve_unix(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
     if sock.exists() {
         // Probe whether the existing socket is live (another aiui is
         // listening) or a stale leftover from a crashed previous run.
@@ -69,8 +111,7 @@ pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
                     sock.display()
                 ));
                 let app_for_exit = app.clone();
-                let _ = app
-                    .run_on_main_thread(move || app_for_exit.exit(1));
+                let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
                 return;
             }
             Err(_) => {
@@ -96,41 +137,7 @@ pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
     };
     trace(&format!("lifetime: listening on {}", sock.display()));
 
-    let wake = Arc::new(Notify::new());
-
-    // Shutdown watcher — armed every time conns hits 0.
-    {
-        let conns = conns.clone();
-        let wake = wake.clone();
-        let app = app.clone();
-        tokio::spawn(async move {
-            loop {
-                wake.notified().await;
-                if conns.load(Ordering::SeqCst) > 0 {
-                    continue;
-                }
-                trace(&format!(
-                    "lifetime: no clients, grace timer {SHUTDOWN_GRACE_SECS}s"
-                ));
-                tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_secs(SHUTDOWN_GRACE_SECS)) => {
-                        if conns.load(Ordering::SeqCst) == 0 {
-                            trace("lifetime: grace expired, exiting");
-                            // Hard exit bypassing Tauri's ExitRequested dance —
-                            // Cmd-Q and window-close are deliberately blocked
-                            // there, so the only legitimate shutdown path is
-                            // this one.
-                            let _ = app;
-                            std::process::exit(0);
-                        }
-                    }
-                    _ = wake.notified() => {
-                        trace("lifetime: new client within grace, staying");
-                    }
-                }
-            }
-        });
-    }
+    let wake = make_shutdown_watcher(conns.clone(), app.clone());
 
     loop {
         match listener.accept().await {
@@ -161,6 +168,134 @@ pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
     }
 }
 
+#[cfg(windows)]
+async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
+    let pipe_name = sock.to_string_lossy().to_string();
+
+    // Multi-instance probe: try to *connect* as a client. If it succeeds
+    // another aiui already serves this pipe and we're the duplicate.
+    // ERROR_FILE_NOT_FOUND (`NotFound`) means free; ERROR_PIPE_BUSY (231)
+    // means a server exists but is currently saturated — also "duplicate".
+    match ClientOptions::new().open(&pipe_name) {
+        Ok(c) => {
+            drop(c);
+            trace(&format!(
+                "lifetime: another aiui already serves {pipe_name} — exiting (multi-instance)"
+            ));
+            let app_for_exit = app.clone();
+            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+            return;
+        }
+        Err(e) if e.raw_os_error() == Some(231) => {
+            trace(&format!(
+                "lifetime: pipe {pipe_name} busy — another aiui is up, exiting"
+            ));
+            let app_for_exit = app.clone();
+            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+            return;
+        }
+        Err(_) => {
+            // Pipe name is free — proceed to bind.
+        }
+    }
+
+    let mut next_server = match ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_name)
+    {
+        Ok(s) => s,
+        Err(e) => {
+            trace(&format!(
+                "lifetime: create_pipe {pipe_name} failed: {e} — exiting (multi-instance race)"
+            ));
+            let app_for_exit = app.clone();
+            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+            return;
+        }
+    };
+    trace(&format!("lifetime: listening on {pipe_name}"));
+
+    let wake = make_shutdown_watcher(conns.clone(), app.clone());
+
+    loop {
+        if let Err(e) = next_server.connect().await {
+            trace(&format!("lifetime: pipe connect error: {e}"));
+        }
+        let stream: NamedPipeServer = next_server;
+
+        // Immediately rotate to a fresh server instance so the pipe stays
+        // available for the *next* client; otherwise a second connect
+        // attempt would race with the rotation and see ERROR_PIPE_BUSY.
+        next_server = match ServerOptions::new().create(&pipe_name) {
+            Ok(s) => s,
+            Err(e) => {
+                trace(&format!("lifetime: pipe rotate failed: {e} — exiting"));
+                let app_for_exit = app.clone();
+                let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+                return;
+            }
+        };
+
+        let n = conns.fetch_add(1, Ordering::SeqCst) + 1;
+        trace(&format!("lifetime: client connected, active={n}"));
+        let conns = conns.clone();
+        let wake = wake.clone();
+        tokio::spawn(async move {
+            let mut stream = stream;
+            let mut buf = [0u8; 64];
+            loop {
+                match stream.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => continue,
+                }
+            }
+            let left = conns.fetch_sub(1, Ordering::SeqCst) - 1;
+            trace(&format!("lifetime: client disconnected, active={left}"));
+            if left == 0 {
+                wake.notify_one();
+            }
+        });
+    }
+}
+
+/// Shared shutdown timer wiring used by both backends. Returns the wake
+/// `Notify` that connect/disconnect handlers signal — armed once when
+/// the last client leaves, and cancellable by a fresh connect within
+/// the grace period.
+fn make_shutdown_watcher(conns: Arc<AtomicUsize>, app: AppHandle) -> Arc<Notify> {
+    let wake = Arc::new(Notify::new());
+    let conns_w = conns.clone();
+    let wake_w = wake.clone();
+    tokio::spawn(async move {
+        loop {
+            wake_w.notified().await;
+            if conns_w.load(Ordering::SeqCst) > 0 {
+                continue;
+            }
+            trace(&format!(
+                "lifetime: no clients, grace timer {SHUTDOWN_GRACE_SECS}s"
+            ));
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(SHUTDOWN_GRACE_SECS)) => {
+                    if conns_w.load(Ordering::SeqCst) == 0 {
+                        trace("lifetime: grace expired, exiting");
+                        // Hard exit bypassing Tauri's ExitRequested dance —
+                        // Cmd-Q and window-close are deliberately blocked
+                        // there, so the only legitimate shutdown path is
+                        // this one.
+                        let _ = app;
+                        std::process::exit(0);
+                    }
+                }
+                _ = wake_w.notified() => {
+                    trace("lifetime: new client within grace, staying");
+                }
+            }
+        }
+    });
+    wake
+}
+
 /// True iff this process appears to be running in an interactive desktop
 /// session — i.e. somewhere a user could see a window. Returns false on
 /// remote/headless contexts (SSH, CI, docker exec) where launching a GUI
@@ -186,14 +321,14 @@ pub fn is_interactive_session() -> bool {
 /// MCP child process. On an interactive desktop session: if the GUI isn't
 /// running, launch it; if it dies, relaunch and reattach. On
 /// remote/headless hosts: never spawn a GUI — just keep retrying the
-/// socket attach in case a tunnel-fronted GUI on the user's machine
+/// channel attach in case a tunnel-fronted GUI on the user's machine
 /// becomes reachable. The loop only exits when this MCP-stdio process
 /// itself is terminated, which happens when the parent (Claude Desktop /
 /// Claude Code) tears down its MCP children.
 ///
-/// "Auto-resurrect" contract holds for local-Mac usage. On remotes the
-/// MCP-stdio child trusts the SSH-reverse-tunnel to forward port 7777
-/// back to the user's machine where the actual aiui GUI lives.
+/// "Auto-resurrect" contract holds for local-Mac and local-Windows usage.
+/// On remotes the MCP-stdio child trusts the SSH-reverse-tunnel to forward
+/// port 7777 back to the user's machine where the actual aiui GUI lives.
 pub async fn mcp_attach(sock: PathBuf) {
     let interactive = is_interactive_session();
     if !interactive {
@@ -204,39 +339,23 @@ pub async fn mcp_attach(sock: PathBuf) {
     }
 
     loop {
-        // Try to attach. If the socket isn't there, spawn the GUI and retry.
         let mut attached = false;
         for attempt in 1..=30u32 {
-            match UnixStream::connect(&sock).await {
-                Ok(mut stream) => {
-                    trace(&format!(
-                        "lifetime: mcp attached to {} (attempt {attempt})",
-                        sock.display()
-                    ));
+            match try_attach(&sock).await {
+                Ok(()) => {
                     attached = true;
-                    let mut buf = [0u8; 64];
-                    loop {
-                        match stream.read(&mut buf).await {
-                            Ok(0) | Err(_) => break,
-                            Ok(_) => continue,
-                        }
-                    }
                     trace("lifetime: mcp socket closed — GUI is gone, will relaunch");
                     break;
                 }
                 Err(e) => {
                     if attempt == 1 && interactive {
                         trace(&format!(
-                            "lifetime: gui socket not ready ({e}), launching GUI via `open --auto`"
+                            "lifetime: gui channel not ready ({e}), launching GUI"
                         ));
-                        let _ = std::process::Command::new("open")
-                            .args(["-g", "-a", "aiui", "--args", "--auto"])
-                            .spawn();
+                        spawn_gui_detached();
                     } else if attempt == 1 {
-                        // Non-interactive: don't spawn, just log the first miss
-                        // so the trace explains why we're waiting.
                         trace(&format!(
-                            "lifetime: gui socket not ready ({e}), \
+                            "lifetime: gui channel not ready ({e}), \
                              non-interactive session — GUI must be reachable \
                              via SSH-reverse-tunnel from the user's machine"
                         ));
@@ -246,11 +365,84 @@ pub async fn mcp_attach(sock: PathBuf) {
             }
         }
         if !attached {
-            trace("lifetime: mcp gave up waiting for gui socket after 30 attempts; retrying in 5s");
+            trace(
+                "lifetime: mcp gave up waiting for gui channel after 30 attempts; retrying in 5s",
+            );
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
         // GUI was connected and has now closed; loop back to resurrect it
         // (or wait + retry if launch failed / suppressed).
+    }
+}
+
+/// Try to connect once and drain. Returns Ok(()) when the channel was
+/// established and later closed by the server (normal lifecycle), Err on
+/// connect failure.
+async fn try_attach(sock: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let mut stream = UnixStream::connect(sock).await?;
+        trace(&format!("lifetime: mcp attached to {}", sock.display()));
+        let mut buf = [0u8; 64];
+        loop {
+            match stream.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => continue,
+            }
+        }
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        let pipe_name = sock.to_string_lossy().to_string();
+        let mut stream: NamedPipeClient = ClientOptions::new().open(&pipe_name)?;
+        trace(&format!("lifetime: mcp attached to {pipe_name}"));
+        let mut buf = [0u8; 64];
+        loop {
+            match stream.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => continue,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Spawn the GUI process and detach so the MCP-stdio child does not own
+/// it.
+///
+/// - macOS: `open -g -a aiui --args --auto` hands ownership to
+///   LaunchServices, which respects LSUIElement (no Dock icon flash).
+/// - Windows: re-spawn the same binary without `--mcp-stdio`. The child
+///   becomes a sibling under Claude Desktop's process tree, which is fine
+///   because Windows does not propagate exit signals to children the way
+///   macOS does. NSIS does not register an `aiui` LaunchServices-style
+///   alias, so we identify the binary via `current_exe()`.
+fn spawn_gui_detached() {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("open")
+            .args(["-g", "-a", "aiui", "--args", "--auto"])
+            .spawn();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        match std::env::current_exe() {
+            Ok(exe) => {
+                let _ = std::process::Command::new(exe).arg("--auto").spawn();
+            }
+            Err(e) => {
+                trace(&format!(
+                    "lifetime: cannot locate own binary to spawn GUI: {e}"
+                ));
+            }
+        }
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        if let Ok(exe) = std::env::current_exe() {
+            let _ = std::process::Command::new(exe).arg("--auto").spawn();
+        }
     }
 }
 

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -26,8 +26,8 @@ fn home() -> PathBuf {
 fn claude_desktop_config_path() -> PathBuf {
     #[cfg(target_os = "windows")]
     {
-        let base = dirs::config_dir().unwrap_or_else(|| home());
-        return base.join("Claude").join("claude_desktop_config.json");
+        let base = dirs::config_dir().unwrap_or_else(home);
+        base.join("Claude").join("claude_desktop_config.json")
     }
     #[cfg(not(target_os = "windows"))]
     {

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -17,6 +17,28 @@ fn home() -> PathBuf {
     dirs::home_dir().expect("home dir")
 }
 
+/// Path to Claude Desktop's user config file. Differs per OS:
+///
+/// - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+/// - Windows: `%APPDATA%\Claude\claude_desktop_config.json` —
+///   `dirs::config_dir()` resolves Roaming AppData on Windows.
+/// - Linux: same XDG-style layout as macOS for completeness.
+fn claude_desktop_config_path() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        let base = dirs::config_dir().unwrap_or_else(|| home());
+        return base.join("Claude").join("claude_desktop_config.json");
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        home()
+            .join("Library")
+            .join("Application Support")
+            .join("Claude")
+            .join("claude_desktop_config.json")
+    }
+}
+
 fn backup(path: &PathBuf) -> std::io::Result<()> {
     if !path.exists() {
         return Ok(());
@@ -31,11 +53,7 @@ fn backup(path: &PathBuf) -> std::io::Result<()> {
 }
 
 pub fn patch_claude_desktop_config(app_binary_path: &str) -> StepResult {
-    let path = home()
-        .join("Library")
-        .join("Application Support")
-        .join("Claude")
-        .join("claude_desktop_config.json");
+    let path = claude_desktop_config_path();
 
     let existing: Value = if path.exists() {
         match fs::read_to_string(&path) {
@@ -259,18 +277,35 @@ pub fn push_token_to_remote(host_alias: &str, token_path: &str) -> StepResult {
 }
 
 pub fn app_binary_path() -> String {
-    // when bundled, the executable sits at aiui.app/Contents/MacOS/aiui
+    // when bundled, the executable sits at aiui.app/Contents/MacOS/aiui on
+    // macOS and at the NSIS install dir on Windows. `current_exe` is the
+    // truth source on both — the per-OS string is only a last-ditch
+    // fallback for environments where `current_exe` errors out (rare).
     std::env::current_exe()
         .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|_| "/Applications/aiui.app/Contents/MacOS/aiui".to_string())
+        .unwrap_or_else(|_| default_app_binary_path().to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn default_app_binary_path() -> &'static str {
+    "/Applications/aiui.app/Contents/MacOS/aiui"
+}
+
+#[cfg(target_os = "windows")]
+fn default_app_binary_path() -> &'static str {
+    // Default per-user NSIS install location. If the user picked a custom
+    // path during install, `current_exe` returns the truth and this
+    // fallback never fires.
+    r"C:\Users\Public\aiui\aiui.exe"
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn default_app_binary_path() -> &'static str {
+    "/usr/local/bin/aiui"
 }
 
 pub fn is_claude_config_current(app_binary_path: &str) -> bool {
-    let path = home()
-        .join("Library")
-        .join("Application Support")
-        .join("Claude")
-        .join("claude_desktop_config.json");
+    let path = claude_desktop_config_path();
     let Ok(s) = fs::read_to_string(&path) else {
         return false;
     };
@@ -309,20 +344,49 @@ pub fn is_claude_code_config_current(app_binary_path: &str) -> bool {
 }
 
 /// Best-effort check whether the Claude Desktop application is currently
-/// running on this Mac. Used to switch the "Restart Claude Desktop" button
-/// label between Start / Restart so we don't ask the user to "restart"
+/// running. Used to switch the "Restart Claude Desktop" button label
+/// between Start / Restart so we don't ask the user to "restart"
 /// something that isn't running.
 ///
-/// Pure read-only — uses `pgrep -f` against the typical install path. If
-/// `pgrep` is missing or errors, we assume "not running" rather than
-/// blocking the UI.
+/// Pure read-only. Per-OS process probe:
+///
+/// - macOS: `pgrep -f /Applications/Claude.app/` matches against the full
+///   command line, which catches helper processes too (still a true positive).
+/// - Windows: `tasklist /FI "IMAGENAME eq Claude.exe" /NH` lists running
+///   processes by image name; non-empty stdout means at least one match.
+///
+/// If the probe errors out we assume "not running" rather than blocking
+/// the UI.
 pub fn is_claude_desktop_running() -> bool {
-    let out = std::process::Command::new("pgrep")
-        .args(["-f", "/Applications/Claude.app/"])
-        .output();
-    match out {
-        Ok(o) => o.status.success() && !o.stdout.is_empty(),
-        Err(_) => false,
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("pgrep")
+            .args(["-f", "/Applications/Claude.app/"])
+            .output();
+        match out {
+            Ok(o) => o.status.success() && !o.stdout.is_empty(),
+            Err(_) => false,
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let out = std::process::Command::new("tasklist")
+            .args(["/FI", "IMAGENAME eq Claude.exe", "/NH"])
+            .output();
+        match out {
+            Ok(o) if o.status.success() => {
+                // tasklist prints "INFO: No tasks are running …" on a
+                // miss instead of empty stdout, so look for the actual
+                // image name (case-insensitive).
+                let s = String::from_utf8_lossy(&o.stdout).to_lowercase();
+                s.contains("claude.exe")
+            }
+            _ => false,
+        }
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        false
     }
 }
 

--- a/companion/src-tauri/tauri.ci.conf.json
+++ b/companion/src-tauri/tauri.ci.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -39,6 +39,11 @@
     ],
     "macOS": {
       "minimumSystemVersion": "11.0"
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      }
     }
   }
 }

--- a/python/src/aiui_mcp/server.py
+++ b/python/src/aiui_mcp/server.py
@@ -51,7 +51,31 @@ log = logging.getLogger("aiui")
 log.info("---- %s started pid=%d ----", BUILD_INFO, os.getpid())
 
 
-TOKEN_PATH = Path(os.environ.get("AIUI_TOKEN_PATH", "~/.config/aiui/token")).expanduser()
+def _default_token_path() -> str:
+    """Per-OS default location of the companion's pairing token.
+
+    The companion (Tauri side) writes the token to its OS-correct config
+    directory; this server reads from the matching path so the two sides
+    agree without needing AIUI_TOKEN_PATH to be set.
+
+    - Linux / macOS: `~/.config/aiui/token` — XDG-style. macOS keeps the
+      same path as Linux so existing v0.4.x installs don't have to migrate.
+    - Windows: `%APPDATA%\\aiui\\token` — matches Tauri's `dirs::config_dir()`.
+
+    In practice the Python side runs on the Linux remote almost always —
+    the Windows branch only kicks in if someone runs `aiui-mcp` directly
+    on a Windows host (rare, but no longer broken).
+    """
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return str(Path(appdata) / "aiui" / "token")
+        # Fallback if APPDATA is somehow unset — unusual on Windows.
+        return str(Path.home() / "AppData" / "Roaming" / "aiui" / "token")
+    return "~/.config/aiui/token"
+
+
+TOKEN_PATH = Path(os.environ.get("AIUI_TOKEN_PATH", _default_token_path())).expanduser()
 ENDPOINT = os.environ.get("AIUI_ENDPOINT", "http://127.0.0.1:7777")
 TIMEOUT_S = float(os.environ.get("AIUI_TIMEOUT_S", "120"))
 HEALTH_TIMEOUT_S = float(os.environ.get("AIUI_HEALTH_TIMEOUT_S", "3"))


### PR DESCRIPTION
## Summary

Port aiui from macOS-only to Windows, with feature parity. Two commits:

1. **Phase 1 — platform-clean Rust core** (`feat: Windows-port Phase 1`)
   The Rust core compiles for both targets without behavioural change on
   macOS. All Mac-only assumptions (XDG paths, `ps -axo`, `pgrep`, `open`,
   `/Applications/aiui.app` strings, Unix domain socket, `Info.plist`
   version probe) are now `cfg`-gated or replaced with cross-platform
   equivalents (`sysinfo`, named pipes, `tasklist`, `cmd /C start`).

2. **Phase 2a — CI cross-build + NSIS artifact** (`ci: add Windows build matrix`)
   GHA matrix builds the same checks on `macos-14` and `windows-latest`,
   produces an NSIS `.exe` + minisign `.sig` as a 14-day artifact, and
   wires `webviewInstallMode = downloadBootstrapper` into `tauri.conf.json`
   so the installer auto-bootstraps WebView2 on the user's machine.

## Why now

We don't have a Windows machine for interactive testing. CI is the
cheapest way to exercise the platform-clean code path against a real
Windows toolchain before we rent a VM for E2E.

## What's verified

On macOS arm64 (local):
- `cargo check`, `cargo clippy`: clean
- `cargo test --lib`: 60/60 passed
- `cargo build --release`: 57s
- `./target/release/aiui --mcp-stdio < /dev/null`: clean exit

On Windows x86_64: this PR's CI is the first run.

## Out of scope

- Phase 2b: interactive E2E on a Windows VM (Azure Spot / Windows 365
  / Parallels) — pairing flow, `confirm.image` with Windows paths,
  reverse-tunnel from Windows → remote Linux.
- Phase 3: multi-platform `latest.json` updater feed.
- Phase 4: code-signing (planned to ship unsigned for v1).

## Test plan

- [ ] CI: macOS job stays green (no Mac regression).
- [ ] CI: Windows job builds NSIS installer successfully.
- [ ] CI: download artifact, run on a Windows VM (Phase 2b).
- [ ] Windows VM: install, GUI launches, Setup-Window renders with native title bar.
- [ ] Windows VM: pairing flow, `scp` token to remote Linux, Claude Desktop config patched in `%APPDATA%\Claude\`.
- [ ] Windows VM: `/aiui:test-dialog` from remote → Windows dialog window.
- [ ] Windows VM: `confirm.image` with `C:\path\to\file.png`.
- [ ] Mac regression: pairing, dialog, top-most, stale-child sweep, uninstall hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)