### PR TITLE
feat: 2h dialog TTL with countdown warnings + auto-cancel (v0.4.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.41] — 2026-05-06
+
+### Changed
+
+- **`DIALOG_TTL` raised from 5 min to 2 h.** A 5-min limit silently
+  killed any agent dialog the user took longer than that to fill in;
+  worst case the form returned `{cancelled: true, reason:
+  "ttl_expired"}` to the agent and the user's input was discarded
+  with no warning. 2 h covers any realistic form-filling session
+  without artificial pressure and is short enough to auto-recover
+  from a genuinely stuck WebView. Reported 2026-05-06 on the Weekly
+  Planner form.
+- **mcp-stdio `/render` HTTP client now per-call long-poll.** The
+  shared reqwest client keeps its 300-s default for /health,
+  /version, /update, etc., but POST /render gets an explicit
+  `.timeout(DIALOG_TTL + 60 s)` override so it doesn't trip the
+  300-s default during a long form. Without the override, every
+  reqwest timeout would race the backend TTL sweep and randomly
+  return a transport error instead of a clean cancellation.
+
+### Added
+
+- **Backend → frontend TTL handoff.** `DialogRequest` now carries
+  `ttl_secs`. Single source of truth for the deadline lives in
+  `DIALOG_TTL`; the frontend just reads what the backend declared.
+- **Countdown warning banners in the dialog window.** Two-stage:
+  - **T-15 min**: yellow, dismissible, *"Noch ca. {countdown} Min
+    zum Abschicken — danach werden die Eingaben automatisch
+    verworfen."*
+  - **T-2 min**: red, non-dismissible, *"Weniger als {countdown}
+    bis zum automatischen Abbruch. Bitte jetzt abschicken oder
+    abbrechen."*
+  - **T-5 s**: frontend auto-cancels via the existing `handleCancel`
+    code path, so the user's session ends with a clean close instead
+    of the backend's TTL sweep racing a last-second submit.
+- **Timers are per-dialog with full reset on every new
+  `dialog:show`.** A second dialog after the first submitted starts
+  with fresh banners + countdown; callbacks scheduled by the
+  previous dialog see a mismatched id and no-op, eliminating
+  stale-timer races. Cleanup also runs on submit, cancel, and
+  component-destroy.
+
 ## [0.4.40] — 2026-05-06
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.40"
+version = "0.4.41"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -9,6 +9,11 @@ use uuid::Uuid;
 pub struct DialogRequest {
     pub id: String,
     pub spec: serde_json::Value,
+    /// Companion-side TTL for this dialog, in seconds. Frontend reads
+    /// this to schedule warning banners (T-15 min, T-2 min) and an
+    /// auto-cancel slightly before the backend sweeps. Single source
+    /// of truth for "how long the user has" is here in Rust. v0.4.41.
+    pub ttl_secs: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,8 +34,13 @@ pub struct DialogResult {
 }
 
 /// How long an unresolved dialog may sit in the registry before opportunistic
-/// sweep cancels it. Bound for `cargo`-controlled tweaking later.
-pub const DIALOG_TTL: Duration = Duration::from_secs(5 * 60);
+/// sweep cancels it. Two hours — long enough to cover any realistic form
+/// the user could fill out without artificial pressure, short enough to
+/// auto-recover from a genuinely stuck WebView. v0.4.41 raised from 5 min
+/// after the 2026-05-06 Weekly-Planner feedback where complex forms hit
+/// the prior limit mid-fill. Frontend gets the value (via
+/// `DialogRequest.ttl_secs`) and surfaces it as countdown warnings.
+pub const DIALOG_TTL: Duration = Duration::from_secs(2 * 60 * 60);
 
 /// Hard cap on concurrently registered dialogs. When exceeded, the oldest
 /// entry is evicted so the map cannot grow without bound even under bursty

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -506,6 +506,10 @@ async fn render(
     let dr = DialogRequest {
         id: id.clone(),
         spec: req.spec,
+        // Sent so the frontend can schedule warning banners + auto-cancel
+        // a fraction before the backend sweep fires. Single source of
+        // truth lives in `DIALOG_TTL`. v0.4.41.
+        ttl_secs: DIALOG_TTL.as_secs(),
     };
 
     // ── Idle-restart check (#41) ────────────────────────────────────────

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -675,10 +675,20 @@ async fn render_dialog(
     let mut spec = spec;
     crate::imageresolve::resolve_local_paths(&mut spec);
     let body = json!({ "spec": spec });
+    // POST /render is long-poll: the GUI holds the response open
+    // until the user clicks submit/cancel or the companion-side
+    // `DIALOG_TTL` sweep fires (currently 2 h). Override the shared
+    // reqwest client's 300-s default per-call so the user has the
+    // full TTL to fill out the form. We add 60 s slack on top so a
+    // backend-side TTL cancel still reaches us cleanly before our
+    // own timeout. v0.4.41.
     let resp = http
         .post(&url)
         .bearer_auth(&token)
         .json(&body)
+        .timeout(std::time::Duration::from_secs(
+            crate::dialog::DIALOG_TTL.as_secs() + 60,
+        ))
         .send()
         .await
         .map_err(|e| RenderError::Transport(format!("POST /render: {e}")))?;

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -81,6 +81,11 @@
     "confirm.yes": "Ja",
     "confirm.no": "Nein",
     "unknown_kind": "Unbekannter Widget-Typ: {kind}",
-    "close": "Schließen"
+    "close": "Schließen",
+    "ttl": {
+      "yellow": "Noch ca. {countdown} Min zum Abschicken — danach werden die Eingaben automatisch verworfen.",
+      "red": "Weniger als {countdown} bis zum automatischen Abbruch. Bitte jetzt abschicken oder abbrechen.",
+      "dismiss_aria": "Hinweis ausblenden"
+    }
   }
 }

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -81,6 +81,11 @@
     "confirm.yes": "Yes",
     "confirm.no": "No",
     "unknown_kind": "Unknown widget kind: {kind}",
-    "close": "Close"
+    "close": "Close",
+    "ttl": {
+      "yellow": "About {countdown} min left to submit — after that your input will be discarded automatically.",
+      "red": "Less than {countdown} until auto-cancel. Please submit or cancel now.",
+      "dismiss_aria": "Dismiss notice"
+    }
   }
 }

--- a/companion/src/lib/DialogShell.svelte
+++ b/companion/src/lib/DialogShell.svelte
@@ -7,9 +7,135 @@
   import Form from "./widgets/Form.svelte";
   import Confirm from "./widgets/Confirm.svelte";
 
-  type DialogReq = { id: string; spec: any };
+  type DialogReq = { id: string; spec: any; ttl_secs?: number };
 
   let current = $state<DialogReq | null>(null);
+
+  // TTL warning state. The backend sets `DIALOG_TTL` (currently 2 h)
+  // and sends it along in `dialog:show`; we surface countdown banners
+  // 15 min and 2 min before expiry, then auto-cancel a few seconds
+  // before the backend sweep so the user's session reliably ends with
+  // a "Zeit abgelaufen — Eingaben verworfen" close instead of a stale
+  // dialog. v0.4.41. All timer state is per-dialog and reset on every
+  // new `dialog:show` event, so a second dialog after the first
+  // submitted starts with fresh banners and countdowns.
+  let yellowBanner = $state(false);
+  let yellowDismissed = $state(false);
+  let redBanner = $state(false);
+  let remainingSecs = $state<number | null>(null);
+  let ttlTimers: ReturnType<typeof setTimeout>[] = [];
+  let countdownInterval: ReturnType<typeof setInterval> | null = null;
+  // ID of the dialog whose timers are currently scheduled. We snapshot
+  // it on every scheduled callback so a timer that fires AFTER the
+  // dialog has been replaced (or already submitted) cannot bleed into
+  // the next dialog — classic race-on-rebind hazard with setTimeout.
+  let ttlDialogId: string | null = null;
+
+  function clearTtlTimers() {
+    for (const t of ttlTimers) clearTimeout(t);
+    ttlTimers = [];
+    if (countdownInterval !== null) {
+      clearInterval(countdownInterval);
+      countdownInterval = null;
+    }
+    yellowBanner = false;
+    yellowDismissed = false;
+    redBanner = false;
+    remainingSecs = null;
+    ttlDialogId = null;
+  }
+
+  /**
+   * Arm warning banners + auto-cancel for a freshly-arrived dialog.
+   * Always called via `clearTtlTimers()` first so two consecutive
+   * dialogs cannot leave stale timers running. Negative or missing
+   * `ttl_secs` (older companion that doesn't send the field) → no
+   * timers, no banners, current behaviour.
+   */
+  function scheduleTtl(ttl_secs: number | undefined, dialogId: string) {
+    clearTtlTimers();
+    if (!ttl_secs || ttl_secs <= 0) return;
+    ttlDialogId = dialogId;
+
+    const YELLOW_LEAD_SECS = 15 * 60;
+    const RED_LEAD_SECS = 2 * 60;
+    // Auto-cancel 5 seconds before the backend sweep so the dialog
+    // ends cleanly on the frontend side first; the still-running
+    // `/render` HTTP call then returns the cancellation to the agent.
+    // Without this lead, the backend's TTL_EXPIRED sweep races the
+    // user's last-second submit.
+    const AUTO_CANCEL_LEAD_SECS = 5;
+
+    const yellowDelayMs = (ttl_secs - YELLOW_LEAD_SECS) * 1000;
+    const redDelayMs = (ttl_secs - RED_LEAD_SECS) * 1000;
+    const cancelDelayMs = Math.max(0, (ttl_secs - AUTO_CANCEL_LEAD_SECS) * 1000);
+
+    if (yellowDelayMs > 0) {
+      ttlTimers.push(
+        setTimeout(() => {
+          if (ttlDialogId !== dialogId) return;
+          yellowBanner = true;
+          startCountdown(YELLOW_LEAD_SECS, dialogId);
+        }, yellowDelayMs),
+      );
+    } else {
+      // Edge case: TTL already <= 15 min on arrival. Show yellow now,
+      // start the countdown from whatever's left.
+      yellowBanner = true;
+      startCountdown(ttl_secs, dialogId);
+    }
+
+    if (redDelayMs > 0) {
+      ttlTimers.push(
+        setTimeout(() => {
+          if (ttlDialogId !== dialogId) return;
+          redBanner = true;
+          // Red overrides yellow's countdown: tighter cadence, no
+          // dismiss button.
+          startCountdown(RED_LEAD_SECS, dialogId);
+        }, redDelayMs),
+      );
+    }
+
+    ttlTimers.push(
+      setTimeout(() => {
+        if (ttlDialogId !== dialogId) return;
+        // Auto-cancel — same code path as the ESC key / Cancel button.
+        void handleCancel();
+      }, cancelDelayMs),
+    );
+  }
+
+  function startCountdown(initialSecs: number, dialogId: string) {
+    if (countdownInterval !== null) {
+      clearInterval(countdownInterval);
+      countdownInterval = null;
+    }
+    remainingSecs = initialSecs;
+    countdownInterval = setInterval(() => {
+      if (ttlDialogId !== dialogId) {
+        // Race guard: dialog already replaced, stop counting for it.
+        if (countdownInterval !== null) {
+          clearInterval(countdownInterval);
+          countdownInterval = null;
+        }
+        return;
+      }
+      if (remainingSecs !== null && remainingSecs > 0) {
+        remainingSecs -= 1;
+      } else if (countdownInterval !== null) {
+        clearInterval(countdownInterval);
+        countdownInterval = null;
+      }
+    }, 1000);
+  }
+
+  function formatRemaining(secs: number): string {
+    const safe = Math.max(0, secs);
+    const m = Math.floor(safe / 60);
+    const s = safe % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+  }
 
   onMount(() => {
     // Dialog event from Rust. We acknowledge receipt back to the Rust
@@ -21,6 +147,7 @@
     const dialogPromise = listen<DialogReq>("dialog:show", (e) => {
       current = e.payload;
       void invoke("dialog_received", { id: e.payload.id });
+      scheduleTtl(e.payload.ttl_secs, e.payload.id);
     });
 
     // UI ping from Rust (used by /health to verify the event loop). We
@@ -45,6 +172,7 @@
     });
 
     return async () => {
+      clearTtlTimers();
       (await dialogPromise)();
       (await pingPromise)();
       window.removeEventListener("keydown", onKey);
@@ -57,6 +185,7 @@
 
   async function handleSubmit(result: any) {
     if (!current) return;
+    clearTtlTimers();
     const id = current.id;
     current = null;
     await invoke("dialog_submit", { id, result });
@@ -64,6 +193,7 @@
   }
 
   async function handleCancel() {
+    clearTtlTimers();
     if (current) {
       const id = current.id;
       current = null;
@@ -83,6 +213,29 @@
      widget components themselves so they can put whatever sections they
      need into the scroll region and own their own button row. The shell
      just makes sure the WebView fills its window. -->
+
+<!-- TTL warning banners. Two-stage: yellow at T-15min, red at T-2min.
+     Position-fixed overlay so it never reflows the widget below it —
+     content scrolls under the banner. v0.4.41. -->
+{#if redBanner}
+  <div class="ttl-banner red" role="alert" aria-live="assertive">
+    <span class="ttl-banner-text">
+      ⚠️ {$_("dialog.ttl.red", { values: { countdown: remainingSecs !== null ? formatRemaining(remainingSecs) : "—" } })}
+    </span>
+  </div>
+{:else if yellowBanner && !yellowDismissed}
+  <div class="ttl-banner yellow" role="status" aria-live="polite">
+    <span class="ttl-banner-text">
+      ⏱ {$_("dialog.ttl.yellow", { values: { countdown: remainingSecs !== null ? formatRemaining(remainingSecs) : "—" } })}
+    </span>
+    <button
+      class="ttl-banner-dismiss"
+      onclick={() => (yellowDismissed = true)}
+      aria-label={$_("dialog.ttl.dismiss_aria")}
+    >×</button>
+  </div>
+{/if}
+
 {#if current}
   <!-- {#key current.id} forces a fresh widget instance for every new
     dialog, even when two consecutive renders are the same kind (e.g.
@@ -120,5 +273,54 @@
 <style>
   .idle {
     min-height: 80px;
+  }
+
+  /* TTL countdown banner. Position-fixed so the widget below keeps
+     its own three-zone (.window-shell) layout intact — content
+     scrolls beneath the banner. Banner height is deliberately small
+     so a typical small confirm/ask isn't completely covered. */
+  .ttl-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 14px;
+    font-size: 12.5px;
+    line-height: 1.3;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  }
+  .ttl-banner-text {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .ttl-banner.yellow {
+    background: color-mix(in srgb, var(--warning, #f3c623) 28%, var(--bg, #fff));
+    color: color-mix(in srgb, var(--warning, #f3c623) 70%, var(--fg, #000));
+    border-bottom: 1px solid color-mix(in srgb, var(--warning, #f3c623) 60%, transparent);
+  }
+  .ttl-banner.red {
+    background: color-mix(in srgb, var(--danger, #d64545) 22%, var(--bg, #fff));
+    color: color-mix(in srgb, var(--danger, #d64545) 80%, var(--fg, #000));
+    border-bottom: 1px solid color-mix(in srgb, var(--danger, #d64545) 70%, transparent);
+    font-weight: 600;
+  }
+  .ttl-banner-dismiss {
+    flex: 0 0 auto;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: inherit;
+    font-size: 16px;
+    line-height: 1;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+  .ttl-banner-dismiss:hover {
+    background: color-mix(in srgb, currentColor 12%, transparent);
   }
 </style>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.40"
+version = "0.4.41"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Long forms no longer get killed mid-fill. Three coupled changes:

### Backend

- **`DIALOG_TTL` 5 min → 2 h** in `dialog.rs`. The previous 5-min cap silently discarded any agent dialog the user took longer than that — worst case the tool returned \`{cancelled: true, reason: \"ttl_expired\"}\` to the agent and the user got no warning at all that their input was about to be thrown away. 2 h covers real forms without artificial pressure and is short enough to auto-recover from a stuck WebView.
- **Per-call long-poll override for `/render`** in `mcp.rs`. The shared 300-s reqwest client stays for /health, /version, /update, etc. POST /render now sets \`.timeout(DIALOG_TTL + 60 s)\` per call so reqwest doesn't race the backend TTL sweep and return a transport error instead of a clean cancellation.
- **`DialogRequest.ttl_secs`** carries the deadline to the frontend. Single source of truth lives in `DIALOG_TTL`; the frontend just reads what backend declared.

### Frontend (DialogShell.svelte)

Two-stage countdown warnings + auto-cancel, with full timer reset on every new \`dialog:show\`:

| Trigger | UI | Dismiss? | Lead |
|---|---|---|---|
| T-15 min | Yellow banner, *\"Noch ca. {countdown} Min …\"* | ✓ | -15 min |
| T-2 min | Red banner, *\"Weniger als {countdown} bis zum Abbruch …\"* | ✗ | -2 min |
| T-5 s | Frontend `handleCancel()` (same path as ESC / Cancel button) | — | -5 s |

The frontend auto-cancel runs **before** the backend TTL sweep so the user's session ends cleanly via the existing cancel pipeline rather than getting cut off by a race.

### Hardening — \"no new bugs\"

- All timers are tagged with the dialog id; callbacks scheduled by the previous dialog see a mismatched id and no-op. Eliminates stale-timer races when a second dialog arrives while a first is still timing out.
- `clearTtlTimers()` runs on every new `dialog:show`, on submit, on cancel, and on component-destroy.
- Banners + countdown state reset at the same time, so dismissal flags don't bleed across dialogs.
- Old companions that don't send `ttl_secs` → frontend no-ops (no banners, no auto-cancel). Backward compatible.

## Test plan

- [x] `cargo test --lib` — 73 pass (no test regressions).
- [x] `cargo clippy --release -- -D warnings` clean.
- [x] `svelte-check` — 0 errors (9 pre-existing warnings in Form/Settings, none in DialogShell).
- [ ] Run a form, wait 1 h 45 min, verify yellow banner with live countdown.
- [ ] Wait further until red banner appears at T-2 min, verify can't dismiss.
- [ ] Wait until auto-cancel at T-5 s, verify dialog closes cleanly and agent receives `{cancelled: true}`.
- [ ] Run two forms in succession, dismiss yellow on first, verify second starts with fresh banners.
- [ ] Submit first form before any banner appears, verify timers are cleared (no stale auto-cancel of the next dialog).
- [ ] Run a quick `confirm` — no banner visible during normal use (TTL is 2 h, banner threshold is T-15 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)