### PR TITLE
fix: orphan ssh-NTR cleanup + traced exit paths (v0.4.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.37] — 2026-05-05
+
+### Fixed
+
+- **Orphan ssh-NTR tunnels no longer block fresh aiui starts.** When an
+  earlier aiui exited via `app.exit()` or `process::exit()` (multi-
+  instance race, lifetime-grace timeout, HTTP-bind failure, uninstall),
+  Rust Drop was skipped and `tokio::process::Child::kill_on_drop` never
+  fired — `tunnel.rs`'s `ssh -NTR 7777:localhost:7777 ...` children
+  re-parented to launchd (ppid=1) and survived. With `ServerAlive`
+  keeping their SSH session healthy, they held the remote-side port
+  indefinitely. Every fresh aiui then failed `-NTR` with
+  `ExitOnForwardFailure` and fell back into "shared forward" mode
+  forever, even though *its* parent was the only legitimate tunnel
+  owner. Two new mechanisms close this:
+  - **Pre-exit cleanup.** Every `app.exit()` / `process::exit()` in
+    the GUI now calls `housekeeping::pre_exit_cleanup` first, which
+    finds and signals our own ssh-NTR children before the process
+    departs. Trace logs each exit with a reason string so the killer
+    path is identifiable in `aiui-trace.log` next time something
+    goes wrong.
+  - **Startup orphan sweep.** GUI startup signals every ssh-NTR-on-
+    `cfg.http_port` process whose ppid is 1 — orphans inherited from
+    a previously-crashed aiui. Filter is tight (exact arg shape, no
+    heuristic `pkill -f`) so unrelated SSH sessions are never
+    touched.
+- **Trace at every exit path.** `quit_app/uninstall`,
+  `setup-close-no-children`, `http-bind-error`, `multi-instance-live`,
+  `multi-instance-bind-race`, `multi-instance-pipe-busy`,
+  `multi-instance-pipe-race`, `pipe-rotate-failed`, and
+  `grace-expired` are now individually labeled in the trace. The
+  v0.4.36 respawn-loop investigation was crippled by the absence of
+  exit-path attribution; this is the foundation for diagnosing the
+  next one.
+
 ## [0.4.36] — 2026-05-04
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.36"
+version = "0.4.37"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.36"
+version = "0.4.37"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/housekeeping.rs
+++ b/companion/src-tauri/src/housekeeping.rs
@@ -57,6 +57,10 @@ struct StaleChild {
 #[derive(Debug, Clone)]
 struct ProcSnap {
     pid: u32,
+    /// Parent PID. On macOS/Linux this is the immediate parent; orphans
+    /// re-parent to launchd/init (pid 1). `None` only when sysinfo can't
+    /// resolve the parent (rare; treat as "unknown, don't act").
+    ppid: Option<u32>,
     exe: String,
     args: Vec<String>,
 }
@@ -86,6 +90,7 @@ fn snapshot_processes() -> Vec<ProcSnap> {
                 .collect();
             ProcSnap {
                 pid: pid.as_u32(),
+                ppid: p.parent().map(|p| p.as_u32()),
                 exe,
                 args,
             }
@@ -203,6 +208,84 @@ pub fn kill_all_mcp_stdio_children() -> usize {
     children.len()
 }
 
+/// True iff `args` look like a `ssh -N -T -R <port>:localhost:<port> ...`
+/// invocation — exactly the shape `tunnel.rs:run_tunnel` spawns. Tight
+/// match so we never accidentally signal an unrelated `ssh` someone has
+/// running for a different reason. v0.4.37.
+fn is_aiui_ssh_ntr_for_port(args: &[String], port: u16) -> bool {
+    if args.first().map(String::as_str) != Some("ssh") {
+        return false;
+    }
+    let needle = format!("{port}:localhost:{port}");
+    let has_n = args.iter().any(|a| a == "-N");
+    let has_t = args.iter().any(|a| a == "-T");
+    let mut has_r = false;
+    let mut iter = args.iter().peekable();
+    while let Some(a) = iter.next() {
+        if a == "-R" {
+            if let Some(next) = iter.peek() {
+                if next.as_str() == needle {
+                    has_r = true;
+                    break;
+                }
+            }
+        }
+    }
+    has_n && has_t && has_r
+}
+
+/// Filter: every `ssh -NTR <port>:localhost:<port>` process matching our
+/// tunnel signature. When `only_orphans` is true, restrict to processes
+/// whose ppid is 1 (launchd/init) — the case where an earlier aiui crashed
+/// out of `app.exit()` / `process::exit()` without firing `kill_on_drop`,
+/// leaving the ssh child re-parented to launchd. When false, return all
+/// matching processes (used pre-exit so we sweep our own active tunnels
+/// before the rust-side Drop is skipped). Pure over a snapshot.
+fn find_aiui_ssh_ntr(snap: &[ProcSnap], port: u16, only_orphans: bool) -> Vec<u32> {
+    snap.iter()
+        .filter(|p| is_aiui_ssh_ntr_for_port(&p.args, port))
+        .filter(|p| !only_orphans || p.ppid == Some(1))
+        .map(|p| p.pid)
+        .collect()
+}
+
+/// Convenience wrapper for the pre-exit path: traces the imminent exit
+/// and sweeps our own active ssh-NTR tunnels so they don't outlive us as
+/// launchd-orphans when `app.exit()` / `process::exit()` skip Rust Drop.
+///
+/// Called immediately before every exit point in the GUI process. v0.4.37.
+pub fn pre_exit_cleanup(port: u16, reason: &str) {
+    trace(&format!(
+        "[aiui] exit ({reason}): cleaning up ssh-NTR tunnels before shutdown"
+    ));
+    let killed = kill_aiui_ssh_ntr(port, false);
+    trace(&format!(
+        "[aiui] exit ({reason}): swept {killed} ssh-NTR child(ren); proceeding"
+    ));
+}
+
+/// Sweep ssh-NTR tunnel children — see `find_aiui_ssh_ntr` for the filter.
+/// Returns the number of processes signalled. Logs each kill to the trace
+/// for post-mortem debuggability of the v0.4.36 orphan-tunnel-loop.
+pub fn kill_aiui_ssh_ntr(port: u16, only_orphans: bool) -> usize {
+    let snap = snapshot_processes();
+    let pids = find_aiui_ssh_ntr(&snap, port, only_orphans);
+    let mode = if only_orphans { "orphan" } else { "all" };
+    for pid in &pids {
+        trace(&format!(
+            "housekeeping: killing {mode} ssh-NTR tunnel pid={pid}"
+        ));
+        terminate_pid(*pid);
+    }
+    if !pids.is_empty() {
+        trace(&format!(
+            "housekeeping: terminated {} {mode} ssh-NTR tunnel(s) on :{port}",
+            pids.len()
+        ));
+    }
+    pids.len()
+}
+
 /// Pure decision: given our compile-time version string and the version
 /// string read from the on-disk bundle, return `true` when this in-memory
 /// binary is stale (i.e. should exit so it can be respawned).
@@ -279,6 +362,16 @@ mod tests {
     fn snap(pid: u32, exe: &str, args: &[&str]) -> ProcSnap {
         ProcSnap {
             pid,
+            ppid: Some(0),
+            exe: exe.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn snap_with_ppid(pid: u32, ppid: u32, exe: &str, args: &[&str]) -> ProcSnap {
+        ProcSnap {
+            pid,
+            ppid: Some(ppid),
             exe: exe.to_string(),
             args: args.iter().map(|s| s.to_string()).collect(),
         }
@@ -379,5 +472,93 @@ mod tests {
         assert!(is_aiui_binary(r"C:\Program Files\aiui\AIUI.EXE"));
         assert!(is_aiui_binary("/Applications/aiui.app/Contents/MacOS/aiui"));
         assert!(!is_aiui_binary("/usr/bin/python3"));
+    }
+
+    fn ssh_ntr_args(host: &str, port: u16) -> Vec<String> {
+        // Mirrors the spawn in tunnel.rs:run_tunnel exactly.
+        [
+            "ssh",
+            "-N",
+            "-T",
+            "-R",
+            &format!("{port}:localhost:{port}"),
+            "-o",
+            "ServerAliveInterval=30",
+            "-o",
+            "ServerAliveCountMax=3",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "--",
+            host,
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    #[test]
+    fn ssh_ntr_signature_matches_real_tunnel_args() {
+        let a = ssh_ntr_args("dev@devhost", 7777);
+        assert!(is_aiui_ssh_ntr_for_port(&a, 7777));
+    }
+
+    #[test]
+    fn ssh_ntr_signature_rejects_other_ports() {
+        let a = ssh_ntr_args("dev@devhost", 7777);
+        assert!(!is_aiui_ssh_ntr_for_port(&a, 8888));
+    }
+
+    #[test]
+    fn ssh_ntr_signature_rejects_local_forward() {
+        // -L instead of -R — local forward, not our reverse tunnel.
+        let a: Vec<String> = ["ssh", "-N", "-T", "-L", "7777:localhost:7777", "host"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(!is_aiui_ssh_ntr_for_port(&a, 7777));
+    }
+
+    #[test]
+    fn ssh_ntr_signature_rejects_non_ssh_command() {
+        let a: Vec<String> = ["bash", "-c", "ssh -N -T -R 7777:localhost:7777 host"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(!is_aiui_ssh_ntr_for_port(&a, 7777));
+    }
+
+    #[test]
+    fn find_aiui_ssh_ntr_orphans_only_filters_on_ppid() {
+        let s = vec![
+            // Orphan from a crashed earlier aiui — re-parented to pid 1.
+            snap_with_ppid(30295, 1, "/usr/bin/ssh", &ssh_ntr_args("dev@devhost", 7777).iter().map(String::as_str).collect::<Vec<_>>()),
+            // Active tunnel from the current GUI (ppid != 1).
+            snap_with_ppid(40000, 76770, "/usr/bin/ssh", &ssh_ntr_args("customer@macmini", 7777).iter().map(String::as_str).collect::<Vec<_>>()),
+        ];
+        let orphans = find_aiui_ssh_ntr(&s, 7777, true);
+        assert_eq!(orphans, vec![30295]);
+
+        let all = find_aiui_ssh_ntr(&s, 7777, false);
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn find_aiui_ssh_ntr_ignores_unrelated_ssh() {
+        let unrelated: Vec<String> = ["ssh", "user@host", "ls"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let s = vec![ProcSnap {
+            pid: 99999,
+            ppid: Some(1),
+            exe: "/usr/bin/ssh".into(),
+            args: unrelated,
+        }];
+        assert!(find_aiui_ssh_ntr(&s, 7777, true).is_empty());
+        assert!(find_aiui_ssh_ntr(&s, 7777, false).is_empty());
     }
 }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -317,6 +317,11 @@ async fn quit_app(app: tauri::AppHandle) -> Result<(), String> {
     // ourselves. Otherwise an already-running mcp_attach loop on a child
     // can race the GUI exit and re-launch us.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    let port = app
+        .try_state::<Arc<config::AppConfig>>()
+        .map(|c| c.http_port)
+        .unwrap_or(7777);
+    housekeeping::pre_exit_cleanup(port, "quit_app/uninstall");
     app.exit(0);
     Ok(())
 }
@@ -987,16 +992,36 @@ pub fn run() {
                     // Hop to main thread to call exit cleanly.
                     let app_for_exit = app_handle_for_exit.clone();
                     let _ = app_handle_for_exit.run_on_main_thread(move || {
+                        housekeeping::pre_exit_cleanup(
+                            port_for_error,
+                            "http-bind-error",
+                        );
                         app_for_exit.exit(1);
                     });
                 }
             });
 
+            // Startup orphan sweep: any `ssh -NTR <port>:localhost:<port>`
+            // process that's been re-parented to launchd (ppid=1) is a
+            // tunnel from a previously-crashed aiui that exited via
+            // `app.exit()` / `process::exit()` and skipped Drop. Left
+            // alive, it holds the remote-side port and forces the new
+            // GUI into shared-forward mode forever — the v0.4.36 loop
+            // root cause. Sweep before binding our own tunnels. v0.4.37.
+            {
+                let port = cfg.http_port;
+                let killed = housekeeping::kill_aiui_ssh_ntr(port, true);
+                logging::trace(&format!(
+                    "[aiui] startup: swept {killed} orphan ssh-NTR tunnel(s) on :{port}"
+                ));
+            }
+
             // Lifetime socket — couples GUI lifetime to MCP-stdio children.
             // Counter is shared with `/health` via `LifetimeStats`.
+            let lifetime_port = cfg.http_port;
             rt.spawn(async move {
                 let sock = lifetime::socket_path(&cfg_lt.config_dir);
-                lifetime::gui_serve(sock, app_handle_lt, lifetime_lt.conns.clone()).await;
+                lifetime::gui_serve(sock, app_handle_lt, lifetime_lt.conns.clone(), lifetime_port).await;
             });
 
             // Auto-start reverse tunnels for every registered remote.
@@ -1149,6 +1174,11 @@ pub fn run() {
                         log::info!(
                             "[aiui] setup window closed and no MCP-stdio children attached — quitting; auto-resurrect will bring us back on next tool call"
                         );
+                        let port = app_for_check
+                            .try_state::<Arc<config::AppConfig>>()
+                            .map(|c| c.http_port)
+                            .unwrap_or(7777);
+                        housekeeping::pre_exit_cleanup(port, "setup-close-no-children");
                         app_for_check.exit(0);
                     } else {
                         log::debug!(

--- a/companion/src-tauri/src/lifetime.rs
+++ b/companion/src-tauri/src/lifetime.rs
@@ -85,19 +85,19 @@ impl LifetimeStats {
 /// previous behaviour silently tore the existing instance's listener
 /// out from under it on every dup-launch, which is how the 2026-05-04
 /// dual-companion incident produced reset connections in the first place.
-pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
+pub async fn gui_serve(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>, http_port: u16) {
     #[cfg(unix)]
     {
-        gui_serve_unix(sock, app, conns).await;
+        gui_serve_unix(sock, app, conns, http_port).await;
     }
     #[cfg(windows)]
     {
-        gui_serve_windows(sock, app, conns).await;
+        gui_serve_windows(sock, app, conns, http_port).await;
     }
 }
 
 #[cfg(unix)]
-async fn gui_serve_unix(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
+async fn gui_serve_unix(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>, http_port: u16) {
     if sock.exists() {
         // Probe whether the existing socket is live (another aiui is
         // listening) or a stale leftover from a crashed previous run.
@@ -111,7 +111,10 @@ async fn gui_serve_unix(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) 
                     sock.display()
                 ));
                 let app_for_exit = app.clone();
-                let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+                let _ = app.run_on_main_thread(move || {
+                    crate::housekeeping::pre_exit_cleanup(http_port, "multi-instance-live");
+                    app_for_exit.exit(1)
+                });
                 return;
             }
             Err(_) => {
@@ -131,13 +134,16 @@ async fn gui_serve_unix(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) 
                 sock.display()
             ));
             let app_for_exit = app.clone();
-            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+            let _ = app.run_on_main_thread(move || {
+                crate::housekeeping::pre_exit_cleanup(http_port, "multi-instance-bind-race");
+                app_for_exit.exit(1)
+            });
             return;
         }
     };
     trace(&format!("lifetime: listening on {}", sock.display()));
 
-    let wake = make_shutdown_watcher(conns.clone(), app.clone());
+    let wake = make_shutdown_watcher(conns.clone(), app.clone(), http_port);
 
     loop {
         match listener.accept().await {
@@ -169,7 +175,7 @@ async fn gui_serve_unix(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) 
 }
 
 #[cfg(windows)]
-async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>) {
+async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize>, http_port: u16) {
     let pipe_name = sock.to_string_lossy().to_string();
 
     // Multi-instance probe: try to *connect* as a client. If it succeeds
@@ -183,7 +189,10 @@ async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize
                 "lifetime: another aiui already serves {pipe_name} — exiting (multi-instance)"
             ));
             let app_for_exit = app.clone();
-            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+            let _ = app.run_on_main_thread(move || {
+                crate::housekeeping::pre_exit_cleanup(http_port, "multi-instance-live");
+                app_for_exit.exit(1)
+            });
             return;
         }
         Err(e) if e.raw_os_error() == Some(231) => {
@@ -191,7 +200,10 @@ async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize
                 "lifetime: pipe {pipe_name} busy — another aiui is up, exiting"
             ));
             let app_for_exit = app.clone();
-            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+            let _ = app.run_on_main_thread(move || {
+                crate::housekeeping::pre_exit_cleanup(http_port, "multi-instance-pipe-busy");
+                app_for_exit.exit(1)
+            });
             return;
         }
         Err(_) => {
@@ -209,13 +221,16 @@ async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize
                 "lifetime: create_pipe {pipe_name} failed: {e} — exiting (multi-instance race)"
             ));
             let app_for_exit = app.clone();
-            let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+            let _ = app.run_on_main_thread(move || {
+                crate::housekeeping::pre_exit_cleanup(http_port, "multi-instance-pipe-race");
+                app_for_exit.exit(1)
+            });
             return;
         }
     };
     trace(&format!("lifetime: listening on {pipe_name}"));
 
-    let wake = make_shutdown_watcher(conns.clone(), app.clone());
+    let wake = make_shutdown_watcher(conns.clone(), app.clone(), http_port);
 
     loop {
         if let Err(e) = next_server.connect().await {
@@ -231,7 +246,10 @@ async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize
             Err(e) => {
                 trace(&format!("lifetime: pipe rotate failed: {e} — exiting"));
                 let app_for_exit = app.clone();
-                let _ = app.run_on_main_thread(move || app_for_exit.exit(1));
+                let _ = app.run_on_main_thread(move || {
+                    crate::housekeeping::pre_exit_cleanup(http_port, "pipe-rotate-failed");
+                    app_for_exit.exit(1)
+                });
                 return;
             }
         };
@@ -262,7 +280,7 @@ async fn gui_serve_windows(sock: PathBuf, app: AppHandle, conns: Arc<AtomicUsize
 /// `Notify` that connect/disconnect handlers signal — armed once when
 /// the last client leaves, and cancellable by a fresh connect within
 /// the grace period.
-fn make_shutdown_watcher(conns: Arc<AtomicUsize>, app: AppHandle) -> Arc<Notify> {
+fn make_shutdown_watcher(conns: Arc<AtomicUsize>, app: AppHandle, http_port: u16) -> Arc<Notify> {
     let wake = Arc::new(Notify::new());
     let conns_w = conns.clone();
     let wake_w = wake.clone();
@@ -283,6 +301,7 @@ fn make_shutdown_watcher(conns: Arc<AtomicUsize>, app: AppHandle) -> Arc<Notify>
                         // Cmd-Q and window-close are deliberately blocked
                         // there, so the only legitimate shutdown path is
                         // this one.
+                        crate::housekeeping::pre_exit_cleanup(http_port, "grace-expired");
                         let _ = app;
                         std::process::exit(0);
                     }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.36",
+  "version": "0.4.37",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.36"
+version = "0.4.37"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Root cause of the v0.4.36 setup-window respawn-loop. Trace from a real reproduction (PIDs 30295/30301 surviving since 2026-05-02 with ppid=1) showed that **every ssh-NTR tunnel child created by tunnel.rs becomes a launchd-orphan whenever aiui exits via `app.exit()` or `process::exit()`** — Drop is skipped, `tokio::process::Child::kill_on_drop(true)` never fires. With `ServerAliveInterval=30` keeping the SSH session alive, the orphan holds the remote-side port indefinitely. Every subsequent fresh aiui start fails its own `-NTR` (ExitOnForwardFailure) and falls back into shared-forward poll mode forever.

Two complementary mechanisms close it:

- **`housekeeping::pre_exit_cleanup(port, reason)`** called immediately before every `app.exit()` / `process::exit()` in the GUI process. Sweeps our own active ssh-NTR-on-`port` children before the process departs. Each exit path now passes a reason string that's traced, so the next investigation has actual attribution. Wired into all 8 GUI exit sites: setup-close-no-children, http-bind-error, multi-instance-live, multi-instance-bind-race, multi-instance-pipe-busy, multi-instance-pipe-race, pipe-rotate-failed, grace-expired (plus the existing quit_app/uninstall path).
- **Startup orphan sweep** in `lib.rs:run()` setup. Every `ssh -N -T -R <port>:localhost:<port> ...` process whose ppid is 1 gets signalled before the new GUI binds its own tunnels. Tight match (exact arg shape per `tunnel.rs:run_tunnel`) — no heuristic `pkill -f`, so unrelated SSH sessions are never touched.

The ssh-NTR signature filter is exposed via `is_aiui_ssh_ntr_for_port` and `find_aiui_ssh_ntr` as pure functions, with 5 new unit tests covering: real tunnel-args match, port-mismatch rejection, `-L`-instead-of-`-R` rejection, non-`ssh`-command rejection, and ppid-based orphan filtering.

## Test plan

- [x] `cargo check` clean.
- [x] `cargo test --lib` — 66 passed (was 61 + 5 new ssh-NTR sig tests).
- [ ] Local repro: `pkill 30295 30301`, restart aiui, both Settings remotes flip from "geteilter Forward" to "verbunden".
- [ ] Trigger an exit deliberately (e.g. `lsof` → SIGKILL one aiui to provoke multi-instance-bind-race), observe `[aiui] exit (multi-instance-bind-race): swept N ssh-NTR child(ren)` in `/tmp/aiui-trace.log`, verify `ps aux | grep "ssh.*7777"` returns no matches afterward.
- [ ] Restart Claude Desktop, confirm respawn-loop does not return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)