### PR TITLE
fix: mermaid flowchart labels render again (v0.4.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.38] — 2026-05-06
+
+### Fixed
+
+- **Mermaid flowchart node labels are visible again.** Mermaid 11
+  renders flowchart node labels inside `<foreignObject>` SVG elements
+  (HTML-in-SVG, for proper word-wrapping). The DOMPurify pass in
+  `MermaidView.svelte` was stripping `<foreignObject>` outright as a
+  belt-and-braces measure on top of `securityLevel: 'strict'` — the
+  result was correctly-shaped, correctly-coloured boxes with **no
+  text**. Reproduced 2026-05-06 with a Bundesrepublik-Verfassungsorgane
+  flowchart. The forbid-list now keeps only `<script>` (event-handler
+  attributes are still caught by `FORBID_ATTR` and the svg/svgFilters
+  profile), and Mermaid's native HTML labels render through.
+
 ## [0.4.37] — 2026-05-05
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.37"
+version = "0.4.38"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.37",
+  "version": "0.4.38",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/lib/widgets/MermaidView.svelte
+++ b/companion/src/lib/widgets/MermaidView.svelte
@@ -6,11 +6,22 @@
   //
   // Pipeline:
   //   1. mermaid.render() turns the source DSL into an SVG string
-  //   2. DOMPurify sanitises the SVG (script/foreignObject/event-attrs out)
+  //   2. DOMPurify sanitises the SVG (script + event-attrs out)
   //   3. {@html} drops it into the DOM
   //
   // mermaid.initialize({ securityLevel: 'strict' }) blocks HTML-in-labels
   // upstream; the DOMPurify pass is the second line of defence.
+  //
+  // v0.4.38: `<foreignObject>` is allowed through now. Mermaid 11 renders
+  // flowchart node labels inside `<foreignObject>` elements (HTML inside
+  // SVG, for proper word-wrapping). `securityLevel: 'strict'` blocks the
+  // HTML *inside* those elements being interpreted as markup, but does
+  // not stop Mermaid from emitting the elements themselves — and our
+  // previous belt-and-braces strip was deleting them outright, leaving
+  // labelless boxes (the 0.4.37 Verfassungsorgane test). DOMPurify's
+  // svg/svgFilters profile + the FORBID_ATTR list still keep scripts and
+  // event handlers out, so dropping `foreignObject` from FORBID_TAGS is
+  // safe.
 
   import { onMount } from "svelte";
   import mermaid from "mermaid";
@@ -51,10 +62,10 @@
       .then(({ svg: rendered }) => {
         svg = DOMPurify.sanitize(rendered, {
           USE_PROFILES: { svg: true, svgFilters: true },
-          // Belt-and-braces removals; mermaid + securityLevel:strict
-          // shouldn't emit these, but if a future mermaid release ever
-          // does, we drop them rather than execute.
-          FORBID_TAGS: ["script", "foreignObject"],
+          // Mermaid 11 emits node labels inside `<foreignObject>`, so
+          // it stays in the allow-list. `<script>` is the only tag we
+          // forbid outright; event-handler attrs are caught by FORBID_ATTR.
+          FORBID_TAGS: ["script"],
           FORBID_ATTR: ["onclick", "onload", "onerror", "onmouseover"],
         });
         error = null;

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.37"
+version = "0.4.38"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Mermaid 11 renders flowchart node labels inside `<foreignObject>` SVG elements (HTML-in-SVG for proper word-wrapping). `MermaidView.svelte`'s DOMPurify pass was stripping `<foreignObject>` outright as belt-and-braces on top of `securityLevel: 'strict'` — the result was correctly-shaped, correctly-coloured boxes with **no text**. Reproduced 2026-05-06 with a Bundesrepublik-Verfassungsorgane flowchart (screenshot in the bug report: empty colored rectangles where the node labels should be).

The forbid-list now keeps only `<script>`. Event-handler attributes are still caught by `FORBID_ATTR` and DOMPurify's `svg`/`svgFilters` profile, so dropping `<foreignObject>` from the strip list is safe.

## Test plan

- [ ] Render a flowchart with text labels in nodes — labels visible.
- [ ] Render a flowchart with edge labels — labels visible.
- [ ] Render a flowchart with `<script>` injected via a node label string — script tag stripped, no execution.
- [ ] Sequence diagrams + state diagrams unchanged (they don't use foreignObject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)