### PR TITLE
fix: silent update check is truly silent (v0.4.39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.39] — 2026-05-06
+
+### Fixed
+
+- **Silent update-check no longer steals focus mid-dialog.**
+  `checkForUpdates({ silent: true })` is fired automatically by
+  `App.svelte` after every successful render (the `update:check`
+  event from Rust), on window focus, and on mount. When a new
+  version *was* actually available, the function silently called
+  `invoke("surface_for_dialog")` and `ask("Update verfügbar?")`
+  anyway — surfacing the Settings window in Regular activation
+  policy and stealing focus from whatever dialog the agent had
+  on screen. Reproduced 2026-05-06 right after 0.4.38 shipped:
+  user opened an agent dialog, the post-render auto-check picked
+  up 0.4.38, the install prompt opened on top of the active
+  dialog, the user's interaction broke. The silent path now
+  truly silent — error toasts, "you're on latest" messages, and
+  the install prompt are all gated behind `!silent`. Available
+  updates surface only on the next manual "Nach Updates suchen"
+  click or on the next GUI restart (Tauri-Updater pulls
+  automatically). Console logs the deferred update for
+  diagnostics.
+
 ## [0.4.38] — 2026-05-06
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.38"
+version = "0.4.39"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/lib/updater.ts
+++ b/companion/src/lib/updater.ts
@@ -4,15 +4,26 @@ import { ask, message } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 
 /**
- * Checks the configured endpoint for a new version. If one exists, prompts the
- * user via a native dialog. On confirm: downloads, verifies signature, swaps,
- * relaunches. Silent if already on latest. Call from onMount of the settings
- * window, or wire to a "Check for updates" button.
+ * Checks the configured endpoint for a new version.
+ *
+ * Two modes:
+ *  • `silent: true` (auto-triggers from App.svelte: post-render event,
+ *    window-focus, mount). NEVER surfaces UI — neither error toasts,
+ *    "you're on latest", nor an install prompt. If a new version is
+ *    available the function only logs to console and returns. The user
+ *    will see the prompt the next time they manually click "Nach
+ *    Updates suchen" in Settings, or when the next GUI restart picks
+ *    up the new bundle. Rationale: post-render auto-checks fired in
+ *    the middle of an agent's dialog, briefly surfacing the Settings
+ *    window and stealing focus from the live `confirm`/`ask`/`form`
+ *    the user was answering (reproduced 2026-05-06 right after 0.4.38
+ *    shipped — agent's window broke because the silent post-render
+ *    check picked up 0.4.38 mid-dialog).
+ *  • `silent: false` (manual button in Settings): full UX —
+ *    error/no-update messages and the install prompt.
  *
  * UX note: use `message()` (single OK button) for pure-info outcomes, and
- * `ask()` (Yes/No) only when the user actually has a decision to make. Using
- * `ask()` for "you're on the latest version" produces a nonsensical two-
- * button dialog.
+ * `ask()` (Yes/No) only when the user actually has a decision to make.
  */
 export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<void> {
   let update: Update | null;
@@ -24,6 +35,8 @@ export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<
         title: "aiui",
         kind: "warning",
       });
+    } else {
+      console.debug(`[aiui] silent update check failed: ${e}`);
     }
     return;
   }
@@ -37,9 +50,17 @@ export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<
     return;
   }
 
-  // When running in Accessory mode (auto-spawned from MCP-stdio), macOS
-  // won't bring a modal dialog to the front on its own. Promote the app to
-  // Regular + surface the window so the user actually sees the prompt.
+  // Update available.
+  if (opts.silent) {
+    // Defer entirely — no surfacing, no prompt, no policy change.
+    // Manual Settings click or next GUI restart will pick it up.
+    console.debug(`[aiui] update available (${update.version}) — deferred until manual check or restart`);
+    return;
+  }
+
+  // Manual path: prompt + install. Promote to Regular activation so
+  // the modal actually fronts (Accessory-mode app otherwise loses to
+  // Claude Desktop on focus).
   await invoke("surface_for_dialog");
 
   const wantInstall = await ask(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.38"
+version = "0.4.39"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

`checkForUpdates({ silent: true })` is fired automatically by `App.svelte` after every successful render (via the `update:check` event from Rust), on window focus, and on mount. When a new version was actually available, the silent path called `invoke(\"surface_for_dialog\")` and `ask(\"Update verfügbar?\")` anyway — surfacing the Settings window in Regular activation policy and stealing focus from whatever dialog the agent had on screen.

Reproduced 2026-05-06 right after 0.4.38 shipped: user opened an agent dialog, the post-render auto-check picked up 0.4.38 mid-dialog, the install prompt opened on top of the active dialog, the user's interaction broke.

The silent path is now truly silent — error toasts, \"you're on latest\" messages, and the install prompt are all gated behind \`!silent\`. Available updates surface only on the next manual \"Nach Updates suchen\" click or on the next GUI restart (Tauri-Updater pulls automatically). Console logs the deferred update for diagnostics.

Manual button path unchanged.

## Test plan

- [ ] Render a dialog, wait for post-render auto-check to fire — no Settings surfacing, no prompt.
- [ ] Manually click \"Nach Updates suchen\" with an update available — full prompt + install flow.
- [ ] Manually click \"Nach Updates suchen\" on latest — \"Du bist auf der aktuellen Version\" message.
- [ ] Force `check()` to throw (e.g. offline) → silent: nothing visible, manual: error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)