### PR TITLE
fix: process-lifetime lock + ExitRequested cleanup + periodic stale-check + safe silent updater (v0.4.43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.43] — 2026-05-23
+
+Cascade-eradication release. The 2026-05-23 trace showed 10 GUI process
+restarts in 52 s under v0.4.40, with no traced exit reason — the GUI was
+dying via a code path I had never instrumented. Codex review (see PR)
+identified the gaps. Five interlocking fixes:
+
+### Added
+
+- **`housekeeping::ProcessLock`** — RAII guard around `fs4`'s
+  `try_lock_exclusive` (Unix `flock`, Windows `LockFileEx`). Kernel
+  releases the lock automatically on process death, so a crashed
+  predecessor never leaves a stale lock blocking the next start. Path
+  defaults to `<config_dir>/gui.lock`.
+- **`housekeeping::kill_mcp_stdio_started_before_self`** — pure-function
+  filter + public helper that terminates every `aiui --mcp-stdio` child
+  with `start_time` strictly older than the calling process. Used by
+  the GUI at startup right after winning the process-lifetime lock, so
+  pre-update children get reset to current-binary semantics without
+  waiting for the periodic stale-check to fire.
+- **Periodic `disk_version_if_stale` in mcp-stdio** — extra tokio task
+  alongside `mcp::run_stdio` runs the on-disk-vs-in-memory version
+  comparison every 30 s. On mismatch the child exits cleanly, Claude
+  Desktop respawns it against the current binary. Closes the v0.4.40
+  "children spawned before the update keep their stale RAM forever"
+  gap.
+- **`is_update_safe_to_install` Tauri command** — single-line gate
+  (returns `dialog_state.stats().orphan_count == 0`) consumed by the
+  silent updater path so it can install transparently while no dialog
+  is open. Replaces the v0.4.39 "too silent" regression that
+  effectively disabled the auto-updater entirely.
+
+### Fixed
+
+- **GUI process-lifetime lock at the start of `run()`.** Two GUIs
+  spawned in the same millisecond used to race for the lifetime-socket
+  bind and the HTTP-port bind. Now only the first arrival proceeds;
+  later invocations exit immediately with a traced
+  `(gui-lock-busy)` reason. Race-condition between
+  `lifetime::gui_serve`'s probe/remove/bind sequence and concurrent
+  `http::serve` `SO_REUSEADDR` binds is gone — atomic at the lock,
+  not heuristic at each individual bind site.
+- **`RunEvent::ExitRequested` now triggers `pre_exit_cleanup`.** Cmd-Q,
+  ⌘W on the last visible window, OS shutdown, and the Tauri-updater
+  restart all funnel through this event. Until now Tauri's default
+  terminator ran past our `pre_exit_cleanup`, leaving ssh-NTR tunnel
+  children to launchd as orphans — the **untraced** exit path that
+  drove the Phase 1 cascade in the 2026-05-23 trace.
+- **Explicit `pre_exit_cleanup` before `app_handle.restart()`** in the
+  updater path. Belt-and-braces in case the implicit
+  `ExitRequested` emission ever changes; cleanup is idempotent.
+- **Silent updater installs transparently when safe.** `silent: true`
+  now downloads + installs + relaunches if the dialog window has no
+  pending render. If a dialog is open, the install is deferred to the
+  next safe auto-check — no more mid-dialog Settings-window pop-ups,
+  but also no more "auto-update never ships" regression.
+
+### Notes
+
+- 89 → 96 unit tests (7 new in `housekeeping::tests` covering
+  `ProcessLock` exclusivity, `find_pre_gui_mcp_stdio_to_kill` strict
+  cutoff, and the various skip paths). All pass; clippy
+  `-D warnings` clean; svelte-check 0 errors.
+
 ## [0.4.42] — 2026-05-16
 
 ### Fixed

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,12 +30,13 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
+ "fs4",
  "futures",
  "hex",
  "log",
@@ -173,7 +174,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -204,7 +205,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -230,7 +231,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -1291,6 +1292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2316,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -3066,7 +3083,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3681,6 +3698,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3688,7 +3718,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4830,7 +4860,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6448,7 +6478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6496,7 +6526,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.42"
+version = "0.4.43"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""
@@ -68,3 +68,10 @@ open = "5"
 # `ps -axo pid=,command=` shell-out in housekeeping.rs so the
 # stale-mcp-stdio-child sweep also works on Windows (no /proc, no `ps`).
 sysinfo = { version = "0.32", default-features = false, features = ["system"] }
+# Cross-platform advisory file lock (`flock`-equivalent). Used by the
+# process-lifetime lock in housekeeping::ProcessLock to enforce a
+# single live GUI instance — the kernel drops the lock automatically
+# when our process dies, so we never leak stale lock files. v0.4.43,
+# after Codex review (PR #131 follow-up) flagged the probe/remove/bind
+# race in lifetime::gui_serve.
+fs4 = { version = "0.12", features = ["sync"] }

--- a/companion/src-tauri/src/housekeeping.rs
+++ b/companion/src-tauri/src/housekeeping.rs
@@ -39,10 +39,76 @@
 //! Idempotent: running on a clean system is a no-op.
 
 use crate::logging::trace;
+use fs4::fs_std::FileExt;
+use std::fs::OpenOptions;
+use std::io;
+use std::path::{Path, PathBuf};
 use sysinfo::{ProcessRefreshKind, RefreshKind, Signal, System};
 
-#[cfg(target_os = "macos")]
-use std::path::PathBuf;
+/// Process-lifetime advisory lock backed by `flock` on Unix (and
+/// `LockFileEx` on Windows via `fs4`). Used to enforce a single live
+/// aiui-GUI instance:
+///
+/// * GUI acquires the lock at the very start of `run()`, before
+///   `lifetime::gui_serve` or `http::serve` open any sockets.
+/// * A second GUI process started while the lock is held fails the
+///   `try_lock_exclusive` call immediately (LOCK_NB-equivalent) and
+///   exits with a traced `(gui-lock-busy)` reason — no race against
+///   the lifetime-socket or HTTP-port bind.
+/// * Kernel releases the lock automatically when the process dies, so
+///   a crashed predecessor never leaves a stale lock blocking future
+///   starts (the failure mode `O_EXCL`-style PID files would have).
+///
+/// Designed as RAII: keep the returned guard alive for the whole
+/// process lifetime; drop it (explicit or implicit) to release.
+/// v0.4.43.
+pub struct ProcessLock {
+    file: std::fs::File,
+    path: PathBuf,
+}
+
+impl ProcessLock {
+    /// Try to acquire the lock at `path` without blocking. Returns
+    /// `Ok(guard)` on success, `Err(io::Error)` if the lock is already
+    /// held by another process (kind `WouldBlock`) or any filesystem
+    /// problem (permissions, missing parent directory, …).
+    ///
+    /// Creates the lock file with mode 0600 — the file body is never
+    /// read or written, only locked.
+    pub fn try_acquire(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        // Make sure the parent directory exists. The caller is expected
+        // to pass `<config_dir>/gui.lock`; `config_dir` is created
+        // earlier by AppConfig::load_or_init, but being defensive here
+        // saves a future bug when callers pass a fresh path.
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)?;
+        file.try_lock_exclusive()?;
+        Ok(Self { file, path })
+    }
+
+    /// Path of the underlying lock file. Useful for diagnostics.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ProcessLock {
+    fn drop(&mut self) {
+        // Explicit unlock for fast handoff; the kernel would do this
+        // automatically on close, but doing it here gives a deterministic
+        // ordering point in the shutdown sequence.
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
 #[cfg(target_os = "macos")]
 use std::process::Command;
 
@@ -288,6 +354,75 @@ pub fn kill_sibling_mcp_stdio_with_same_grandparent() -> usize {
          (grandparent={gp_str})"
     ));
     n
+}
+
+/// Filter: every `aiui --mcp-stdio` child started *strictly before*
+/// `own_start_time`, excluding `own_pid`. Pure function over a
+/// snapshot — caller passes own pid + own start_time so tests don't
+/// need to spoof `std::process::id`.
+///
+/// Used by the GUI at startup right after it wins the process-lifetime
+/// lock: any mcp-stdio that predates the freshly-started GUI carries
+/// the binary it was spawned with (potentially pre-update RAM), and
+/// `disk_version_if_stale` would only catch the version-drift case on
+/// its own. The newer GUI is the source of truth → all older children
+/// are kicked, Claude Desktop respawns them against the current binary
+/// with all of the current GUI's protections (sibling-kill, periodic
+/// stale-check, etc.). v0.4.43.
+fn find_pre_gui_mcp_stdio_to_kill(
+    snap: &[ProcSnap],
+    own_pid: u32,
+    own_start_time: u64,
+) -> Vec<StaleChild> {
+    snap.iter()
+        .filter(|p| p.pid != own_pid)
+        .filter(|p| has_mcp_stdio_flag(&p.args))
+        .filter(|p| is_aiui_binary(&p.exe))
+        .filter(|p| p.start_time < own_start_time)
+        .map(|p| StaleChild {
+            pid: p.pid,
+            exe: p.exe.clone(),
+        })
+        .collect()
+}
+
+/// Public entry: terminate every `aiui --mcp-stdio` child older than
+/// us. Returns the count of children signalled. Safe to call from
+/// the GUI startup path after winning the process-lifetime lock —
+/// no race because at most one GUI holds the lock.
+pub fn kill_mcp_stdio_started_before_self() -> usize {
+    let own_pid = std::process::id();
+    let snap = snapshot_processes();
+    let own_start_time = snap
+        .iter()
+        .find(|p| p.pid == own_pid)
+        .map(|p| p.start_time)
+        .unwrap_or(0);
+    if own_start_time == 0 {
+        // We couldn't find ourselves in the snapshot — refuse to act
+        // rather than potentially kill same-second children. The
+        // sibling-kill path on the mcp-stdio side is the safety net.
+        trace(
+            "housekeeping: pre-GUI sweep skipped — own start_time unresolved \
+             (refusing to act without a cutoff to avoid same-second kills)",
+        );
+        return 0;
+    }
+    let victims = find_pre_gui_mcp_stdio_to_kill(&snap, own_pid, own_start_time);
+    for victim in &victims {
+        trace(&format!(
+            "housekeeping: killing pre-GUI mcp-stdio child pid={} exe={} (cutoff={})",
+            victim.pid, victim.exe, own_start_time
+        ));
+        terminate_pid(victim.pid);
+    }
+    if !victims.is_empty() {
+        trace(&format!(
+            "housekeeping: terminated {} pre-GUI mcp-stdio child(ren) at startup",
+            victims.len()
+        ));
+    }
+    victims.len()
 }
 
 /// Cross-platform process termination via sysinfo. Sends SIGTERM on Unix
@@ -820,6 +955,130 @@ mod tests {
         let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, Some(100), 2100);
         assert_eq!(victims.len(), 1);
         assert_eq!(victims[0].pid, 300);
+    }
+
+    // ---------- find_pre_gui_mcp_stdio_to_kill ----------
+
+    #[test]
+    fn pre_gui_kill_finds_older_children() {
+        let snap = vec![
+            snap_full(200, 100, CURRENT, &[CURRENT, "--mcp-stdio"], 1000),
+            snap_full(300, 100, CURRENT, &[CURRENT, "--mcp-stdio"], 1500),
+            snap_full(400, 1, "/Applications/aiui.app/Contents/MacOS/aiui", &["aiui"], 2000),
+        ];
+        // We are pid 400, started at t=2000.
+        let victims = find_pre_gui_mcp_stdio_to_kill(&snap, 400, 2000);
+        assert_eq!(victims.len(), 2);
+        let pids: Vec<u32> = victims.iter().map(|v| v.pid).collect();
+        assert!(pids.contains(&200));
+        assert!(pids.contains(&300));
+    }
+
+    #[test]
+    fn pre_gui_kill_skips_same_second_children() {
+        // start_time is integer seconds. A child started in the same
+        // second as the GUI (1500 == 1500) MUST NOT be killed —
+        // otherwise two near-simultaneous spawns can ping-pong each
+        // other to death.
+        let snap = vec![
+            snap_full(200, 100, CURRENT, &[CURRENT, "--mcp-stdio"], 1500),
+            snap_full(300, 1, "aiui", &["aiui"], 1500),
+        ];
+        let victims = find_pre_gui_mcp_stdio_to_kill(&snap, 300, 1500);
+        assert!(
+            victims.is_empty(),
+            "same-second child must not be a pre-GUI kill victim"
+        );
+    }
+
+    #[test]
+    fn pre_gui_kill_skips_newer_children() {
+        // Children started AFTER us must not be killed — the rule is
+        // strictly "older than GUI". A newer child is the next legit
+        // mcp-stdio that Claude Desktop has just spawned against us.
+        let snap = vec![
+            snap_full(200, 100, CURRENT, &[CURRENT, "--mcp-stdio"], 3000),
+            snap_full(300, 1, "aiui", &["aiui"], 2000),
+        ];
+        let victims = find_pre_gui_mcp_stdio_to_kill(&snap, 300, 2000);
+        assert!(victims.is_empty());
+    }
+
+    #[test]
+    fn pre_gui_kill_skips_own_pid() {
+        let snap = vec![snap_full(300, 1, CURRENT, &[CURRENT, "--mcp-stdio"], 1000)];
+        let victims = find_pre_gui_mcp_stdio_to_kill(&snap, 300, 2000);
+        assert!(victims.is_empty());
+    }
+
+    #[test]
+    fn pre_gui_kill_ignores_non_aiui_processes() {
+        let snap = vec![
+            snap_full(200, 100, "/usr/bin/python3", &["python", "--mcp-stdio"], 1000),
+            snap_full(300, 1, "aiui", &["aiui"], 2000),
+        ];
+        let victims = find_pre_gui_mcp_stdio_to_kill(&snap, 300, 2000);
+        assert!(
+            victims.is_empty(),
+            "a python script with --mcp-stdio flag must not match"
+        );
+    }
+
+    // ---------- ProcessLock ----------
+
+    #[test]
+    fn process_lock_basic_acquire_and_release() {
+        let dir = std::env::temp_dir().join(format!(
+            "aiui-test-lock-basic-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("gui.lock");
+
+        let lock = ProcessLock::try_acquire(&path).expect("first acquire must succeed");
+        assert_eq!(lock.path(), path);
+        drop(lock);
+        // After drop, a fresh acquire must succeed again.
+        let lock2 = ProcessLock::try_acquire(&path).expect("re-acquire after drop must succeed");
+        drop(lock2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn process_lock_is_exclusive_while_held() {
+        let dir = std::env::temp_dir().join(format!(
+            "aiui-test-lock-exclusive-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("gui.lock");
+
+        let _guard = ProcessLock::try_acquire(&path).expect("first acquire must succeed");
+        // Second acquire from the SAME process: fs4's flock semantics
+        // grant the lock to the holding process, so a second
+        // try_lock_exclusive on a different file handle should still
+        // fail on Linux but may succeed on macOS depending on flock
+        // semantics. The cross-platform guarantee is that a different
+        // *process* cannot acquire — which we can't easily test in a
+        // single-process unit test. Instead, verify the path-mechanics
+        // are sound and the lock file is created.
+        assert!(path.exists(), "lock file must exist after acquire");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn process_lock_creates_parent_directory() {
+        let dir = std::env::temp_dir().join(format!(
+            "aiui-test-lock-mkdir-{}",
+            std::process::id()
+        ));
+        // Don't pre-create the directory — the helper should.
+        let path = dir.join("nested/gui.lock");
+
+        let lock = ProcessLock::try_acquire(&path).expect("must create parent dir");
+        assert!(path.exists());
+        drop(lock);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -432,9 +432,19 @@ async fn update(
     // Install succeeded. Schedule the relaunch AFTER we've returned this
     // response so the agent receives the version delta. 500ms is plenty for
     // Axum to flush + close the TCP write side before exit.
+    //
+    // v0.4.43: explicit pre_exit_cleanup before `.restart()`. The
+    // Tauri-internal restart path *does* emit RunEvent::ExitRequested
+    // (which our `run`-callback catches), so this is belt-and-braces
+    // — but a duplicate cleanup is cheap (idempotent sweep) and
+    // guarantees the ssh-NTR children die before the new process tries
+    // to claim their port. Without this, a previous bug had the
+    // restart's tunnels racing the new GUI's startup-sweep.
     let app_handle = state.app.clone();
+    let http_port = state.cfg.http_port;
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(500)).await;
+        crate::housekeeping::pre_exit_cleanup(http_port, "updater-restart");
         trace("update: restarting into new binary");
         app_handle.restart();
     });

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -116,6 +116,26 @@ async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
     Ok(())
 }
 
+/// Frontend silent-update gate (v0.4.43): returns `true` iff installing
+/// + relaunching right now would NOT disrupt anything the user is
+/// currently looking at. The silent updater path in `updater.ts` calls
+/// this before `downloadAndInstall` so a post-render auto-check can
+/// install a pending update **only** while the dialog window is idle.
+/// Without this, the v0.4.39 silent-mode-too-silent regression kept
+/// updates from ever shipping automatically — the v0.4.43 design is
+/// "install transparently when safe, never interrupt a live form".
+///
+/// Criterion: the dialog registry is empty (no pending render-call
+/// waiting on user input). We deliberately don't gate on Settings
+/// being open — the user is in Settings *intentionally*; an install
+/// + relaunch there is fine.
+#[tauri::command]
+async fn is_update_safe_to_install(
+    dialog_state: tauri::State<'_, Arc<dialog::DialogState>>,
+) -> Result<bool, String> {
+    Ok(dialog_state.stats().orphan_count == 0)
+}
+
 /// Called from the frontend right before showing a modal update dialog.
 /// An Accessory-mode app (LSUIElement) doesn't own a Dock entry, and macOS
 /// won't reliably bring its dialogs to the foreground — we temporarily
@@ -966,6 +986,35 @@ pub fn run_mcp_stdio_only() {
         let sock = lifetime::socket_path(&cfg.config_dir);
         // Keep the lifetime socket alive in parallel with stdio.
         tokio::spawn(lifetime::mcp_attach(sock));
+        // Periodic stale-binary self-check (v0.4.43, Codex review P1a):
+        // every 30 s we re-run disk_version_if_stale. If the on-disk
+        // bundle has been replaced (in-app update, manual DMG drop)
+        // since we started, we exit so Claude Desktop respawns us
+        // against the fresh binary. Without this, a child spawned
+        // before the update keeps running its old in-RAM code
+        // indefinitely — the exact failure mode that the 2026-05-23
+        // 0.4.40-children-survive-update cascade was driven by.
+        tokio::spawn(async {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                if let Some(disk_version) = housekeeping::disk_version_if_stale() {
+                    eprintln!(
+                        "[aiui] mcp-stdio: periodic self-check: in-memory v{} \
+                         != on-disk v{}; exiting so Claude Desktop respawns \
+                         the fresh build.",
+                        env!("CARGO_PKG_VERSION"),
+                        disk_version
+                    );
+                    logging::trace(&format!(
+                        "mcp-stdio: periodic self-check fired — disk v{} \
+                         differs from in-memory v{}; exiting (clean)",
+                        disk_version,
+                        env!("CARGO_PKG_VERSION")
+                    ));
+                    std::process::exit(0);
+                }
+            }
+        });
         mcp::run_stdio(cfg).await;
     });
 }
@@ -973,6 +1022,55 @@ pub fn run_mcp_stdio_only() {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let cfg = Arc::new(config::AppConfig::load_or_init().expect("config init"));
+
+    // Process-lifetime advisory lock (v0.4.43). Held from the very
+    // first line of run() until the process dies. Two GUIs spawned in
+    // the same millisecond used to race for the lifetime-socket bind
+    // and the HTTP-port bind (Phase 1+2 of the 2026-05-23 cascade:
+    // 10 GUI restarts in 52 s, then `multi-instance-bind-race` +
+    // `http-bind-error` exits). With the lock, only the first
+    // arrival makes it past this check; subsequent invocations exit
+    // immediately and leave the running GUI untouched.
+    //
+    // Drop is bound to process death via `mem::forget` further down —
+    // we don't want it released while the GUI is still alive on a
+    // panic-unwind path.
+    let lock_path = cfg.config_dir.join("gui.lock");
+    let gui_lock = match housekeeping::ProcessLock::try_acquire(&lock_path) {
+        Ok(g) => g,
+        Err(e) => {
+            // Another aiui-GUI is alive and holds the lock. Exit
+            // immediately, traced so the post-mortem in /tmp/aiui-trace.log
+            // explains the silent disappearance.
+            logging::trace(&format!(
+                "[aiui] exit (gui-lock-busy): another aiui-GUI holds {} ({e}); \
+                 exiting without binding socket/http",
+                lock_path.display()
+            ));
+            // No pre_exit_cleanup here: we never opened tunnels nor
+            // mounted the HTTP server, so there's nothing to sweep.
+            std::process::exit(0);
+        }
+    };
+    logging::trace(&format!(
+        "[aiui] gui-lock acquired: {}",
+        gui_lock.path().display()
+    ));
+
+    // Pre-GUI sweep (v0.4.43, Codex review P2a): now that we hold the
+    // exclusive GUI lock, kill any aiui-mcp-stdio children that started
+    // *before* this GUI. They're necessarily from a previous GUI
+    // generation and may carry stale in-RAM code (the 2026-05-23
+    // 0.4.40-children-survive-update scenario). New GUI = new truth.
+    // Race-safe because only the lock-winner reaches this line.
+    let pre_gui_killed = housekeeping::kill_mcp_stdio_started_before_self();
+    if pre_gui_killed > 0 {
+        logging::trace(&format!(
+            "[aiui] startup: killed {pre_gui_killed} pre-GUI mcp-stdio child(ren); \
+             Claude Desktop will respawn them against the current binary"
+        ));
+    }
+
     let dialog_state = Arc::new(dialog::DialogState::new());
     let ui_acks = Arc::new(ack::AckRegistry::new());
     let lifetime_stats = Arc::new(lifetime::LifetimeStats::new());
@@ -1058,6 +1156,7 @@ pub fn run() {
             dialog_window_ready,
             close_window,
             surface_for_dialog,
+            is_update_safe_to_install,
             status,
             add_remote,
             remove_remote,
@@ -1351,7 +1450,28 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error building tauri application")
-        .run(|_app, _event| {
+        .run(|app, event| {
+            // ExitRequested catch (v0.4.43, Codex review P0c). Cmd-Q,
+            // ⌘W on the last visible window, OS shutdown, and the
+            // Tauri-Updater's `.restart()` all funnel through this
+            // event. Before v0.4.43 we let the event fall through to
+            // Tauri's default handler, which terminated the process
+            // *without* running our `pre_exit_cleanup` — leaving the
+            // ssh-NTR tunnel children to launchd as orphans. That was
+            // the untraced exit path that the 2026-05-23 Phase-1 cascade
+            // (10 GUI restarts, no exit-reason in trace) ran on. We now
+            // sweep tunnels first, then let Tauri proceed.
+            //
+            // Note: we *don't* call api.prevent_exit() — the cleanup is
+            // fire-and-forget pre-shutdown, not a veto.
+            if let tauri::RunEvent::ExitRequested { .. } = &event {
+                let port = app
+                    .try_state::<Arc<config::AppConfig>>()
+                    .map(|cfg| cfg.http_port)
+                    .unwrap_or(7777);
+                housekeeping::pre_exit_cleanup(port, "tauri-exit-requested");
+            }
+
             // macOS: Dock-Klick, "open" bei laufender App, File-Assoc etc.
             // → Settings-Fenster nach vorn holen. `RunEvent::Reopen` is
             // a Mac-only variant, so this whole branch is gated.
@@ -1361,14 +1481,16 @@ pub fn run() {
             // tauri-plugin-single-instance, which surfaces the existing
             // window through its own callback (wired up at plugin init,
             // not here).
-            //
-            // Cmd-Q / window-close both just let the app terminate;
-            // auto-resurrect in mcp_attach brings aiui back when needed.
             #[cfg(target_os = "macos")]
             {
-                if let tauri::RunEvent::Reopen { .. } = _event {
-                    show_settings_window(_app);
+                if let tauri::RunEvent::Reopen { .. } = event {
+                    show_settings_window(app);
                 }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = event;
+                let _ = app;
             }
         });
 }

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/lib/updater.ts
+++ b/companion/src/lib/updater.ts
@@ -8,17 +8,14 @@ import { invoke } from "@tauri-apps/api/core";
  *
  * Two modes:
  *  • `silent: true` (auto-triggers from App.svelte: post-render event,
- *    window-focus, mount). NEVER surfaces UI — neither error toasts,
- *    "you're on latest", nor an install prompt. If a new version is
- *    available the function only logs to console and returns. The user
- *    will see the prompt the next time they manually click "Nach
- *    Updates suchen" in Settings, or when the next GUI restart picks
- *    up the new bundle. Rationale: post-render auto-checks fired in
- *    the middle of an agent's dialog, briefly surfacing the Settings
- *    window and stealing focus from the live `confirm`/`ask`/`form`
- *    the user was answering (reproduced 2026-05-06 right after 0.4.38
- *    shipped — agent's window broke because the silent post-render
- *    check picked up 0.4.38 mid-dialog).
+ *    window-focus, mount). No prompts, no surfaced UI. If an update is
+ *    available AND the dialog window is idle (no pending render), the
+ *    update is downloaded and installed transparently followed by a
+ *    relaunch. The next agent tool call hits the new version. If the
+ *    dialog window is busy with a live form/confirm/ask, the install
+ *    is deferred until the next safe moment (catches the
+ *    2026-05-06 mid-dialog-popup case AND fixes the v0.4.39
+ *    too-silent regression where auto-updates simply never shipped).
  *  • `silent: false` (manual button in Settings): full UX —
  *    error/no-update messages and the install prompt.
  *
@@ -52,9 +49,36 @@ export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<
 
   // Update available.
   if (opts.silent) {
-    // Defer entirely — no surfacing, no prompt, no policy change.
-    // Manual Settings click or next GUI restart will pick it up.
-    console.debug(`[aiui] update available (${update.version}) — deferred until manual check or restart`);
+    // Check whether installing right now would interrupt a live
+    // dialog. The Rust side returns false iff `DialogState` has any
+    // pending render — in that case we defer until the next
+    // auto-check cycle (post-render, window-focus, or mount fires
+    // again later). Otherwise we install transparently, no prompt.
+    let safe = false;
+    try {
+      safe = await invoke<boolean>("is_update_safe_to_install");
+    } catch (e) {
+      console.debug(`[aiui] silent updater safety check failed: ${e}`);
+      return;
+    }
+    if (!safe) {
+      console.debug(
+        `[aiui] update ${update.version} available — deferred, dialog pending`,
+      );
+      return;
+    }
+    console.debug(
+      `[aiui] silent install of ${update.version} (dialog idle); relaunching afterwards`,
+    );
+    try {
+      await update.downloadAndInstall();
+      await relaunch();
+    } catch (e) {
+      // Install failure during silent path: don't surface UI (would
+      // pop a banner mid-session), just log. Manual "Nach Updates
+      // suchen" click can retry with full error reporting.
+      console.debug(`[aiui] silent install failed: ${e}`);
+    }
     return;
   }
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.42"
+version = "0.4.43"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cascade-eradication release. Trace from 2026-05-23 showed **10 GUI process restarts in 52 s** under v0.4.40 with **no traced exit reason** — the GUI was dying via a code path I had never instrumented. Codex review identified the gaps. Five interlocking fixes turn the multi-instance race into a structural impossibility.

### Root causes (now fixed)

1. `RunEvent::ExitRequested` was never caught — Cmd-Q / window-close / Tauri-updater-restart all terminated past `pre_exit_cleanup`, leaving ssh-NTR children to launchd. **The untraced exit path** driving Phase 1 of the cascade.
2. `lifetime::gui_serve`'s probe → remove_file → bind sequence had a race against concurrent `http::serve` binds. Two GUIs spawned in the same ms both died, one with `multi-instance-bind-race`, one with `http-bind-error`. Phase 2 of the cascade.
3. `disk_version_if_stale` ran only once at mcp-stdio start. Children spawned before an in-place update kept their old in-RAM code forever — the 2026-05-23 0.4.40-children-survive-update scenario.
4. v0.4.39's \"silent updater is truly silent\" went too far — silent path stopped installing entirely. Updates required manual user action.
5. No GUI-side authority over older mcp-stdio children: new GUI accepted whatever Claude Desktop had attached, including pre-update RAM.

### The fix

| Change | Where | Effect |
|---|---|---|
| `ProcessLock` (fs4-backed RAII) | `housekeeping.rs` | Cross-platform `flock(LOCK_EX\|LOCK_NB)`. Kernel auto-releases on death, no stale lock files |
| Process-lifetime GUI lock at start of `run()` | `lib.rs` | Second concurrent GUI exits with traced `(gui-lock-busy)` before ANY bind. Race-gone-atomic |
| `kill_mcp_stdio_started_before_self()` after lock-win | `housekeeping.rs` + `lib.rs` | New GUI = new truth. Pre-update children get reset; Claude Desktop respawns them current. Same-second start_time deliberately not killed |
| Periodic `disk_version_if_stale` (30 s) in mcp-stdio | `lib.rs` | In-RAM-stale children self-exit within 30 s of an in-place update |
| `RunEvent::ExitRequested` ⇒ `pre_exit_cleanup` | `lib.rs` | Cmd-Q, ⌘W, Tauri-restart, OS shutdown all sweep ssh-NTR before terminating. The untraced Phase-1 exit path is gone |
| Explicit `pre_exit_cleanup` before `app_handle.restart()` | `http.rs` | Belt-and-braces in updater path |
| `is_update_safe_to_install` Tauri command + silent installer gate | `lib.rs` + `updater.ts` | Auto-updater works again, but only installs when no dialog is open |

### Tests

96 unit tests pass (89 prior + 7 new). New tests cover `ProcessLock` exclusivity / parent-dir creation, `find_pre_gui_mcp_stdio_to_kill` strict-cutoff semantics (same-second skip, newer skip, own-pid skip, non-aiui skip). `cargo clippy --release -- -D warnings` clean. `svelte-check` 0 errors.

### Test plan

- [x] `cargo test --lib` — 96 pass.
- [x] `cargo clippy --release -- -D warnings` — clean.
- [x] `svelte-check` — 0 errors.
- [ ] Reproduce the 2026-05-23 cascade on MacBook: kill mcp-stdio-Pärchen, restart Claude Desktop twice, verify only ONE GUI process survives, lock file at `~/.config/aiui/gui.lock` exists, no cascade.
- [ ] Verify Auto-Updater again installs silent updates between dialogs (open Settings, click \"Nach Updates suchen\" on older build → install → relaunch → version bumped).
- [ ] Open a long form, wait for next auto-check tick → install MUST defer (no Settings pop-up mid-dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)