### PR TITLE
fix: kill older sibling mcp-stdio with same grandparent (v0.4.42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.42] — 2026-05-16
+
+### Fixed
+
+- **Sibling `aiui --mcp-stdio` cleanup at child startup.** Claude
+  Desktop has been observed (2026-05-16) to occasionally spawn a fresh
+  `aiui --mcp-stdio` child without killing the previous one. Both
+  children attached to the lifetime socket, both registered their
+  prompt list, and Claude Desktop's slash-command routing then
+  couldn't decide which child owned `prompts/get` — `/aiui:health`,
+  `/aiui:version` etc. failed with "kein erkannter Befehl" even
+  though the prompts were correctly listed in the autocomplete.
+  Existing housekeeping covered stale-by-binary-path
+  (`kill_stale_mcp_stdio_children`) and stale-by-version
+  (`disk_version_if_stale`), but not stale-by-duplicate-spawn —
+  same path, same version, just two of them. New
+  `kill_sibling_mcp_stdio_with_same_grandparent` runs once at every
+  mcp-stdio startup: enumerates running `aiui --mcp-stdio`
+  processes, picks the ones whose **grandparent** PID matches ours
+  (= same Claude Desktop / Claude Code instance, via the
+  `disclaimer`/wrapper-process intermediate), and were started
+  **before** us, and sends them SIGTERM along with their wrapper.
+  Strict newer-kills-older rule prevents two simultaneously-started
+  duplicates from tearing each other down. No-op when grandparent
+  can't be resolved (terminal-launched mcp-stdio, orphans). Never
+  touches the grandparent itself (= Claude Desktop / Claude Code).
+  Cross-platform via the existing `sysinfo` snapshot path used by
+  the other housekeeping sweeps. Eight unit tests cover same-/
+  different-grandparent, newer-skip, unknown-noop, own-pid-skip,
+  and chain-break edge cases.
+
 ## [0.4.41] — 2026-05-06
 
 ### Changed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.41"
+version = "0.4.42"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/housekeeping.rs
+++ b/companion/src-tauri/src/housekeeping.rs
@@ -53,7 +53,7 @@ struct StaleChild {
     exe: String,
 }
 
-/// Lightweight snapshot of one process — what we need for both filters.
+/// Lightweight snapshot of one process — what we need for the filters.
 #[derive(Debug, Clone)]
 struct ProcSnap {
     pid: u32,
@@ -63,6 +63,12 @@ struct ProcSnap {
     ppid: Option<u32>,
     exe: String,
     args: Vec<String>,
+    /// Process start time in seconds since the Unix epoch (whatever
+    /// `sysinfo::Process::start_time` returns for the current OS).
+    /// Used by the sibling-mcp-stdio sweep to enforce a strict
+    /// "younger kills older" rule and avoid two simultaneously-started
+    /// duplicates from killing each other. v0.4.42.
+    start_time: u64,
 }
 
 /// Enumerate every running process via `sysinfo` and return a snapshot.
@@ -93,6 +99,7 @@ fn snapshot_processes() -> Vec<ProcSnap> {
                 ppid: p.parent().map(|p| p.as_u32()),
                 exe,
                 args,
+                start_time: p.start_time(),
             }
         })
         .collect()
@@ -143,6 +150,144 @@ fn find_all_children(snap: &[ProcSnap], own_pid: u32) -> Vec<StaleChild> {
             exe: p.exe.clone(),
         })
         .collect()
+}
+
+/// Resolve the grandparent (= parent's parent) PID of `pid` in the
+/// snapshot. Returns `None` if the chain breaks at any step — caller
+/// treats that as "unknown lineage, do not act".
+fn grandparent_pid(snap: &[ProcSnap], pid: u32) -> Option<u32> {
+    let me = snap.iter().find(|p| p.pid == pid)?;
+    let ppid = me.ppid?;
+    let parent = snap.iter().find(|p| p.pid == ppid)?;
+    parent.ppid
+}
+
+/// Filter: other `aiui --mcp-stdio` children spawned by the same MCP
+/// client (= same grandparent in the process tree, typically the Claude
+/// Desktop or Claude Code App process) and started *before* us. Pure
+/// function over a snapshot — the `(own_pid, own_grandparent, own_start)`
+/// triple comes from the caller so tests don't need to spoof
+/// `std::process::id()`.
+///
+/// "Same grandparent" was picked over "same parent" because every
+/// mcp-stdio on macOS sits one level below a Claude.app helper wrapper
+/// (`disclaimer`); each spawn gets its own wrapper, so PPIDs differ,
+/// but the wrappers themselves are all children of the same Claude.app
+/// process.
+///
+/// "Started before us" enforces a strict newer-kills-older rule. Two
+/// mcp-stdios spawned at the same instant from the same parent would
+/// otherwise see each other as "older" and tear each other down.
+/// v0.4.42.
+fn find_sibling_mcp_stdio_to_kill(
+    snap: &[ProcSnap],
+    own_pid: u32,
+    own_grandparent: Option<u32>,
+    own_start_time: u64,
+) -> Vec<StaleChild> {
+    let Some(own_gp) = own_grandparent else {
+        return Vec::new();
+    };
+    snap.iter()
+        .filter(|p| p.pid != own_pid)
+        .filter(|p| has_mcp_stdio_flag(&p.args))
+        .filter(|p| is_aiui_binary(&p.exe))
+        .filter(|p| p.start_time < own_start_time)
+        .filter(|p| grandparent_pid(snap, p.pid) == Some(own_gp))
+        .map(|p| StaleChild {
+            pid: p.pid,
+            exe: p.exe.clone(),
+        })
+        .collect()
+}
+
+/// Kill any older `aiui --mcp-stdio` children spawned by the *same* MCP
+/// client as us. Called once at mcp-stdio startup, after the
+/// `disk_version_if_stale` self-check. Returns the number of siblings
+/// terminated.
+///
+/// Why this exists: Claude Desktop has been observed (2026-05-16) to
+/// occasionally spawn a fresh `aiui --mcp-stdio` child while leaving
+/// the previous one running. Both children attach to the lifetime
+/// socket, both register their prompt list, and Claude Desktop's
+/// internal slash-command routing then can't decide which child owns
+/// `prompts/get` — the slash-command fails with "kein erkannter
+/// Befehl" even though the prompt list itself was loaded correctly.
+/// The aiui-side fix is the strict newer-kills-older policy here: the
+/// fresh child wins, the stale one gets SIGTERM, Claude Desktop is
+/// left with exactly one mcp-stdio per app instance.
+///
+/// We also terminate the immediate parent (the
+/// `Claude.app/Contents/Helpers/disclaimer` wrapper on macOS) of the
+/// older sibling so it doesn't immediately respawn a replacement and
+/// trigger the race again. The grandparent — the Claude.app process
+/// itself — is never touched.
+///
+/// Safety: if our own lineage can't be fully resolved (e.g. we're
+/// running standalone from a terminal, no MCP-client grandparent), the
+/// function is a no-op. We never broadly sweep all aiui-mcp-stdio
+/// children — `kill_all_mcp_stdio_children` is the uninstall-only path
+/// for that.
+pub fn kill_sibling_mcp_stdio_with_same_grandparent() -> usize {
+    let own_pid = std::process::id();
+    let snap = snapshot_processes();
+    let own_grandparent = grandparent_pid(&snap, own_pid);
+    let own_start_time = snap
+        .iter()
+        .find(|p| p.pid == own_pid)
+        .map(|p| p.start_time)
+        .unwrap_or(0);
+
+    let siblings = find_sibling_mcp_stdio_to_kill(
+        &snap,
+        own_pid,
+        own_grandparent,
+        own_start_time,
+    );
+
+    if siblings.is_empty() {
+        return 0;
+    }
+
+    let gp_str = own_grandparent
+        .map(|gp| gp.to_string())
+        .unwrap_or_else(|| "<unknown>".into());
+
+    for sibling in &siblings {
+        // Find the sibling's immediate parent (typically the disclaimer
+        // wrapper on macOS) so we can SIGTERM it as well — without
+        // that, Claude Desktop's spawn-supervisor would re-run a fresh
+        // child against the just-killed pid and we'd be back to two.
+        let sibling_ppid = snap
+            .iter()
+            .find(|p| p.pid == sibling.pid)
+            .and_then(|p| p.ppid);
+
+        trace(&format!(
+            "housekeeping: killing older sibling mcp-stdio pid={} exe={} \
+             (same grandparent={} as own pid={})",
+            sibling.pid, sibling.exe, gp_str, own_pid
+        ));
+        terminate_pid(sibling.pid);
+
+        // Belt-and-braces guard: never SIGTERM the grandparent itself —
+        // that would be the Claude Desktop / Claude Code app and would
+        // take our own current MCP session down with it.
+        if let Some(wrapper_pid) = sibling_ppid {
+            if Some(wrapper_pid) != own_grandparent && wrapper_pid != own_pid {
+                trace(&format!(
+                    "housekeeping: also terminating sibling wrapper pid={wrapper_pid}"
+                ));
+                terminate_pid(wrapper_pid);
+            }
+        }
+    }
+    let n = siblings.len();
+    trace(&format!(
+        "housekeeping: terminated {n} older sibling mcp-stdio child(ren) on startup \
+         (grandparent={gp_str})"
+    ));
+    n
 }
 
 /// Cross-platform process termination via sysinfo. Sends SIGTERM on Unix
@@ -365,6 +510,7 @@ mod tests {
             ppid: Some(0),
             exe: exe.to_string(),
             args: args.iter().map(|s| s.to_string()).collect(),
+            start_time: 0,
         }
     }
 
@@ -374,6 +520,23 @@ mod tests {
             ppid: Some(ppid),
             exe: exe.to_string(),
             args: args.iter().map(|s| s.to_string()).collect(),
+            start_time: 0,
+        }
+    }
+
+    fn snap_full(
+        pid: u32,
+        ppid: u32,
+        exe: &str,
+        args: &[&str],
+        start_time: u64,
+    ) -> ProcSnap {
+        ProcSnap {
+            pid,
+            ppid: Some(ppid),
+            exe: exe.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            start_time,
         }
     }
 
@@ -546,6 +709,119 @@ mod tests {
         assert_eq!(all.len(), 2);
     }
 
+    // ---------- find_sibling_mcp_stdio_to_kill ----------
+
+    /// Build the canonical Claude-Desktop process tree:
+    ///   100 (Claude.app)
+    ///   ├─ 200 (disclaimer wrapper)
+    ///   │    └─ 300 (aiui --mcp-stdio, older, start=1100)
+    ///   └─ 400 (disclaimer wrapper)
+    ///        └─ 500 (aiui --mcp-stdio, newer, start=2100)
+    fn canonical_claude_desktop_tree() -> Vec<ProcSnap> {
+        vec![
+            snap_full(100, 1, "/Applications/Claude.app/Contents/MacOS/Claude", &["Claude"], 800),
+            snap_full(200, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 1099),
+            snap_full(300, 200, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
+            snap_full(400, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 2099),
+            snap_full(500, 400, CURRENT, &[CURRENT, "--mcp-stdio"], 2100),
+        ]
+    }
+
+    #[test]
+    fn grandparent_resolves_through_disclaimer_wrapper() {
+        let snap = canonical_claude_desktop_tree();
+        assert_eq!(grandparent_pid(&snap, 500), Some(100));
+        assert_eq!(grandparent_pid(&snap, 300), Some(100));
+    }
+
+    #[test]
+    fn grandparent_is_none_when_chain_breaks() {
+        // Orphan with ppid=1 but no entry for pid=1 in the snapshot.
+        let snap = vec![snap_full(500, 1, CURRENT, &[CURRENT, "--mcp-stdio"], 2100)];
+        assert_eq!(grandparent_pid(&snap, 500), None);
+    }
+
+    #[test]
+    fn sibling_kill_finds_older_same_grandparent() {
+        let snap = canonical_claude_desktop_tree();
+        // We are pid 500 (the newer mcp-stdio), grandparent 100, start 2100.
+        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, Some(100), 2100);
+        assert_eq!(victims.len(), 1);
+        assert_eq!(victims[0].pid, 300);
+    }
+
+    #[test]
+    fn sibling_kill_skips_newer_siblings() {
+        let snap = canonical_claude_desktop_tree();
+        // We are pid 300 (the older mcp-stdio). The newer one (500) must
+        // NOT show up — otherwise two simultaneously-started duplicates
+        // would tear each other down.
+        let victims = find_sibling_mcp_stdio_to_kill(&snap, 300, Some(100), 1100);
+        assert!(victims.is_empty(), "older must not target newer siblings");
+    }
+
+    #[test]
+    fn sibling_kill_ignores_other_mcp_client() {
+        // Two completely different MCP clients on the same Mac:
+        //   100 (Claude Desktop) → 200 (disclaimer) → 300 (aiui --mcp-stdio, older)
+        //   150 (Claude Code CLI) → 250 (bash)       → 350 (aiui --mcp-stdio, newer — us)
+        let snap = vec![
+            snap_full(100, 1, "/Applications/Claude.app/Contents/MacOS/Claude", &["Claude"], 800),
+            snap_full(200, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 1099),
+            snap_full(300, 200, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
+            snap_full(150, 1, "/opt/homebrew/bin/claude", &["claude"], 1500),
+            snap_full(250, 150, "/bin/bash", &["bash", "-c", "..."], 1599),
+            snap_full(350, 250, CURRENT, &[CURRENT, "--mcp-stdio"], 1600),
+        ];
+        // We are pid 350; grandparent is 150. Sibling 300's grandparent is
+        // 100 — different MCP client, must not be killed.
+        let victims = find_sibling_mcp_stdio_to_kill(&snap, 350, Some(150), 1600);
+        assert!(
+            victims.is_empty(),
+            "must not kill mcp-stdio of a different MCP client (different grandparent)"
+        );
+    }
+
+    #[test]
+    fn sibling_kill_noop_when_own_grandparent_unknown() {
+        let snap = canonical_claude_desktop_tree();
+        // Caller couldn't resolve our grandparent — must be a no-op
+        // regardless of what siblings exist, so we don't broadly sweep.
+        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, None, 2100);
+        assert!(victims.is_empty());
+    }
+
+    #[test]
+    fn sibling_kill_skips_own_pid_even_if_older() {
+        let snap = canonical_claude_desktop_tree();
+        // Caller passes our own pid as `own_pid` — we must never
+        // include ourselves even if start_time math says we're older
+        // than some hypothetical caller frame.
+        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, Some(100), 9999);
+        assert_eq!(victims.iter().filter(|v| v.pid == 500).count(), 0);
+    }
+
+    #[test]
+    fn sibling_kill_skips_unrelated_aiui_mcp_in_tree() {
+        // Two old aiui-mcp-stdio children, but only one is in our
+        // grandparent lineage. The other should not be touched.
+        let snap = vec![
+            snap_full(100, 1, "Claude", &["Claude"], 800),
+            snap_full(200, 100, "disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 1099),
+            snap_full(300, 200, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
+            // unrelated tree:
+            snap_full(700, 1, "OtherApp", &["OtherApp"], 800),
+            snap_full(750, 700, "wrapper", &["wrapper", CURRENT, "--mcp-stdio"], 1099),
+            snap_full(770, 750, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
+            // us:
+            snap_full(400, 100, "disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 2099),
+            snap_full(500, 400, CURRENT, &[CURRENT, "--mcp-stdio"], 2100),
+        ];
+        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, Some(100), 2100);
+        assert_eq!(victims.len(), 1);
+        assert_eq!(victims[0].pid, 300);
+    }
+
     #[test]
     fn find_aiui_ssh_ntr_ignores_unrelated_ssh() {
         let unrelated: Vec<String> = ["ssh", "user@host", "ls"]
@@ -557,6 +833,7 @@ mod tests {
             ppid: Some(1),
             exe: "/usr/bin/ssh".into(),
             args: unrelated,
+            start_time: 0,
         }];
         assert!(find_aiui_ssh_ntr(&s, 7777, true).is_empty());
         assert!(find_aiui_ssh_ntr(&s, 7777, false).is_empty());

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -940,6 +940,21 @@ pub fn run_mcp_stdio_only() {
         std::process::exit(0);
     }
 
+    // Multi-instance protection (v0.4.42): kill any older
+    // `aiui --mcp-stdio` siblings spawned by the same MCP client. Claude
+    // Desktop has been observed (2026-05-16) to occasionally spawn a
+    // fresh child without killing the previous one — when both attach
+    // to the lifetime socket and both register their prompt list,
+    // Claude Desktop's slash-command routing can't decide which child
+    // owns `prompts/get` and the slash-command fails with "kein
+    // erkannter Befehl". The newer child (us) wins; the older one
+    // gets SIGTERM, along with its disclaimer wrapper, so Claude
+    // Desktop can't immediately respawn the same race. Safe no-op if
+    // we can't resolve our own grandparent (terminal-launched
+    // mcp-stdio, orphaned process). Existing single-child setups are
+    // untouched: nothing to kill, function returns 0.
+    let _ = housekeeping::kill_sibling_mcp_stdio_with_same_grandparent();
+
     let cfg = Arc::new(config::AppConfig::load_or_init().expect("config init"));
     logging::trace(&format!(
         "mcp-stdio: entering run loop, token_path={}",

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.41",
+  "version": "0.4.42",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.41"
+version = "0.4.42"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Closes the duplicate-mcp-stdio race that produces \"kein erkannter Befehl\" on aiui slash commands in Claude Desktop.

### Symptom (2026-05-16)

User in Claude Desktop:
- `/aiui:health`, `/aiui:version`, etc. appear in slash-command autocomplete (CD has loaded the prompts list from aiui).
- Submitting any of them returns *\"… ist hier kein erkannter Befehl. Einige Befehle funktionieren nur im Claude Code-Terminal.\"*
- MCP-server log shows the `prompts/list` succeeding but no `prompts/get` call ever reaches aiui.

### Root cause

`ps aux` on the user's MacBook:

```
13994  01:07:38  …/Helpers/disclaimer …/aiui --mcp-stdio
13998  01:07:38  …/aiui --mcp-stdio
14368     54:57  …/Helpers/disclaimer …/aiui --mcp-stdio
14369     54:57  …/aiui --mcp-stdio
```

Claude Desktop spawned a fresh mcp-stdio child without killing the previous one. Both registered prompts; CD's internal routing then couldn't decide which child owns `prompts/get`.

Existing housekeeping covered stale-by-binary-path and stale-by-version, **not** stale-by-duplicate-spawn (same path, same version, just two of them).

### Fix

New `housekeeping::kill_sibling_mcp_stdio_with_same_grandparent`, called at every mcp-stdio startup right after the `disk_version_if_stale` self-check:

1. Take a `sysinfo` snapshot.
2. Resolve our **grandparent** PID (= Claude Desktop / Claude Code app, via the `disclaimer` wrapper intermediate).
3. Find all other `aiui --mcp-stdio` processes with the same grandparent that started **before** us.
4. SIGTERM them and their wrapper parent (so CD's spawn-supervisor can't immediately re-run a fresh child against the just-killed pid).

Strict **newer-kills-older** rule: two simultaneously-started duplicates can't tear each other down. No-op when grandparent can't be resolved (terminal-launched mcp-stdio, orphans). The grandparent itself (= Claude Desktop / Claude Code) is **never** touched.

### Tests

Eight new unit tests covering:
- Grandparent resolves through the disclaimer wrapper.
- Grandparent is `None` when chain breaks.
- Sibling-kill finds older same-grandparent victim.
- Sibling-kill skips newer siblings (no symmetric kill).
- Sibling-kill ignores mcp-stdio of a different MCP client (different grandparent — e.g. parallel Claude Code).
- No-op when own grandparent is unknown.
- Skips own pid even if older.
- Skips unrelated aiui-mcp in tree (only same-grandparent matches).

`cargo test --lib`: **81 pass** (73 + 8 new). `cargo clippy --release -- -D warnings`: clean.

## Test plan

- [x] All housekeeping tests pass.
- [x] Clippy clean.
- [ ] Reproduce on MacBook: kill aiui-mcp-stdio, restart Claude Desktop twice within a minute, observe that only one child survives. `ps aux | grep aiui-mcp` should show exactly one PID pair (disclaimer + aiui).
- [ ] Verify `/aiui:health` then works.
- [ ] Verify Claude Code parallel session is untouched (different grandparent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)