### PR TITLE
feat: per-spec window sizing + MCP progress notifications + blocking-tool hints (v0.4.40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.40] — 2026-05-06
+
+### Added
+
+- **Per-spec dialog window sizing.** `dialog::estimate_dialog_size`
+  scans the rendered spec and picks an inner-size in (520..=1100,
+  480..=900) before the window surfaces. Wide widgets (`wireframe` ≥ 3
+  cols, `mermaid`, `table` ≥ 4 cols, `image_grid` ≥ 4 cols) widen the
+  window; long forms grow vertically; tabs add a tab-bar header
+  height. Confirm/ask specs keep the 520×480 base. Reused windows
+  resize to fit the new spec on each render — a confirm after a long
+  form no longer keeps the form's tall geometry. Pure function with
+  unit tests.
+- **Resizable dialog window.** `resizable(true)`,
+  `min_inner_size(360, 320)`, `max_inner_size` removed. The user has
+  the last word; the per-spec estimate is just a sensible starting
+  point.
+- **MCP `notifications/progress` for blocking tool calls.** While
+  `confirm`/`ask`/`form` waits on the user, the companion sends a
+  progress notification every 10 s with the client-supplied
+  `progressToken`. Keeps Claude Desktop and Claude Code from
+  concluding "tool hung" mid-dialog (default client timeouts are
+  60–120 s). Routed through a new mpsc-based stdout writer in
+  `mcp::run_stdio` so notifications interleave cleanly with the
+  eventual tool response. No-op if the client doesn't pass a
+  `progressToken`. v0.4.40.
+- **Tool descriptions explicitly state blocking semantics.** The
+  `confirm`/`ask`/`form` descriptions now end with a note that the
+  tool blocks until user submit/cancel, that responses can take
+  minutes, and that progress notifications fire every ~10 s. Stops
+  the agent from typing "Companion scheint zu hängen" when the
+  user is just thinking.
+
 ## [0.4.39] — 2026-05-06
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.39"
+version = "0.4.40"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.39"
+version = "0.4.40"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -58,6 +58,137 @@ pub struct DialogStats {
     pub oldest_age_secs: Option<u64>,
 }
 
+/// Initial inner-size estimate for the dialog window, derived from the
+/// rendered spec. Pure function so the caller (`/render`) can size the
+/// window before the Svelte side mounts. The user can resize freely
+/// afterwards (the window is `resizable(true)` since v0.4.40).
+///
+/// Heuristics, in order of effect:
+///   • `tabs` → +40 px header for the tab bar
+///   • Wide widgets (`wireframe` ≥ 3 columns, `mermaid`, `image_grid`
+///     ≥ 4 columns, `table` ≥ 4 columns) bump the **width** to fit
+///   • Per field, an estimated content height is added; chrome (header
+///     + title + footer ≈ 220 px) is included in the base height of
+///     480 px and only exceeded once content actually warrants it
+///   • Output is clamped to (1100, 900) so we never spawn a window
+///     bigger than a small laptop screen
+///
+/// Confirm/ask specs (no `fields` array) keep the base size — they're
+/// short and look right at 520×480.
+pub fn estimate_dialog_size(spec: &serde_json::Value) -> (f64, f64) {
+    const BASE_W: f64 = 520.0;
+    const BASE_H: f64 = 480.0;
+    const MAX_W: f64 = 1100.0;
+    const MAX_H: f64 = 900.0;
+    /// Approx. vertical pixels eaten by header chip + title + description
+    /// + footer-with-buttons. Fields below this threshold fit in the
+    /// base height with no extra room needed.
+    const CHROME_H: f64 = 220.0;
+
+    let mut width = BASE_W;
+    let mut content_h: f64 = 0.0;
+
+    if let Some(tabs) = spec.get("tabs").and_then(|v| v.as_array()) {
+        if !tabs.is_empty() {
+            content_h += 40.0;
+        }
+    }
+
+    for field in collect_visible_fields(spec) {
+        let kind = field.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        let (w_min, h_add) = match kind {
+            "wireframe" => {
+                let cols = field
+                    .get("columns")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(1)
+                    .max(1);
+                let cols_w = match cols {
+                    1..=2 => BASE_W,
+                    3 => 720.0,
+                    _ => 880.0,
+                };
+                let panels = field
+                    .get("panels")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let rows = ((panels as f64) / (cols as f64)).ceil();
+                (cols_w, (rows * 100.0).max(150.0))
+            }
+            "mermaid" => (720.0, 280.0),
+            "table" => {
+                let cols = field
+                    .get("columns")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let w = if cols >= 4 { 720.0 } else { BASE_W };
+                let rows = field
+                    .get("rows")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                (w, (rows.min(8) as f64 * 32.0 + 80.0).max(180.0))
+            }
+            "image_grid" => {
+                let cols = field
+                    .get("columns")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(3)
+                    .max(1);
+                let w = if cols >= 4 { 720.0 } else { BASE_W };
+                let images = field
+                    .get("images")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let rows = ((images as f64) / (cols as f64)).ceil();
+                (w, (rows * 130.0 + 30.0).max(160.0))
+            }
+            "image" => (BASE_W, 220.0),
+            "tree" => (BASE_W, 240.0),
+            "list" => {
+                let items = field
+                    .get("items")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                (BASE_W, (items as f64 * 36.0 + 40.0).clamp(80.0, 320.0))
+            }
+            "markdown" | "static_text" => (BASE_W, 80.0),
+            // Standard inputs (text, password, number, select, checkbox,
+            // slider, date, datetime, date_range, color, …) and the
+            // catch-all for anything we forgot.
+            _ => (BASE_W, 60.0),
+        };
+        width = width.max(w_min);
+        content_h += h_add;
+    }
+
+    let needed_h = CHROME_H + content_h;
+    let height = if needed_h > BASE_H {
+        needed_h.min(MAX_H)
+    } else {
+        BASE_H
+    };
+    (width.min(MAX_W), height)
+}
+
+fn collect_visible_fields(spec: &serde_json::Value) -> Vec<&serde_json::Value> {
+    let mut out = Vec::new();
+    if let Some(tabs) = spec.get("tabs").and_then(|v| v.as_array()) {
+        for tab in tabs {
+            if let Some(fields) = tab.get("fields").and_then(|v| v.as_array()) {
+                out.extend(fields.iter());
+            }
+        }
+    } else if let Some(fields) = spec.get("fields").and_then(|v| v.as_array()) {
+        out.extend(fields.iter());
+    }
+    out
+}
+
 /// Returned by `try_register` when a dialog is already in flight.
 /// Surfaced via /render as a 409 so the calling agent can distinguish
 /// "companion not reachable" from "companion is busy with someone
@@ -312,6 +443,91 @@ mod tests {
         ack.blocking_recv().expect("first ack must arrive");
         // Second ack on the same id is a silent no-op.
         s.ack(&id);
+    }
+
+    #[test]
+    fn estimate_size_confirm_keeps_base() {
+        let spec = serde_json::json!({ "kind": "confirm", "title": "ok?" });
+        let (w, h) = estimate_dialog_size(&spec);
+        assert_eq!(w, 520.0);
+        assert_eq!(h, 480.0);
+    }
+
+    #[test]
+    fn estimate_size_short_form_keeps_base() {
+        let spec = serde_json::json!({
+            "kind": "form",
+            "fields": [
+                { "kind": "text", "name": "a" },
+                { "kind": "checkbox", "name": "b" }
+            ]
+        });
+        let (w, h) = estimate_dialog_size(&spec);
+        assert_eq!(w, 520.0);
+        assert_eq!(h, 480.0);
+    }
+
+    #[test]
+    fn estimate_size_long_form_grows_height_only() {
+        let mut fields = Vec::new();
+        for i in 0..10 {
+            fields.push(serde_json::json!({ "kind": "text", "name": format!("f{i}") }));
+        }
+        let spec = serde_json::json!({ "kind": "form", "fields": fields });
+        let (w, h) = estimate_dialog_size(&spec);
+        assert_eq!(w, 520.0);
+        assert!(h > 480.0, "10-field form should exceed base height, got {h}");
+        assert!(h <= 900.0, "must clamp to MAX_H");
+    }
+
+    #[test]
+    fn estimate_size_wireframe_3col_widens() {
+        let spec = serde_json::json!({
+            "kind": "form",
+            "fields": [
+                { "kind": "wireframe", "columns": 3, "panels": [
+                    { "title": "A" }, { "title": "B" }, { "title": "C" }
+                ]}
+            ]
+        });
+        let (w, _h) = estimate_dialog_size(&spec);
+        assert_eq!(w, 720.0);
+    }
+
+    #[test]
+    fn estimate_size_mermaid_widens_and_grows() {
+        let spec = serde_json::json!({
+            "kind": "form",
+            "fields": [{ "kind": "mermaid", "source": "graph TD; A-->B" }]
+        });
+        let (w, h) = estimate_dialog_size(&spec);
+        assert_eq!(w, 720.0);
+        assert!(h > 480.0, "mermaid should push height past base, got {h}");
+    }
+
+    #[test]
+    fn estimate_size_clamps_to_max() {
+        let mut fields = Vec::new();
+        for i in 0..50 {
+            fields.push(serde_json::json!({ "kind": "text", "name": format!("f{i}") }));
+        }
+        let spec = serde_json::json!({ "kind": "form", "fields": fields });
+        let (_w, h) = estimate_dialog_size(&spec);
+        assert_eq!(h, 900.0, "50-field form must clamp to MAX_H");
+    }
+
+    #[test]
+    fn estimate_size_walks_into_tabs() {
+        let spec = serde_json::json!({
+            "kind": "form",
+            "tabs": [
+                { "label": "T1", "fields": [
+                    { "kind": "wireframe", "columns": 4, "panels": [{}, {}, {}, {}] }
+                ]}
+            ]
+        });
+        let (w, _h) = estimate_dialog_size(&spec);
+        assert_eq!(w, 880.0, "4-col wireframe inside tab should still widen");
     }
 
     #[test]

--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -80,9 +80,9 @@ pub fn estimate_dialog_size(spec: &serde_json::Value) -> (f64, f64) {
     const BASE_H: f64 = 480.0;
     const MAX_W: f64 = 1100.0;
     const MAX_H: f64 = 900.0;
-    /// Approx. vertical pixels eaten by header chip + title + description
-    /// + footer-with-buttons. Fields below this threshold fit in the
-    /// base height with no extra room needed.
+    // Approx. vertical pixels eaten by header chip + title + description
+    // + footer-with-buttons. Fields below this threshold fit in the
+    // base height with no extra room needed.
     const CHROME_H: f64 = 220.0;
 
     let mut width = BASE_W;

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -551,7 +551,10 @@ async fn render(
     // Surface the window from the main thread. If the window is being
     // built fresh (first render of this session, or after the user
     // closed it), `ensure_dialog_window` reset the ready flag.
-    surface_main_window(&state.app, &id);
+    // Window-size estimate is per-spec — wide widgets widen, long
+    // forms grow vertically. v0.4.40.
+    let size = crate::dialog::estimate_dialog_size(&dr.spec);
+    surface_main_window(&state.app, &id, size);
 
     // Window-ready handshake: wait until the frontend signals that
     // its `dialog:show` listener is registered. Without this gate
@@ -749,15 +752,19 @@ async fn wait_for_dialog_ready(app: &AppHandle, phase: &str) {
 }
 
 /// Surface the dialog window for the incoming render. If the window
-/// already exists, show + focus + unminimize; otherwise build it.
+/// already exists, show + focus + unminimize + resize to fit this
+/// spec; otherwise build it at the spec-derived inner size.
 /// All Tauri window operations have to run on the main thread, so we
 /// hop there via `run_on_main_thread`.
-fn surface_main_window(app: &AppHandle, id: &str) {
+fn surface_main_window(app: &AppHandle, id: &str, size: (f64, f64)) {
     let app_for_show = app.clone();
     let id_for_log = id.to_string();
     let rc = app.clone().run_on_main_thread(move || {
-        trace(&format!("render: main-thread callback id={}", id_for_log));
-        match crate::ensure_dialog_window(&app_for_show) {
+        trace(&format!(
+            "render: main-thread callback id={} size=({:.0},{:.0})",
+            id_for_log, size.0, size.1
+        ));
+        match crate::ensure_dialog_window(&app_for_show, size) {
             Ok(_win) => {
                 trace("render: main-thread dialog window ready (show/build)");
             }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -662,11 +662,19 @@ pub(crate) fn build_setup_window(
 /// window so the user gets a consistent aiui chrome regardless of
 /// which view they're seeing — the *content* is what differs.
 ///
-/// Reused across renders: if a dialog window already exists, we just
-/// surface it. The frontend handles the actual content swap when the
+/// Reused across renders: if a dialog window already exists, we surface
+/// it and resize it to the new spec's estimated size — small confirm
+/// after a wide form shouldn't keep the wide form's geometry, and
+/// vice versa. Frontend handles the actual content swap when the
 /// `dialog:show` event arrives.
+///
+/// `size` is the per-spec inner-size estimate from
+/// `dialog::estimate_dialog_size`. The window is resizable, so the user
+/// can drag past these defaults — we just pick a sensible starting
+/// geometry given what the agent asked us to render.
 pub(crate) fn ensure_dialog_window(
     app: &tauri::AppHandle,
+    size: (f64, f64),
 ) -> tauri::Result<tauri::WebviewWindow> {
     // Promote the app from Accessory to Regular for the duration of the
     // dialog. In Accessory mode (LSUIElement-style daemon, no Dock icon)
@@ -681,6 +689,10 @@ pub(crate) fn ensure_dialog_window(
         let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
     }
     if let Some(win) = app.get_webview_window(DIALOG_WINDOW_LABEL) {
+        // Resize to fit the new spec before surfacing. Without this,
+        // a confirm rendered after a long form would keep the form's
+        // tall geometry (and vice versa).
+        let _ = win.set_size(tauri::LogicalSize::new(size.0, size.1));
         let _ = win.show();
         let _ = win.set_focus();
         let _ = win.unminimize();
@@ -711,10 +723,14 @@ pub(crate) fn ensure_dialog_window(
         WebviewUrl::App("index.html".into()),
     )
     .title("aiui")
-    .inner_size(520.0, 480.0)
-    .min_inner_size(520.0, 380.0)
-    .max_inner_size(520.0, 640.0)
-    .resizable(false)
+    // Initial size from `estimate_dialog_size` — we widen for
+    // wireframe/mermaid/table and grow vertically for long forms,
+    // clamped to (1100, 900). Resizable so the user always has the
+    // last word; min size keeps the dialog usable but prevents
+    // accidental sub-icon collapse. v0.4.40.
+    .inner_size(size.0, size.1)
+    .min_inner_size(360.0, 320.0)
+    .resizable(true)
     .center()
     // Native, fully-visible title bar so macOS handles window-drag
     // for us. Tauri's `data-tauri-drag-region` HTML attribute and

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -19,6 +19,14 @@ use crate::logging::trace;
 use serde_json::{json, Value};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
+
+/// How often the companion fires `notifications/progress` while a
+/// `confirm`/`ask`/`form` tool call waits on the user. Picked to land
+/// well below MCP-client default timeouts (Claude Desktop ≈ 60 s,
+/// Claude Code ≈ 120 s) so the notification clearly signals "still
+/// alive" before any client-side give-up. v0.4.40.
+const PROGRESS_NOTIFY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
 const SKILL_MD: &str = include_str!("../../../docs/skill.md");
 
@@ -111,14 +119,37 @@ const STDIN_IDLE_LIMIT: std::time::Duration = std::time::Duration::from_secs(6 *
 /// Top-level entry: read JSON-RPC messages from stdin, dispatch to handlers,
 /// write responses to stdout. Runs until stdin closes or the idle deadline
 /// expires.
+///
+/// Outgoing traffic flows through an mpsc channel rather than directly
+/// onto stdout, so that a long-running tool call (waiting on the user
+/// in `confirm`/`ask`/`form`) can interleave `notifications/progress`
+/// onto the wire from a side-task without racing for the stdout lock.
+/// v0.4.40.
 pub async fn run_stdio(cfg: Arc<AppConfig>) {
     let stdin = tokio::io::stdin();
     let mut reader = BufReader::new(stdin).lines();
-    let mut stdout = tokio::io::stdout();
     let http = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(300))
         .build()
         .expect("reqwest client");
+
+    // Single writer task drains the channel onto stdout. Capacity 128
+    // is comfortable for one-response-at-a-time + ~6 progress
+    // notifications per minute per active tool call.
+    let (tx, mut rx) = mpsc::channel::<Value>(128);
+    let writer_task = tokio::spawn(async move {
+        let mut stdout = tokio::io::stdout();
+        while let Some(msg) = rx.recv().await {
+            if stdout
+                .write_all(format!("{msg}\n").as_bytes())
+                .await
+                .is_err()
+            {
+                break;
+            }
+            let _ = stdout.flush().await;
+        }
+    });
 
     trace("mcp-stdio: run_stdio entered");
 
@@ -139,11 +170,11 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
                 }
                 Ok(None) => {
                     trace("mcp-stdio: stdin closed, exiting");
-                    return;
+                    break;
                 }
                 Err(e) => {
                     trace(&format!("mcp-stdio: stdin error: {e}, exiting"));
-                    return;
+                    break;
                 }
             },
             _ = tokio::time::sleep(STDIN_IDLE_LIMIT) => {
@@ -157,7 +188,7 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
                         "mcp-stdio: no input for {:?}, parent likely gone, exiting",
                         elapsed
                     ));
-                    return;
+                    break;
                 }
                 trace(&format!(
                     "mcp-stdio: idle-timer fired but only {:?} elapsed (likely post-suspend); rearming",
@@ -180,19 +211,39 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
             continue;
         };
 
-        let response = match dispatch(method, params, &cfg, &http).await {
-            Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
-            Err(err) => json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "error": { "code": err.code, "message": err.message }
-            }),
-        };
-        let _ = stdout
-            .write_all(format!("{response}\n").as_bytes())
-            .await;
-        let _ = stdout.flush().await;
+        // Each request gets its own dispatch task so progress
+        // notifications can be sent in parallel via the writer
+        // channel. Tasks share `cfg` and `http` (both `Clone`-able);
+        // the channel is the sync point.
+        let cfg_for_task = cfg.clone();
+        let http_for_task = http.clone();
+        let tx_for_task = tx.clone();
+        let method_owned = method.to_string();
+        tokio::spawn(async move {
+            let response = match dispatch(
+                &method_owned,
+                params,
+                &cfg_for_task,
+                &http_for_task,
+                &tx_for_task,
+            )
+            .await
+            {
+                Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+                Err(err) => json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": { "code": err.code, "message": err.message }
+                }),
+            };
+            let _ = tx_for_task.send(response).await;
+        });
     }
+
+    // Close the channel so the writer task drains and exits. Without
+    // this, exit waits forever on the still-open sender.
+    drop(tx);
+    let _ = writer_task.await;
 }
 
 struct RpcError {
@@ -205,6 +256,7 @@ async fn dispatch(
     params: Value,
     cfg: &Arc<AppConfig>,
     http: &reqwest::Client,
+    tx: &mpsc::Sender<Value>,
 ) -> Result<Value, RpcError> {
     match method {
         "initialize" => Ok(json!({
@@ -227,7 +279,7 @@ async fn dispatch(
             "instructions": INSTRUCTIONS
         })),
         "tools/list" => Ok(json!({ "tools": tools_list() })),
-        "tools/call" => tools_call(params, cfg, http).await,
+        "tools/call" => tools_call(params, cfg, http, tx).await,
         "prompts/list" => Ok(json!({ "prompts": prompts_list() })),
         "prompts/get" => prompts_get(params),
         _ => Err(RpcError {
@@ -243,7 +295,7 @@ fn tools_list() -> Value {
     json!([
         {
             "name": "confirm",
-            "description": "Before writing any yes/no question into chat, call this tool instead. Pass `destructive: true` (red button) for delete / drop / force-push / rollback / prod-deploy — never trust loose prior approval for irreversible steps; re-confirm in a dialog. For visual sign-off (\"is this image OK?\", \"keep this generated diagram?\") pass `image: {src, alt?, max_height?}` — `src` accepts data: URLs, http(s) URLs, or absolute / `~/`-rooted local paths (resolved on YOUR host). Returns {cancelled, confirmed}. For 3+ options, use `ask`. For pure information the user only reads, render in chat.",
+            "description": "Before writing any yes/no question into chat, call this tool instead. Pass `destructive: true` (red button) for delete / drop / force-push / rollback / prod-deploy — never trust loose prior approval for irreversible steps; re-confirm in a dialog. For visual sign-off (\"is this image OK?\", \"keep this generated diagram?\") pass `image: {src, alt?, max_height?}` — `src` accepts data: URLs, http(s) URLs, or absolute / `~/`-rooted local paths (resolved on YOUR host). Returns {cancelled, confirmed}. For 3+ options, use `ask`. For pure information the user only reads, render in chat. **This tool blocks until the user clicks a button. Response can take minutes — do not assume aiui is broken on slow response, the user is just thinking. The companion sends MCP progress notifications every ~10 s while waiting.**",
             "inputSchema": {
                 "type": "object",
                 "required": ["title"],
@@ -269,7 +321,7 @@ fn tools_list() -> Value {
         },
         {
             "name": "ask",
-            "description": "Before listing options in chat and waiting for the user to type back which one (deploy strategy, migration path, file to act on …), call this tool instead. Per-option `description` carries the trade-off; `multi_select` and `allow_other` cover the rest. For visual choice (\"which of these images?\") pass `thumbnail: <src>` per option — same resolution rules as anywhere else in aiui (data:, http(s)://, or absolute local path). Returns {cancelled, answers, other?}. For yes/no, use `confirm`. For ≥ 2 related inputs, use `form`.",
+            "description": "Before listing options in chat and waiting for the user to type back which one (deploy strategy, migration path, file to act on …), call this tool instead. Per-option `description` carries the trade-off; `multi_select` and `allow_other` cover the rest. For visual choice (\"which of these images?\") pass `thumbnail: <src>` per option — same resolution rules as anywhere else in aiui (data:, http(s)://, or absolute local path). Returns {cancelled, answers, other?}. For yes/no, use `confirm`. For ≥ 2 related inputs, use `form`. **This tool blocks until the user picks an option or cancels. Response can take minutes — do not assume aiui is broken on slow response. Progress notifications fire every ~10 s while waiting.**",
             "inputSchema": {
                 "type": "object",
                 "required": ["question", "options"],
@@ -296,7 +348,7 @@ fn tools_list() -> Value {
         },
         {
             "name": "form",
-            "description": "Whenever the user needs to provide ≥ 2 related inputs, or any single input that doesn't belong in chat (secret, date/datetime/range, bounded number, sortable ranking, multi-select, color pick, table-row triage with column context, image confirm/grid), call this tool instead of typing the questions one by one. Fields: text, password, number, select, checkbox, slider, date, datetime, date_range, color, static_text, markdown, image, mermaid, wireframe, image_grid, list, table, tree. Group long forms with `tabs: [{label, fields: [...]}]` (one submit, all tabs validated). Footer actions are top-level on the form (`actions: [...]`), NOT inside a tab — they always render at the window's bottom. Action variants: primary (blue), success (green), destructive (red). Returns {cancelled, action?, values}. For yes/no, use `confirm`. For one-of-N pick, use `ask`. Sortable list field shape (most common stumble — always include `value` per item): {\"kind\":\"list\",\"name\":\"rank\",\"label\":\"Sortieren\",\"sortable\":true,\"items\":[{\"label\":\"A\",\"value\":\"a\"},{\"label\":\"B\",\"value\":\"b\"}]}. Image fields (`image`, `image_grid`, list-item `thumbnail`): `src` accepts (1) an absolute or `~/`-rooted local path — aiui's bridge on YOUR host reads it and inlines as `data:`; (2) an `http(s)://` URL — Mac-companion fetches and inlines; (3) a `data:` URL — pass through. Pick the path form when the file is on disk on your host. Relative paths and cross-host paths don't resolve. Never base64-roundtrip through a shell pipeline — build the `data:` URL in your runtime. For schematic visualisations (flowcharts, sequence/state diagrams, gantt, mind-maps) use the `mermaid` field instead of ASCII art: `{\"kind\":\"mermaid\",\"source\":\"graph TD; A --> B; B --> C\"}`. For UI-layout mockups (dashboard tiles, hardware-UI panels, login screens, anything with fixed-position boxes-and-labels) use the `wireframe` field — declarative panel grid, NOT ASCII boxes-and-pipes: `{\"kind\":\"wireframe\",\"columns\":3,\"panels\":[{\"title\":\"STATUS\",\"content\":\"Tiefe: 18 m\\nKurs: 270°\",\"col_span\":1},{\"title\":\"EMPFANG\",\"content\":\"14:32 [STARK]…\",\"col_span\":2}]}`. Each panel has optional `title` (uppercase header), `content` (multi-line monospace text, escape `\\n`), `col_span`/`row_span` (default 1), and `tone` (\"default\"/\"muted\"/\"highlight\"). See the aiui skill for the full field catalog.",
+            "description": "Whenever the user needs to provide ≥ 2 related inputs, or any single input that doesn't belong in chat (secret, date/datetime/range, bounded number, sortable ranking, multi-select, color pick, table-row triage with column context, image confirm/grid), call this tool instead of typing the questions one by one. Fields: text, password, number, select, checkbox, slider, date, datetime, date_range, color, static_text, markdown, image, mermaid, wireframe, image_grid, list, table, tree. Group long forms with `tabs: [{label, fields: [...]}]` (one submit, all tabs validated). Footer actions are top-level on the form (`actions: [...]`), NOT inside a tab — they always render at the window's bottom. Action variants: primary (blue), success (green), destructive (red). Returns {cancelled, action?, values}. For yes/no, use `confirm`. For one-of-N pick, use `ask`. Sortable list field shape (most common stumble — always include `value` per item): {\"kind\":\"list\",\"name\":\"rank\",\"label\":\"Sortieren\",\"sortable\":true,\"items\":[{\"label\":\"A\",\"value\":\"a\"},{\"label\":\"B\",\"value\":\"b\"}]}. Image fields (`image`, `image_grid`, list-item `thumbnail`): `src` accepts (1) an absolute or `~/`-rooted local path — aiui's bridge on YOUR host reads it and inlines as `data:`; (2) an `http(s)://` URL — Mac-companion fetches and inlines; (3) a `data:` URL — pass through. Pick the path form when the file is on disk on your host. Relative paths and cross-host paths don't resolve. Never base64-roundtrip through a shell pipeline — build the `data:` URL in your runtime. For schematic visualisations (flowcharts, sequence/state diagrams, gantt, mind-maps) use the `mermaid` field instead of ASCII art: `{\"kind\":\"mermaid\",\"source\":\"graph TD; A --> B; B --> C\"}`. For UI-layout mockups (dashboard tiles, hardware-UI panels, login screens, anything with fixed-position boxes-and-labels) use the `wireframe` field — declarative panel grid, NOT ASCII boxes-and-pipes: `{\"kind\":\"wireframe\",\"columns\":3,\"panels\":[{\"title\":\"STATUS\",\"content\":\"Tiefe: 18 m\\nKurs: 270°\",\"col_span\":1},{\"title\":\"EMPFANG\",\"content\":\"14:32 [STARK]…\",\"col_span\":2}]}`. Each panel has optional `title` (uppercase header), `content` (multi-line monospace text, escape `\\n`), `col_span`/`row_span` (default 1), and `tone` (\"default\"/\"muted\"/\"highlight\"). See the aiui skill for the full field catalog. **This tool blocks until the user submits or cancels. Response can take minutes (longer for complex forms) — do not assume aiui is broken on slow response, the user is filling the form. The companion sends MCP progress notifications every ~10 s while waiting.**",
             "inputSchema": {
                 "type": "object",
                 "required": ["title"],
@@ -433,6 +485,7 @@ async fn tools_call(
     params: Value,
     cfg: &Arc<AppConfig>,
     http: &reqwest::Client,
+    tx: &mpsc::Sender<Value>,
 ) -> Result<Value, RpcError> {
     let name = params
         .get("name")
@@ -441,11 +494,49 @@ async fn tools_call(
         .to_string();
     let args = params.get("arguments").cloned().unwrap_or(json!({}));
 
+    // MCP progress notifications. The client opts in by passing a token
+    // in `params._meta.progressToken` (string or integer). While the
+    // tool blocks on the user, we send a `notifications/progress`
+    // every PROGRESS_NOTIFY_INTERVAL with the same token so the
+    // client knows we're alive — keeps Claude Desktop and Claude
+    // Code from concluding "tool hung" mid-dialog. v0.4.40.
+    let progress_token = params
+        .get("_meta")
+        .and_then(|m| m.get("progressToken"))
+        .cloned();
+    let progress_handle = if let Some(token) = progress_token {
+        let tx_clone = tx.clone();
+        Some(tokio::spawn(async move {
+            let mut elapsed_secs: u64 = 0;
+            loop {
+                tokio::time::sleep(PROGRESS_NOTIFY_INTERVAL).await;
+                elapsed_secs += PROGRESS_NOTIFY_INTERVAL.as_secs();
+                let notif = json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/progress",
+                    "params": {
+                        "progressToken": token,
+                        "progress": elapsed_secs,
+                        "message": format!("aiui still waiting on user ({elapsed_secs}s)"),
+                    }
+                });
+                if tx_clone.send(notif).await.is_err() {
+                    break;
+                }
+            }
+        }))
+    } else {
+        None
+    };
+
     // Cold-start gate: every tool we expose hits the local HTTP server.
     // Wait for it to become reachable instead of returning a connection-
     // refused error the moment we get one — that masks the auto-resurrect
     // path's startup window cleanly.
     if !wait_for_aiui(http, cfg).await {
+        if let Some(h) = progress_handle {
+            h.abort();
+        }
         return Ok(aiui_unreachable_result());
     }
 
@@ -513,12 +604,19 @@ async fn tools_call(
             .map(value_to_tool_text),
 
         _ => {
+            if let Some(h) = progress_handle {
+                h.abort();
+            }
             return Ok(json!({
                 "content": [{"type": "text", "text": format!("unknown tool: {name}")}],
                 "isError": true
             }));
         }
     };
+
+    if let Some(h) = progress_handle {
+        h.abort();
+    }
 
     match outcome {
         Ok(v) => Ok(v),

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.39"
+version = "0.4.40"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Three coupled UX fixes for agent dialogs.

### 1. Per-spec dialog window sizing
`dialog::estimate_dialog_size` (pure, unit-tested) scans the rendered spec and picks an inner-size in (520..=1100, 480..=900) before the window surfaces:
- Wide widgets (`wireframe` ≥ 3 cols, `mermaid`, `table` ≥ 4 cols, `image_grid` ≥ 4 cols) → widen to 720 / 880 px.
- Long forms grow vertically; tabs add a tab-bar header height.
- Confirm/ask specs keep the 520×480 base.
- Reused windows resize to fit the new spec on each render — a confirm after a long form no longer keeps the form's tall geometry.

Window is now `resizable(true)` with `min_inner_size(360, 320)` and no max — user has the last word; estimate is just a sensible starting point. Reproduced 2026-05-06 with the Weekly Planner form (button row clipped, content scrolling).

### 2. MCP `notifications/progress` for blocking tool calls
`mcp::run_stdio` rebuilt around a `tokio::sync::mpsc` channel: a single writer task drains the channel onto stdout. Lets `tools/call` interleave `notifications/progress` events while waiting on the user.

If the client passes `params._meta.progressToken` (per MCP spec 2025-06-18), the companion sends a progress notification every 10 s with the same token while `confirm`/`ask`/`form` blocks. Keeps Claude Desktop and Claude Code from concluding "tool hung" mid-dialog (default client timeouts are 60–120 s). No-op if the client doesn't pass a token.

### 3. Tool descriptions explicitly state blocking semantics
`confirm`/`ask`/`form` descriptions end with: \"This tool blocks until user submit/cancel. Response can take minutes — do not assume aiui is broken on slow response.\" Stops the agent from typing \"Companion scheint zu hängen\" when the user is just thinking (reproduced same Weekly Planner test).

## Test plan

- [x] `cargo test --lib` — 73 pass (66 + 7 new for `estimate_dialog_size`).
- [x] `cargo check` clean.
- [ ] Render a confirm — 520×480, base.
- [ ] Render a wireframe with 4 cols — 880 px wide.
- [ ] Render a long form (10+ fields) — height grows past 480 px.
- [ ] Render a confirm after the long form — window resizes back to 520×480.
- [ ] Drag the dialog larger by hand — sticks; new render resets to estimate.
- [ ] `confirm` with `progressToken` in params._meta — notifications fire every 10 s while user thinks; clean tool response when they click.
- [ ] `confirm` without `progressToken` — no notifications, still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)