### PR TITLE
fix: ExitRequested veto + pending-update banner (v0.4.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.44] — 2026-05-26
+
+Two fixes that close the loop on yesterday's structural changes.
+
+### Fixed
+
+- **`RunEvent::ExitRequested` now vetoes when the GUI is still
+  needed.** v0.4.43 traced the event and ran `pre_exit_cleanup`, but
+  did not actually stop Tauri's default terminator. Result: the GUI
+  still died ~18 ms after every dialog submit on macOS — Tauri's
+  default behaviour for "last visible window closed" reached
+  `ExitRequested` *after* my `on_window_event` returned, and the
+  process exited regardless. v0.4.44 calls `api.prevent_exit()`
+  whenever `LifetimeStats.child_count > 0` **or** the dialog registry
+  has a pending render. The lifetime-grace timer (60 s after the last
+  child detaches) remains the only legitimate "everyone's gone,
+  really exit" trigger in normal operation. Explicit exits (`app.exit`
+  with a code, lifetime-grace-expired) still run cleanup and proceed.
+
+### Added
+
+- **Pending-update banner in Settings (notification-first auto-update).**
+  Replaces the v0.4.43 transparent-silent-install with a model the
+  user actually notices. The periodic auto-check (now 6 h cadence,
+  raised from 30 min) writes the available version into a new
+  Rust-side `PendingUpdate` state and broadcasts an
+  `update:available` event. Settings.svelte renders a non-modal
+  yellow banner at the top of the window: *"aiui v0.4.X ist
+  verfügbar — [Installieren]"*. The Install button routes through the
+  manual `checkForUpdates({ silent: false })` path so the user always
+  sees the native confirmation modal before anything restarts. Banner
+  clears automatically once the on-disk version catches up. No more
+  mid-dialog interruptions, no more silent installs the user never
+  knows about — both regressions from v0.4.39 / v0.4.43 closed.
+
+### Notes
+
+- New Tauri commands: `set_pending_update`, `clear_pending_update`,
+  both consumed by `updater.ts`.
+- `StatusReport` gains a `pending_update: Option<String>` field so a
+  Settings window that opens *after* the auto-check fires still
+  picks up the banner via its 2 s status poll.
+- 89 unit tests still pass; clippy `-D warnings` clean; svelte-check
+  0 errors. Veto logic deliberately not unit-tested as a pure
+  function — extracting it from the `RunEvent` closure was more
+  invasive than the test value justified.
+
 ## [0.4.43] — 2026-05-23
 
 Cascade-eradication release. The 2026-05-23 trace showed 10 GUI process

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.43"
+version = "0.4.44"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.43"
+version = "0.4.44"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ mod skill;
 mod tunnel;
 
 use std::sync::Arc;
-use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 /// Tauri window labels. Setup and dialog live in *separate* windows so:
 ///  • the agent's dialog never visually overlaps the user's settings,
@@ -160,6 +160,48 @@ async fn surface_for_dialog(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Pending-update state (v0.4.44). Holds the version string Tauri's
+/// updater plugin reported as the newest available release, set by
+/// the silent auto-check path; consumed by the Settings banner. Newtype
+/// so Tauri's `State<T>` can distinguish it from other
+/// `Arc<Mutex<Option<String>>>`-typed state (notably `http_error`).
+#[derive(Default)]
+pub struct PendingUpdate(pub std::sync::Mutex<Option<String>>);
+
+#[tauri::command]
+async fn set_pending_update(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<PendingUpdate>>,
+    version: String,
+) -> Result<(), String> {
+    let trimmed = version.trim();
+    let new_value = if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    };
+    if let Ok(mut slot) = state.0.lock() {
+        *slot = new_value.clone();
+    }
+    // Notify every window — both setup and dialog can re-read status
+    // and refresh their banner accordingly. The dialog window will
+    // typically ignore it, the setup window's banner reacts.
+    let _ = app.emit("update:available", &new_value);
+    Ok(())
+}
+
+#[tauri::command]
+async fn clear_pending_update(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<PendingUpdate>>,
+) -> Result<(), String> {
+    if let Ok(mut slot) = state.0.lock() {
+        *slot = None;
+    }
+    let _ = app.emit("update:available", &None::<String>);
+    Ok(())
+}
+
 #[derive(serde::Serialize)]
 struct StatusReport {
     app_binary_path: String,
@@ -204,6 +246,11 @@ struct StatusReport {
     /// uninstall instructions: drag to Trash vs. Apps & Features) without
     /// pulling in `@tauri-apps/plugin-os`. Set once at compile time.
     os: &'static str,
+    /// `Some(version)` when the periodic auto-update check has found a
+    /// newer release that hasn't been installed yet. Drives the
+    /// non-modal banner in Settings ("Update auf v0.4.X verfügbar —
+    /// Installieren"). v0.4.44.
+    pending_update: Option<String>,
 }
 
 const fn current_os() -> &'static str {
@@ -223,6 +270,7 @@ async fn status(
     cfg: tauri::State<'_, Arc<config::AppConfig>>,
     tm: tauri::State<'_, Arc<tunnel::TunnelManager>>,
     http_err: tauri::State<'_, Arc<std::sync::Mutex<Option<String>>>>,
+    pending_update: tauri::State<'_, Arc<PendingUpdate>>,
 ) -> Result<StatusReport, String> {
     let bin = setup::app_binary_path();
     let http_alive = probe_http_self(&cfg).await;
@@ -241,6 +289,7 @@ async fn status(
         http_error: http_err.lock().ok().and_then(|s| s.clone()),
         http_alive,
         os: current_os(),
+        pending_update: pending_update.0.lock().ok().and_then(|s| s.clone()),
     })
 }
 
@@ -1083,6 +1132,20 @@ pub fn run() {
     let http_error: Arc<std::sync::Mutex<Option<String>>> =
         Arc::new(std::sync::Mutex::new(None));
 
+    // Pending-update state (v0.4.44). Set by the silent updater path
+    // in `updater.ts` whenever the periodic auto-check finds a newer
+    // release; read by Settings.svelte to render a non-modal banner
+    // ("Update auf v0.4.X verfügbar — Installieren"). Replaces the
+    // 0.4.43 transparent-silent-install with a notification-first
+    // model: user sees the banner the next time they open Settings,
+    // clicks Install to surface the modal confirmation. No more
+    // mid-dialog interruptions, no more silent installs the user
+    // never knows about.
+    //
+    // Wrapped in a newtype so Tauri's `State<T>` resolution can tell
+    // it apart from `http_error` (same underlying type).
+    let pending_update = Arc::new(PendingUpdate::default());
+
     // Window-ready handshake: the dialog window's frontend signals
     // here (via the `dialog_window_ready` Tauri command) once its
     // listeners are wired up. The render path *waits* on this watch
@@ -1147,6 +1210,7 @@ pub fn run() {
         .manage(lifetime_stats.clone())
         .manage(tunnel_mgr.clone())
         .manage(http_error.clone())
+        .manage(pending_update.clone())
         .manage(dialog_ready_tx.clone())
         .invoke_handler(tauri::generate_handler![
             dialog_submit,
@@ -1157,6 +1221,8 @@ pub fn run() {
             close_window,
             surface_for_dialog,
             is_update_safe_to_install,
+            set_pending_update,
+            clear_pending_update,
             status,
             add_remote,
             remove_remote,
@@ -1451,25 +1517,63 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error building tauri application")
         .run(|app, event| {
-            // ExitRequested catch (v0.4.43, Codex review P0c). Cmd-Q,
-            // ⌘W on the last visible window, OS shutdown, and the
-            // Tauri-Updater's `.restart()` all funnel through this
-            // event. Before v0.4.43 we let the event fall through to
-            // Tauri's default handler, which terminated the process
-            // *without* running our `pre_exit_cleanup` — leaving the
-            // ssh-NTR tunnel children to launchd as orphans. That was
-            // the untraced exit path that the 2026-05-23 Phase-1 cascade
-            // (10 GUI restarts, no exit-reason in trace) ran on. We now
-            // sweep tunnels first, then let Tauri proceed.
+            // ExitRequested handler (v0.4.43 introduced cleanup; v0.4.44
+            // adds the veto for the "headless mode" case). Tauri fires
+            // ExitRequested on Cmd-Q, on ⌘W of the last visible
+            // window, on OS shutdown, and on `.restart()`. The
+            // last-window-close case is the dangerous one: as soon as
+            // the agent's dialog window closes after a submit, Tauri
+            // wants to terminate the process — but that's wrong while
+            // the GUI is meant to live headless serving the lifetime
+            // socket. v0.4.42 lost the GUI ~18 ms after every Dialog
+            // submit through this path (trace 2026-05-26 17:00:28.181
+            // → 17:00:28.199); the dialog-window-close branch of
+            // on_window_event already returned without exit, but
+            // Tauri's default ExitRequested handler ran *after* it
+            // and killed the process anyway.
             //
-            // Note: we *don't* call api.prevent_exit() — the cleanup is
-            // fire-and-forget pre-shutdown, not a veto.
-            if let tauri::RunEvent::ExitRequested { .. } = &event {
+            // Resolution rule:
+            //   • Anyone still depending on us — an attached
+            //     mcp-stdio child or a pending dialog — ⇒ veto the
+            //     exit via `api.prevent_exit()`. The lifetime-grace
+            //     timer (60 s after the last child detaches) remains
+            //     the *only* legitimate "everyone's gone, really
+            //     exit" signal in normal operation.
+            //   • Nobody attached and no pending dialog ⇒ honour the
+            //     exit, but run pre_exit_cleanup first so any ssh-NTR
+            //     tunnel children get SIGTERM instead of becoming
+            //     launchd orphans.
+            if let tauri::RunEvent::ExitRequested { api, code, .. } = &event {
+                let attached = app
+                    .try_state::<Arc<lifetime::LifetimeStats>>()
+                    .map(|s| s.child_count())
+                    .unwrap_or(0);
+                let pending_dialogs = app
+                    .try_state::<Arc<dialog::DialogState>>()
+                    .map(|s| s.stats().orphan_count)
+                    .unwrap_or(0);
+
+                if code.is_none() && (attached > 0 || pending_dialogs > 0) {
+                    // Tauri-initiated quit (no explicit exit code).
+                    // Someone still needs us — keep the process alive.
+                    logging::trace(&format!(
+                        "[aiui] veto tauri-exit-requested: attached_children={attached}, \
+                         pending_dialogs={pending_dialogs}"
+                    ));
+                    api.prevent_exit();
+                    return;
+                }
+
                 let port = app
                     .try_state::<Arc<config::AppConfig>>()
                     .map(|cfg| cfg.http_port)
                     .unwrap_or(7777);
-                housekeeping::pre_exit_cleanup(port, "tauri-exit-requested");
+                let reason = if code.is_some() {
+                    "tauri-exit-requested-explicit"
+                } else {
+                    "tauri-exit-requested-no-attached"
+                };
+                housekeeping::pre_exit_cleanup(port, reason);
             }
 
             // macOS: Dock-Klick, "open" bei laufender App, File-Assoc etc.

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.43",
+  "version": "0.4.44",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/i18n/de.json
+++ b/companion/src/i18n/de.json
@@ -70,6 +70,8 @@
     "uninstall.done.body.other": "Konfiguration ist weg. Klick rechts auf den roten Beenden-Button und entferne aiui anschließend über deinen Paketmanager — eine laufende App kann sich nicht selbst entfernen.",
     "uninstall.done.quit": "aiui beenden",
     "updates.check": "Nach Updates suchen",
+    "pending_update.text": "aiui {version} ist verfügbar.",
+    "pending_update.install": "Installieren",
     "report.button": "Problem melden",
     "report.hint": "Öffnet ein neues Issue auf GitHub mit Version und Build vorausgefüllt."
   },

--- a/companion/src/i18n/en.json
+++ b/companion/src/i18n/en.json
@@ -70,6 +70,8 @@
     "uninstall.done.body.other": "Configuration is gone. Click the red Quit button on the right, then remove aiui via your package manager — a running app can't remove itself.",
     "uninstall.done.quit": "Quit aiui",
     "updates.check": "Check for updates",
+    "pending_update.text": "aiui {version} is available.",
+    "pending_update.install": "Install",
     "report.button": "Report issue",
     "report.hint": "Opens a new GitHub issue with version and build pre-filled."
   },

--- a/companion/src/lib/Settings.svelte
+++ b/companion/src/lib/Settings.svelte
@@ -29,6 +29,12 @@
     /** Lower-case OS identifier from the backend. Used to pick the right
      * variant of OS-specific UI copy (e.g. uninstall instructions). */
     os: "macos" | "windows" | "linux" | "other";
+    /** When the periodic auto-check found a newer release (set by
+     * `set_pending_update` in updater.ts silent path). Settings shows a
+     * non-modal banner with this version + an "Installieren" button.
+     * Cleared once the user installs (clear_pending_update) or once
+     * the on-disk version catches up. v0.4.44. */
+    pending_update: string | null;
   };
   let status = $state<Status | null>(null);
   let newHost = $state("");
@@ -206,9 +212,31 @@
     }
   }
 
+  /** Triggered by the "Installieren" button on the pending-update
+   * banner. Routes through the manual `checkForUpdates` path so the
+   * user sees the native modal confirmation ("install v0.4.X?") and
+   * we don't bypass the explicit-consent step. v0.4.44. */
+  async function installPendingUpdate() {
+    if (busy) return;
+    busy = true;
+    try {
+      await checkForUpdates({ silent: false });
+    } finally {
+      busy = false;
+    }
+  }
+
   onMount(() => {
     refresh();
     timer = window.setInterval(refresh, 2000);
+    // Listen for the cross-window `update:available` broadcast from
+    // Rust so the banner refreshes immediately when the silent
+    // updater detects a new version, not only on the 2 s status poll.
+    void import("@tauri-apps/api/event").then(({ listen }) => {
+      void listen<string | null>("update:available", (e) => {
+        if (status) status = { ...status, pending_update: e.payload ?? null };
+      });
+    });
   });
   onDestroy(() => {
     if (timer) window.clearInterval(timer);
@@ -262,6 +290,26 @@
       <div class="build-info" title={status.build_info}>{status.build_info.split(" ")[1]}</div>
     </div><!-- /.app-header -->
     </header>
+
+    <!-- Pending-update banner (v0.4.44). Non-modal, dismiss-free: it
+         sits above the scroll region until the user clicks Install or
+         the on-disk version catches up (Rust clears the flag after
+         relaunch). No timer-driven popups, no mid-dialog disruption —
+         the user opens Settings and the banner is just there. -->
+    {#if status.pending_update}
+      <div class="update-banner" role="status" aria-live="polite">
+        <span class="update-banner-text">
+          {$_("settings.pending_update.text", { values: { version: status.pending_update } })}
+        </span>
+        <button
+          class="update-banner-button"
+          onclick={installPendingUpdate}
+          disabled={busy}
+        >
+          {$_("settings.pending_update.install")}
+        </button>
+      </div>
+    {/if}
 
     <div class="window-scroll">
     <!-- Show the banner only when the live Rust-side TCP self-probe says
@@ -522,6 +570,46 @@
 {/if}
 
 <style>
+  /* Pending-update banner (v0.4.44). Lives between .window-header and
+     .window-scroll as a flex sibling so it inherits the shell's
+     horizontal padding. Yellow accent for "informational, action
+     available" without screaming. */
+  .update-banner {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 8px 20px 0 20px;
+    padding: 8px 12px;
+    border: 1px solid color-mix(in srgb, var(--warning, #f3c623) 60%, var(--border));
+    background: color-mix(in srgb, var(--warning, #f3c623) 18%, var(--bg, #fff));
+    color: color-mix(in srgb, var(--warning, #f3c623) 70%, var(--fg, #000));
+    border-radius: 8px;
+    font-size: 12.5px;
+    line-height: 1.4;
+  }
+  .update-banner-text {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+  .update-banner-button {
+    flex: 0 0 auto;
+    background: var(--warning, #f3c623);
+    color: var(--bg, #fff);
+    border: none;
+    border-radius: 6px;
+    padding: 4px 10px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .update-banner-button:hover {
+    filter: brightness(0.95);
+  }
+  .update-banner-button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
   .app-header {
     display: flex;
     align-items: center;

--- a/companion/src/lib/lifecycle.ts
+++ b/companion/src/lib/lifecycle.ts
@@ -10,15 +10,19 @@
 //   • on window focus (covers wake-from-sleep and "user came back to the
 //     Mac" without needing an OS-level event hook).
 //
-// A 30-minute cooldown debounces bursts so a chatty session doesn't
-// hammer the GitHub release endpoint. Both windows share the cooldown
-// shape independently — the duplicate hits are still well below GitHub's
-// rate limit.
+// v0.4.44 raised the cooldown from 30 min to 6 h. The check itself is
+// cheap, but with the new notification-first model (silent path sets a
+// pending-update flag instead of installing) we don't need bursty
+// re-checks — once the flag is set, the banner stays until the user
+// installs or the version on disk catches up. Six hours is the
+// "approximate daily" rhythm the user asked for on 2026-05-26: a
+// chatty session won't hammer the GitHub release endpoint, but a
+// long-running GUI still picks up new releases the same day.
 
 import { listen } from "@tauri-apps/api/event";
 import { checkForUpdates } from "./updater";
 
-const UPDATE_COOLDOWN_MS = 30 * 60 * 1000;
+const UPDATE_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 let lastUpdateCheck = 0;
 
 function maybeCheckForUpdates(reason: string) {

--- a/companion/src/lib/updater.ts
+++ b/companion/src/lib/updater.ts
@@ -49,35 +49,26 @@ export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<
 
   // Update available.
   if (opts.silent) {
-    // Check whether installing right now would interrupt a live
-    // dialog. The Rust side returns false iff `DialogState` has any
-    // pending render — in that case we defer until the next
-    // auto-check cycle (post-render, window-focus, or mount fires
-    // again later). Otherwise we install transparently, no prompt.
-    let safe = false;
+    // v0.4.44: notification-first instead of transparent-install. We
+    // record the available version in the Rust-side `PendingUpdate`
+    // state; Settings.svelte reads that on mount and renders a
+    // non-modal banner ("Update auf v{version} verfügbar —
+    // Installieren"). Rust also broadcasts an `update:available`
+    // event so a live Settings window updates its banner immediately.
+    // No `downloadAndInstall` here — the user opts in by clicking
+    // the banner (which calls back into this function with
+    // `silent: false`), so a long form mid-fill is never interrupted
+    // by a sudden restart. The 0.4.43 silent-install path is gone:
+    // it solved the mid-dialog UI problem but left the user
+    // completely unaware that an update happened, which the user
+    // flagged on 2026-05-26.
     try {
-      safe = await invoke<boolean>("is_update_safe_to_install");
-    } catch (e) {
-      console.debug(`[aiui] silent updater safety check failed: ${e}`);
-      return;
-    }
-    if (!safe) {
+      await invoke("set_pending_update", { version: update.version });
       console.debug(
-        `[aiui] update ${update.version} available — deferred, dialog pending`,
+        `[aiui] update ${update.version} available — pending banner set, no install yet`,
       );
-      return;
-    }
-    console.debug(
-      `[aiui] silent install of ${update.version} (dialog idle); relaunching afterwards`,
-    );
-    try {
-      await update.downloadAndInstall();
-      await relaunch();
     } catch (e) {
-      // Install failure during silent path: don't surface UI (would
-      // pop a banner mid-session), just log. Manual "Nach Updates
-      // suchen" click can retry with full error reporting.
-      console.debug(`[aiui] silent install failed: ${e}`);
+      console.debug(`[aiui] failed to record pending update: ${e}`);
     }
     return;
   }
@@ -94,5 +85,13 @@ export async function checkForUpdates(opts: { silent?: boolean } = {}): Promise<
   if (!wantInstall) return;
 
   await update.downloadAndInstall();
+  // Clear the pending-update banner before relaunch — once the new
+  // binary is on disk the banner would be stale (version === current
+  // after relaunch, no longer a pending update).
+  try {
+    await invoke("clear_pending_update");
+  } catch (e) {
+    console.debug(`[aiui] clear_pending_update failed (continuing): ${e}`);
+  }
   await relaunch();
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.43"
+version = "0.4.44"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Two follow-ups to v0.4.43 that close the loop on the issues that were still leaking through:

### Fixed — ExitRequested veto

v0.4.43 traced the event and ran `pre_exit_cleanup`, but didn't call `api.prevent_exit()`. Tauri's default last-window-close terminator still ran ~18 ms after every dialog submit, killing the GUI even though an mcp-stdio child was still attached. v0.4.44 wires the actual veto:

\`\`\`rust
if code.is_none() && (attached_children > 0 || pending_dialogs > 0) {
    api.prevent_exit();
    return;
}
\`\`\`

Lifetime-grace timer (60 s after the last child detaches) is now the only legitimate \"everyone's gone\" trigger. Explicit exits (`app.exit` with a code, lifetime-grace-expired) still run cleanup and proceed.

### Added — pending-update banner (notification-first auto-update)

Replaces the v0.4.43 transparent silent-install with a model the user actually notices:

- New Rust state `PendingUpdate(Mutex<Option<String>>)` registered as Tauri state.
- New commands `set_pending_update(version)` / `clear_pending_update()` + an `update:available` broadcast event.
- `updater.ts` silent path no longer calls `downloadAndInstall` — it sets the pending state. User-initiated path (manual button / banner button) still uses the full modal+install flow.
- `Settings.svelte` renders a non-modal yellow banner at the top of the window when `status.pending_update` is set. \"aiui v0.4.X ist verfügbar — [Installieren]\". Banner clears once the on-disk version catches up.
- Cooldown raised from 30 min to 6 h (the periodic check itself is cheap, but it no longer needs bursty re-checks once the flag is set — banner stays until install).

### Test results

- `cargo test --lib`: **89 pass** (no regression).
- `cargo clippy --release -- -D warnings`: clean.
- `svelte-check`: 0 errors (9 pre-existing warnings in Form.svelte / Settings.svelte unrelated to this change).

### Test plan

- [x] Cargo tests pass.
- [ ] Reproduce on MacBook: submit a confirm, watch trace.log — no `tauri-exit-requested` exit reason should appear, no GUI restart needed.
- [ ] Drop a v0.4.45 stub release on GitHub, wait for auto-check on a running v0.4.44 — banner should appear in Settings within 6 h max.
- [ ] Click banner Install button → native modal → confirm → install + relaunch → banner gone after relaunch.
- [ ] Open a long form, wait through 6 h auto-check tick — no Settings pop-up, no mid-dialog interruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)