### PR TITLE
fix: dialog-lifecycle hardening — Cowork multi-session + empty-window (v0.4.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to this project are documented here.
 
+## [0.4.46] — 2026-05-29
+
+Dialog-lifecycle hardening. Two field-reported regressions from the
+lifecycle work of the last days, both root-caused from a Cowork session's
+logs + trace, plus a defensive pass so a malformed or stranded dialog can
+never leave the user staring at a dead window.
+
+### Fixed
+
+- **Starting a new Cowork session no longer disconnects aiui in the
+  other sessions (Bug A).** `kill_sibling_mcp_stdio_with_same_grandparent`
+  (0.4.42) reaped any older `aiui --mcp-stdio` sharing our Claude.app
+  *grandparent*. That was meant to clear a Claude-Desktop duplicate-child
+  glitch — but in Cowork every concurrently-open session's mcp-stdio sits
+  under the *one* Claude.app grandparent, so opening a new session
+  SIGTERM'd the still-live aiui child of every other session (the
+  2026-05-28 "MCP aiui: Server disconnected" toast on the first MCP call
+  of a fresh session; confirmed in the trace: `killing older sibling
+  pid=30384 (same grandparent=26243)`). Replaced with
+  `kill_orphaned_mcp_stdio_children`, which reaps only *orphaned* children
+  — ones whose parent wrapper has died (reparented to launchd). A live
+  parallel session's child has a live parent and is now spared. The
+  original duplicate-child case is already covered by stdin-EOF.
+- **The dialog window can no longer be left empty and unclosable (Bug B).**
+  The 0.4.45 X-close fix routed dialog teardown through a frontend
+  `onCloseRequested` handler that called `preventDefault()` and then ran
+  the cancel/close itself. If that path failed (empty/stale dialog
+  state), the close was prevented but never completed — the window sat
+  empty and the red X did nothing (the 2026-05-29 overnight report: a
+  blank "aiui" window, 9 ignored X-clicks in the GUI log). Teardown is
+  now **authoritative in Rust**: the `/render` handler destroys the
+  dialog window (`window.destroy()`, bypassing the CloseRequested →
+  frontend round-trip) on *every* terminal outcome — submit, cancel,
+  native X, TTL, or channel-drop — and the window-event handler cancels
+  any in-flight render directly when the user hits X. The fragile
+  frontend `onCloseRequested` is gone.
+
+### Hardened (Bug B+, defensive render flow)
+
+- **Invalid specs are rejected before a window opens.** `/render` now
+  validates the spec (top-level `kind ∈ {ask,form,confirm}`, known field
+  kinds) up front; a bad spec returns `invalid_spec` with a `detail` +
+  `hint` the agent can act on, instead of opening a window that renders
+  an "unknown_kind" placeholder. mcp-stdio surfaces that as a clear tool
+  error so the agent fixes the call and retries.
+- **A dialog window may only exist while a dialog is pending.** A
+  belt-and-suspenders `sweep_orphan_dialog_window` runs on app
+  re-activation (`Reopen`): if a dialog window is found with an empty
+  registry, it's destroyed — so a stranded empty frame self-heals even
+  if some future teardown path is missed.
+- **Every `/render` still resolves to exactly one terminal outcome** —
+  user response, `invalid_spec`, `ui_unreachable`, `busy`, or
+  `ttl_expired` — never a silent hang behind an empty window. (The
+  ack-contract watchdog and TTL paths from earlier releases are retained;
+  this release adds the window-teardown guarantee around them.)
+
 ## [0.4.45] — 2026-05-28
 
 Stability release. A chain of vivid real-world incidents over the last

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.4.45"
+version = "0.4.46"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/dialog.rs
+++ b/companion/src-tauri/src/dialog.rs
@@ -326,6 +326,27 @@ impl DialogState {
         }
     }
 
+    /// Cancel every pending dialog with `reason`, resolving each waiting
+    /// `/render` as cancelled. Returns how many were cancelled. Used by
+    /// the dialog-window X-close handler and the orphan-window sweep
+    /// (v0.4.46, Bug B+) so that tearing the window down *always*
+    /// produces a terminal answer for any in-flight render — never a
+    /// silent hang behind an empty window.
+    pub fn cancel_all(&self, reason: &str) -> usize {
+        let mut map = self.pending.lock().unwrap();
+        let drained: Vec<(String, PendingEntry)> = map.drain().collect();
+        let n = drained.len();
+        for (id, entry) in drained {
+            let _ = entry.result_tx.send(DialogResult {
+                id,
+                cancelled: true,
+                result: serde_json::Value::Null,
+                reason: Some(reason.to_string()),
+            });
+        }
+        n
+    }
+
     /// Like `register` but rejects with `BusyInfo` if a dialog is already
     /// in flight after the TTL sweep. Used by `/render` so that two
     /// parallel callers (multiple aiui calls in one assistant turn,
@@ -443,6 +464,24 @@ mod tests {
         let r = rx.blocking_recv().unwrap();
         assert!(r.cancelled);
         assert_eq!(s.stats().orphan_count, 0);
+    }
+
+    #[test]
+    fn cancel_all_resolves_every_pending() {
+        let s = DialogState::new();
+        let (_id, rx, _ack) = s.register();
+        let n = s.cancel_all("window_closed");
+        assert_eq!(n, 1);
+        let r = rx.blocking_recv().unwrap();
+        assert!(r.cancelled);
+        assert_eq!(r.reason.as_deref(), Some("window_closed"));
+        assert_eq!(s.stats().orphan_count, 0);
+    }
+
+    #[test]
+    fn cancel_all_on_empty_is_zero() {
+        let s = DialogState::new();
+        assert_eq!(s.cancel_all("window_closed"), 0);
     }
 
     #[test]

--- a/companion/src-tauri/src/housekeeping.rs
+++ b/companion/src-tauri/src/housekeeping.rs
@@ -218,48 +218,42 @@ fn find_all_children(snap: &[ProcSnap], own_pid: u32) -> Vec<StaleChild> {
         .collect()
 }
 
-/// Resolve the grandparent (= parent's parent) PID of `pid` in the
-/// snapshot. Returns `None` if the chain breaks at any step — caller
-/// treats that as "unknown lineage, do not act".
-fn grandparent_pid(snap: &[ProcSnap], pid: u32) -> Option<u32> {
-    let me = snap.iter().find(|p| p.pid == pid)?;
-    let ppid = me.ppid?;
-    let parent = snap.iter().find(|p| p.pid == ppid)?;
-    parent.ppid
+/// A process is *orphaned* when its parent is gone — reparented to
+/// launchd/init (`ppid == 1`), parent unknown (`None`), or the ppid no
+/// longer exists in the snapshot. Only orphaned `aiui --mcp-stdio`
+/// children are safe to reap: their MCP client (the Claude.app / Cowork
+/// helper wrapper that spawned them) has died, so they are genuinely
+/// abandoned. A child whose parent is still alive belongs to a *live*
+/// session — and must be spared.
+fn is_orphaned_child(snap: &[ProcSnap], p: &ProcSnap) -> bool {
+    match p.ppid {
+        None => true,
+        Some(1) => true,
+        Some(pp) => !snap.iter().any(|q| q.pid == pp),
+    }
 }
 
-/// Filter: other `aiui --mcp-stdio` children spawned by the same MCP
-/// client (= same grandparent in the process tree, typically the Claude
-/// Desktop or Claude Code App process) and started *before* us. Pure
-/// function over a snapshot — the `(own_pid, own_grandparent, own_start)`
-/// triple comes from the caller so tests don't need to spoof
-/// `std::process::id()`.
+/// Filter: every *orphaned* `aiui --mcp-stdio` child (parent process
+/// gone), excluding `own_pid`. Pure function over a snapshot so tests
+/// don't need to spoof `std::process::id()`.
 ///
-/// "Same grandparent" was picked over "same parent" because every
-/// mcp-stdio on macOS sits one level below a Claude.app helper wrapper
-/// (`disclaimer`); each spawn gets its own wrapper, so PPIDs differ,
-/// but the wrappers themselves are all children of the same Claude.app
-/// process.
-///
-/// "Started before us" enforces a strict newer-kills-older rule. Two
-/// mcp-stdios spawned at the same instant from the same parent would
-/// otherwise see each other as "older" and tear each other down.
-/// v0.4.42.
-fn find_sibling_mcp_stdio_to_kill(
-    snap: &[ProcSnap],
-    own_pid: u32,
-    own_grandparent: Option<u32>,
-    own_start_time: u64,
-) -> Vec<StaleChild> {
-    let Some(own_gp) = own_grandparent else {
-        return Vec::new();
-    };
+/// v0.4.46 (Bug A): replaces the previous "newer-kills-older with the
+/// same grandparent" rule. That rule used the Claude.app process as the
+/// discriminator — but in Cowork every concurrently-open session's
+/// mcp-stdio sits under the *one* Claude.app grandparent, so starting a
+/// new session tore down the still-live aiui connection of every other
+/// session (the 2026-05-28 "Server disconnected on first MCP call"
+/// reports). Orphan-status is the correct discriminator: a leaked child
+/// has lost its parent wrapper; a live parallel session has not. The
+/// genuine duplicate-child case the old rule guarded against is already
+/// covered by stdin-EOF (a client that drops a child closes its stdin,
+/// and `run_stdio` exits on EOF).
+fn find_orphaned_mcp_stdio_to_kill(snap: &[ProcSnap], own_pid: u32) -> Vec<StaleChild> {
     snap.iter()
         .filter(|p| p.pid != own_pid)
         .filter(|p| has_mcp_stdio_flag(&p.args))
         .filter(|p| is_aiui_binary(&p.exe))
-        .filter(|p| p.start_time < own_start_time)
-        .filter(|p| grandparent_pid(snap, p.pid) == Some(own_gp))
+        .filter(|p| is_orphaned_child(snap, p))
         .map(|p| StaleChild {
             pid: p.pid,
             exe: p.exe.clone(),
@@ -267,92 +261,48 @@ fn find_sibling_mcp_stdio_to_kill(
         .collect()
 }
 
-/// Kill any older `aiui --mcp-stdio` children spawned by the *same* MCP
-/// client as us. Called once at mcp-stdio startup, after the
-/// `disk_version_if_stale` self-check. Returns the number of siblings
-/// terminated.
+/// Reap every *orphaned* `aiui --mcp-stdio` child — one whose parent
+/// (the Claude.app / Cowork helper wrapper) has died, leaving it
+/// reparented to launchd. Called once at mcp-stdio startup. Returns the
+/// number of children terminated.
 ///
-/// Why this exists: Claude Desktop has been observed (2026-05-16) to
-/// occasionally spawn a fresh `aiui --mcp-stdio` child while leaving
-/// the previous one running. Both children attach to the lifetime
-/// socket, both register their prompt list, and Claude Desktop's
-/// internal slash-command routing then can't decide which child owns
-/// `prompts/get` — the slash-command fails with "kein erkannter
-/// Befehl" even though the prompt list itself was loaded correctly.
-/// The aiui-side fix is the strict newer-kills-older policy here: the
-/// fresh child wins, the stale one gets SIGTERM, Claude Desktop is
-/// left with exactly one mcp-stdio per app instance.
+/// Why this exists / why it changed (v0.4.46, Bug A): the previous
+/// implementation killed any older mcp-stdio sharing our *grandparent*
+/// (the Claude.app process). That was meant to clear a Claude-Desktop
+/// duplicate-child glitch (one session, two children, slash-command
+/// routing confused — "kein erkannter Befehl"). But it mis-fired badly
+/// under Cowork: every concurrently-open Cowork session's mcp-stdio
+/// sits under the same single Claude.app grandparent, so starting a new
+/// session reaped the still-live aiui connection of every *other*
+/// session (the 2026-05-28 "Server disconnected on first MCP call"
+/// reports). "Same grandparent" can't tell a leaked duplicate from a
+/// live parallel session — both share the app.
 ///
-/// We also terminate the immediate parent (the
-/// `Claude.app/Contents/Helpers/disclaimer` wrapper on macOS) of the
-/// older sibling so it doesn't immediately respawn a replacement and
-/// trigger the race again. The grandparent — the Claude.app process
-/// itself — is never touched.
-///
-/// Safety: if our own lineage can't be fully resolved (e.g. we're
-/// running standalone from a terminal, no MCP-client grandparent), the
-/// function is a no-op. We never broadly sweep all aiui-mcp-stdio
-/// children — `kill_all_mcp_stdio_children` is the uninstall-only path
-/// for that.
-pub fn kill_sibling_mcp_stdio_with_same_grandparent() -> usize {
+/// Orphan-status can: a leaked child has lost its parent wrapper; a live
+/// session's child has not. So we now reap only orphans. The original
+/// duplicate-child case is already covered by stdin-EOF — when a client
+/// drops a child it closes the child's stdin, and `run_stdio` exits on
+/// EOF. We never broadly sweep all aiui-mcp-stdio children;
+/// `kill_all_mcp_stdio_children` is the uninstall-only path for that.
+pub fn kill_orphaned_mcp_stdio_children() -> usize {
     let own_pid = std::process::id();
     let snap = snapshot_processes();
-    let own_grandparent = grandparent_pid(&snap, own_pid);
-    let own_start_time = snap
-        .iter()
-        .find(|p| p.pid == own_pid)
-        .map(|p| p.start_time)
-        .unwrap_or(0);
+    let victims = find_orphaned_mcp_stdio_to_kill(&snap, own_pid);
 
-    let siblings = find_sibling_mcp_stdio_to_kill(
-        &snap,
-        own_pid,
-        own_grandparent,
-        own_start_time,
-    );
-
-    if siblings.is_empty() {
-        return 0;
-    }
-
-    let gp_str = own_grandparent
-        .map(|gp| gp.to_string())
-        .unwrap_or_else(|| "<unknown>".into());
-
-    for sibling in &siblings {
-        // Find the sibling's immediate parent (typically the disclaimer
-        // wrapper on macOS) so we can SIGTERM it as well — without
-        // that, Claude Desktop's spawn-supervisor would re-run a fresh
-        // child against the just-killed pid and we'd be back to two.
-        let sibling_ppid = snap
-            .iter()
-            .find(|p| p.pid == sibling.pid)
-            .and_then(|p| p.ppid);
-
+    for victim in &victims {
         trace(&format!(
-            "housekeeping: killing older sibling mcp-stdio pid={} exe={} \
-             (same grandparent={} as own pid={})",
-            sibling.pid, sibling.exe, gp_str, own_pid
+            "housekeeping: reaping orphaned mcp-stdio pid={} exe={} \
+             (parent gone — abandoned leak)",
+            victim.pid, victim.exe
         ));
-        terminate_pid(sibling.pid);
-
-        // Belt-and-braces guard: never SIGTERM the grandparent itself —
-        // that would be the Claude Desktop / Claude Code app and would
-        // take our own current MCP session down with it.
-        if let Some(wrapper_pid) = sibling_ppid {
-            if Some(wrapper_pid) != own_grandparent && wrapper_pid != own_pid {
-                trace(&format!(
-                    "housekeeping: also terminating sibling wrapper pid={wrapper_pid}"
-                ));
-                terminate_pid(wrapper_pid);
-            }
-        }
+        terminate_pid(victim.pid);
     }
-    let n = siblings.len();
-    trace(&format!(
-        "housekeeping: terminated {n} older sibling mcp-stdio child(ren) on startup \
-         (grandparent={gp_str})"
-    ));
+    let n = victims.len();
+    if n > 0 {
+        trace(&format!(
+            "housekeeping: reaped {n} orphaned mcp-stdio child(ren) on startup"
+        ));
+    }
     n
 }
 
@@ -844,117 +794,87 @@ mod tests {
         assert_eq!(all.len(), 2);
     }
 
-    // ---------- find_sibling_mcp_stdio_to_kill ----------
-
-    /// Build the canonical Claude-Desktop process tree:
-    ///   100 (Claude.app)
-    ///   ├─ 200 (disclaimer wrapper)
-    ///   │    └─ 300 (aiui --mcp-stdio, older, start=1100)
-    ///   └─ 400 (disclaimer wrapper)
-    ///        └─ 500 (aiui --mcp-stdio, newer, start=2100)
-    fn canonical_claude_desktop_tree() -> Vec<ProcSnap> {
-        vec![
-            snap_full(100, 1, "/Applications/Claude.app/Contents/MacOS/Claude", &["Claude"], 800),
-            snap_full(200, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 1099),
-            snap_full(300, 200, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
-            snap_full(400, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 2099),
-            snap_full(500, 400, CURRENT, &[CURRENT, "--mcp-stdio"], 2100),
-        ]
-    }
+    // ---------- find_orphaned_mcp_stdio_to_kill (Bug A, v0.4.46) ----------
 
     #[test]
-    fn grandparent_resolves_through_disclaimer_wrapper() {
-        let snap = canonical_claude_desktop_tree();
-        assert_eq!(grandparent_pid(&snap, 500), Some(100));
-        assert_eq!(grandparent_pid(&snap, 300), Some(100));
-    }
-
-    #[test]
-    fn grandparent_is_none_when_chain_breaks() {
-        // Orphan with ppid=1 but no entry for pid=1 in the snapshot.
-        let snap = vec![snap_full(500, 1, CURRENT, &[CURRENT, "--mcp-stdio"], 2100)];
-        assert_eq!(grandparent_pid(&snap, 500), None);
-    }
-
-    #[test]
-    fn sibling_kill_finds_older_same_grandparent() {
-        let snap = canonical_claude_desktop_tree();
-        // We are pid 500 (the newer mcp-stdio), grandparent 100, start 2100.
-        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, Some(100), 2100);
+    fn orphan_reaped_when_reparented_to_launchd() {
+        // Parent died → child reparented to launchd (ppid==1).
+        let snap = vec![
+            snap_full(1, 0, "/sbin/launchd", &["launchd"], 1),
+            snap_full(300, 1, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
+        ];
+        let victims = find_orphaned_mcp_stdio_to_kill(&snap, 999);
         assert_eq!(victims.len(), 1);
         assert_eq!(victims[0].pid, 300);
     }
 
     #[test]
-    fn sibling_kill_skips_newer_siblings() {
-        let snap = canonical_claude_desktop_tree();
-        // We are pid 300 (the older mcp-stdio). The newer one (500) must
-        // NOT show up — otherwise two simultaneously-started duplicates
-        // would tear each other down.
-        let victims = find_sibling_mcp_stdio_to_kill(&snap, 300, Some(100), 1100);
-        assert!(victims.is_empty(), "older must not target newer siblings");
+    fn orphan_reaped_when_parent_absent_from_snapshot() {
+        // Parent pid 250 is gone (not in the snapshot) → orphan.
+        let snap = vec![snap_full(300, 250, CURRENT, &[CURRENT, "--mcp-stdio"], 1100)];
+        let victims = find_orphaned_mcp_stdio_to_kill(&snap, 999);
+        assert_eq!(victims.len(), 1);
+        assert_eq!(victims[0].pid, 300);
     }
 
     #[test]
-    fn sibling_kill_ignores_other_mcp_client() {
-        // Two completely different MCP clients on the same Mac:
-        //   100 (Claude Desktop) → 200 (disclaimer) → 300 (aiui --mcp-stdio, older)
-        //   150 (Claude Code CLI) → 250 (bash)       → 350 (aiui --mcp-stdio, newer — us)
+    fn live_child_with_alive_parent_is_spared() {
+        // Wrapper 200 is alive → child 300 belongs to a live session.
         let snap = vec![
             snap_full(100, 1, "/Applications/Claude.app/Contents/MacOS/Claude", &["Claude"], 800),
             snap_full(200, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 1099),
             snap_full(300, 200, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
-            snap_full(150, 1, "/opt/homebrew/bin/claude", &["claude"], 1500),
-            snap_full(250, 150, "/bin/bash", &["bash", "-c", "..."], 1599),
-            snap_full(350, 250, CURRENT, &[CURRENT, "--mcp-stdio"], 1600),
         ];
-        // We are pid 350; grandparent is 150. Sibling 300's grandparent is
-        // 100 — different MCP client, must not be killed.
-        let victims = find_sibling_mcp_stdio_to_kill(&snap, 350, Some(150), 1600);
-        assert!(
-            victims.is_empty(),
-            "must not kill mcp-stdio of a different MCP client (different grandparent)"
-        );
+        let victims = find_orphaned_mcp_stdio_to_kill(&snap, 999);
+        assert!(victims.is_empty(), "live child with alive parent must be spared");
     }
 
     #[test]
-    fn sibling_kill_noop_when_own_grandparent_unknown() {
-        let snap = canonical_claude_desktop_tree();
-        // Caller couldn't resolve our grandparent — must be a no-op
-        // regardless of what siblings exist, so we don't broadly sweep.
-        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, None, 2100);
+    fn concurrent_cowork_sessions_all_spared() {
+        // THE Bug A regression test. Two concurrent Cowork sessions, each
+        // with its own live disclaimer wrapper, both under the one live
+        // Claude.app grandparent (100). The old "same grandparent" rule
+        // reaped one when the other started — orphan-status spares both.
+        let snap = vec![
+            snap_full(100, 1, "/Applications/Claude.app/Contents/MacOS/Claude", &["Claude"], 800),
+            snap_full(200, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 1099),
+            snap_full(300, 200, CURRENT, &[CURRENT, "--mcp-stdio"], 1100), // session A
+            snap_full(400, 100, "/Applications/Claude.app/Contents/Helpers/disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 2099),
+            snap_full(500, 400, CURRENT, &[CURRENT, "--mcp-stdio"], 2100), // session B (us)
+        ];
+        let victims = find_orphaned_mcp_stdio_to_kill(&snap, 500);
+        assert!(victims.is_empty(), "live parallel Cowork sessions must all be spared");
+    }
+
+    #[test]
+    fn own_pid_never_reaped_even_if_orphaned() {
+        let snap = vec![snap_full(300, 1, CURRENT, &[CURRENT, "--mcp-stdio"], 1100)];
+        let victims = find_orphaned_mcp_stdio_to_kill(&snap, 300);
+        assert!(victims.is_empty(), "own pid must never be reaped");
+    }
+
+    #[test]
+    fn non_aiui_orphan_and_non_mcp_aiui_ignored() {
+        let snap = vec![
+            // orphaned, but not aiui
+            snap_full(300, 1, "/usr/bin/python", &["python", "foo.py"], 1100),
+            // orphaned aiui, but GUI mode (no --mcp-stdio flag)
+            snap_full(310, 1, CURRENT, &[CURRENT, "--auto"], 1100),
+        ];
+        let victims = find_orphaned_mcp_stdio_to_kill(&snap, 999);
         assert!(victims.is_empty());
     }
 
     #[test]
-    fn sibling_kill_skips_own_pid_even_if_older() {
-        let snap = canonical_claude_desktop_tree();
-        // Caller passes our own pid as `own_pid` — we must never
-        // include ourselves even if start_time math says we're older
-        // than some hypothetical caller frame.
-        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, Some(100), 9999);
-        assert_eq!(victims.iter().filter(|v| v.pid == 500).count(), 0);
-    }
-
-    #[test]
-    fn sibling_kill_skips_unrelated_aiui_mcp_in_tree() {
-        // Two old aiui-mcp-stdio children, but only one is in our
-        // grandparent lineage. The other should not be touched.
-        let snap = vec![
-            snap_full(100, 1, "Claude", &["Claude"], 800),
-            snap_full(200, 100, "disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 1099),
-            snap_full(300, 200, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
-            // unrelated tree:
-            snap_full(700, 1, "OtherApp", &["OtherApp"], 800),
-            snap_full(750, 700, "wrapper", &["wrapper", CURRENT, "--mcp-stdio"], 1099),
-            snap_full(770, 750, CURRENT, &[CURRENT, "--mcp-stdio"], 1100),
-            // us:
-            snap_full(400, 100, "disclaimer", &["disclaimer", CURRENT, "--mcp-stdio"], 2099),
-            snap_full(500, 400, CURRENT, &[CURRENT, "--mcp-stdio"], 2100),
-        ];
-        let victims = find_sibling_mcp_stdio_to_kill(&snap, 500, Some(100), 2100);
-        assert_eq!(victims.len(), 1);
-        assert_eq!(victims[0].pid, 300);
+    fn is_orphaned_child_handles_none_ppid() {
+        let p = ProcSnap {
+            pid: 300,
+            ppid: None,
+            exe: CURRENT.to_string(),
+            args: vec![],
+            start_time: 1,
+        };
+        assert!(is_orphaned_child(&[], &p));
     }
 
     // ---------- find_pre_gui_mcp_stdio_to_kill ----------

--- a/companion/src-tauri/src/http.rs
+++ b/companion/src-tauri/src/http.rs
@@ -458,6 +458,57 @@ async fn update(
     }))
 }
 
+/// Field `kind`s the dialog frontend knows how to render. A spec
+/// carrying anything else would fall through to the "unknown_kind"
+/// placeholder in the WebView — exactly the kind of broken/empty
+/// surface we now refuse to show. Keep in sync with DialogShell /
+/// Form.svelte. (v0.4.46, Bug B+.)
+const KNOWN_FIELD_KINDS: &[&str] = &[
+    "text", "password", "secret", "number", "select", "checkbox", "slider",
+    "date", "datetime", "date_range", "color", "static_text", "markdown",
+    "image", "mermaid", "wireframe", "image_grid", "list", "table", "tree",
+];
+
+/// Validate a dialog spec *before* any window is created (v0.4.46,
+/// Bug B+). On failure returns `(detail, hint)` describing precisely
+/// what's wrong; the caller turns that into a structured `invalid_spec`
+/// response so the agent can fix the spec and retry — and the user never
+/// sees a broken or empty fallback window. Deliberately conservative:
+/// only rejects what the frontend genuinely cannot render (bad
+/// top-level kind, unknown field kind), never well-formed-but-unusual
+/// specs.
+fn validate_spec(spec: &serde_json::Value) -> Result<(), (String, String)> {
+    let kind = spec.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    if !matches!(kind, "ask" | "form" | "confirm") {
+        return Err((
+            format!("top-level 'kind' must be one of ask|form|confirm, got '{kind}'"),
+            "Use confirm for yes/no, ask for one-of-N, form for ≥2 inputs.".into(),
+        ));
+    }
+    let mut fields: Vec<&serde_json::Value> = Vec::new();
+    if let Some(tabs) = spec.get("tabs").and_then(|v| v.as_array()) {
+        for t in tabs {
+            if let Some(fs) = t.get("fields").and_then(|v| v.as_array()) {
+                fields.extend(fs.iter());
+            }
+        }
+    }
+    if let Some(fs) = spec.get("fields").and_then(|v| v.as_array()) {
+        fields.extend(fs.iter());
+    }
+    for f in fields {
+        let fk = f.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        if !KNOWN_FIELD_KINDS.contains(&fk) {
+            let name = f.get("name").and_then(|v| v.as_str()).unwrap_or("<unnamed>");
+            return Err((
+                format!("form field '{name}' has unknown kind '{fk}'"),
+                format!("Allowed field kinds: {}.", KNOWN_FIELD_KINDS.join(", ")),
+            ));
+        }
+    }
+    Ok(())
+}
+
 async fn render(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -483,6 +534,25 @@ async fn render(
     // agent's plain URL would silently render as a broken image.
     // See companion/src-tauri/src/imageresolve.rs for failure modes.
     crate::imageresolve::resolve_image_srcs(&mut req.spec).await;
+
+    // Spec validation (v0.4.46, Bug B+): reject anything the frontend
+    // can't render *before* creating a window, and tell the agent
+    // exactly what to fix. Without this, a bad `kind` opened a window
+    // showing the "unknown_kind" placeholder — a confusing surface the
+    // user had to dismiss. Now the agent gets `invalid_spec` + detail
+    // and can correct the call; nothing is shown to the user.
+    if let Err((detail, hint)) = validate_spec(&req.spec) {
+        trace(&format!("render: rejected — invalid_spec: {detail}"));
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "error": "invalid_spec",
+                "detail": detail,
+                "hint": hint,
+            })),
+        )
+            .into_response();
+    }
 
     // v0.4.36: try_register rejects when a dialog is already in flight
     // instead of evicting the existing one. Two parallel callers — multi-
@@ -708,6 +778,21 @@ async fn render(
         result.id, result.cancelled
     ));
 
+    // Authoritative teardown (v0.4.46, Bug B): the render has reached a
+    // terminal outcome — user submit/cancel, native X-close, TTL expiry,
+    // or channel-drop. Destroy the dialog window now, from Rust, on the
+    // main thread. This is the single point that guarantees a dialog
+    // window never outlives its dialog: it covers the TTL/channel-drop
+    // paths the frontend's own close never reaches (the empty-window
+    // stranding of 2026-05-29), and is a harmless no-op on the
+    // submit/cancel paths where the window is already gone.
+    {
+        let app_for_destroy = state.app.clone();
+        let _ = state
+            .app
+            .run_on_main_thread(move || crate::destroy_dialog_window(&app_for_destroy));
+    }
+
     // Lifecycle-driven update check (#42): fire once after every
     // successful render. Frontend gates with a 30-min cooldown so this is
     // never noisier than the old 6h timer in active use, and zero load
@@ -814,4 +899,61 @@ fn reload_main_webview(app: &AppHandle) {
             trace("render: reload requested but main window is MISSING");
         }
     });
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::validate_spec;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_confirm() {
+        assert!(validate_spec(&json!({"kind":"confirm","title":"ok?"})).is_ok());
+    }
+
+    #[test]
+    fn accepts_form_with_known_fields() {
+        let spec = json!({"kind":"form","fields":[
+            {"kind":"text","name":"a"},
+            {"kind":"secret","name":"tok"},
+            {"kind":"slider","name":"n"}
+        ]});
+        assert!(validate_spec(&spec).is_ok());
+    }
+
+    #[test]
+    fn accepts_form_with_tabs() {
+        let spec = json!({"kind":"form","tabs":[
+            {"label":"T","fields":[{"kind":"checkbox","name":"c"}]}
+        ]});
+        assert!(validate_spec(&spec).is_ok());
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_kind() {
+        let err = validate_spec(&json!({"kind":"wizard"})).unwrap_err();
+        assert!(err.0.contains("wizard"));
+        assert!(err.0.contains("ask|form|confirm"));
+    }
+
+    #[test]
+    fn rejects_missing_top_level_kind() {
+        assert!(validate_spec(&json!({"title":"x"})).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_field_kind_with_name() {
+        let spec = json!({"kind":"form","fields":[{"kind":"hologram","name":"h"}]});
+        let err = validate_spec(&spec).unwrap_err();
+        assert!(err.0.contains("'h'"), "detail names the field: {}", err.0);
+        assert!(err.0.contains("hologram"));
+    }
+
+    #[test]
+    fn rejects_unknown_field_kind_in_tab() {
+        let spec = json!({"kind":"form","tabs":[
+            {"label":"T","fields":[{"kind":"warp","name":"w"}]}
+        ]});
+        assert!(validate_spec(&spec).is_err());
+    }
 }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -116,6 +116,51 @@ async fn close_window(window: tauri::WebviewWindow) -> Result<(), String> {
     Ok(())
 }
 
+/// Authoritatively tear down the dialog window from the Rust side
+/// (v0.4.46, Bug B). Uses `destroy()` (immediate) rather than `close()`
+/// so it bypasses the `CloseRequested` → frontend round-trip that could
+/// strand an empty window when the WebView's handler failed to complete
+/// the close. This is the single teardown point for the dialog window:
+/// the `/render` handler calls it once a render reaches *any* terminal
+/// outcome (submit, cancel, X-close, TTL, channel-drop), so the window
+/// can never outlive the dialog it was showing. Idempotent — a no-op
+/// when the window is already gone.
+pub(crate) fn destroy_dialog_window(app: &tauri::AppHandle) {
+    if let Some(win) = app.get_webview_window(DIALOG_WINDOW_LABEL) {
+        let _ = win.destroy();
+    }
+    // Matching demote for `ensure_dialog_window`'s Regular-mode promote:
+    // drop back to Accessory once the dialog is gone, unless the setup
+    // window is still up.
+    #[cfg(target_os = "macos")]
+    {
+        let setup_open = app
+            .get_webview_window(SETUP_WINDOW_LABEL)
+            .and_then(|w| w.is_visible().ok())
+            .unwrap_or(false);
+        if !setup_open {
+            let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+        }
+    }
+}
+
+/// Belt-and-suspenders invariant (v0.4.46, Bug B+): a dialog window may
+/// only exist while a dialog is pending in the registry. If a window is
+/// found with an empty registry, it's a stranded empty window — destroy
+/// it. Cheap (one mutex read + a window lookup); called on app
+/// re-activation, exactly when a user would otherwise notice a leftover
+/// empty frame.
+pub(crate) fn sweep_orphan_dialog_window(app: &tauri::AppHandle) {
+    let pending = app
+        .try_state::<Arc<dialog::DialogState>>()
+        .map(|s| s.stats().orphan_count)
+        .unwrap_or(0);
+    if pending == 0 && app.get_webview_window(DIALOG_WINDOW_LABEL).is_some() {
+        log::debug!("[aiui] sweep: destroying orphan dialog window (no pending dialog)");
+        destroy_dialog_window(app);
+    }
+}
+
 /// Frontend silent-update gate (v0.4.43): returns `true` iff installing
 /// + relaunching right now would NOT disrupt anything the user is
 /// currently looking at. The silent updater path in `updater.ts` calls
@@ -1009,20 +1054,18 @@ pub fn run_mcp_stdio_only() {
         std::process::exit(0);
     }
 
-    // Multi-instance protection (v0.4.42): kill any older
-    // `aiui --mcp-stdio` siblings spawned by the same MCP client. Claude
-    // Desktop has been observed (2026-05-16) to occasionally spawn a
-    // fresh child without killing the previous one — when both attach
-    // to the lifetime socket and both register their prompt list,
-    // Claude Desktop's slash-command routing can't decide which child
-    // owns `prompts/get` and the slash-command fails with "kein
-    // erkannter Befehl". The newer child (us) wins; the older one
-    // gets SIGTERM, along with its disclaimer wrapper, so Claude
-    // Desktop can't immediately respawn the same race. Safe no-op if
-    // we can't resolve our own grandparent (terminal-launched
-    // mcp-stdio, orphaned process). Existing single-child setups are
-    // untouched: nothing to kill, function returns 0.
-    let _ = housekeeping::kill_sibling_mcp_stdio_with_same_grandparent();
+    // Leak cleanup (v0.4.42, rescoped v0.4.46 / Bug A): reap any
+    // *orphaned* `aiui --mcp-stdio` children — ones whose MCP-client
+    // parent (Claude.app / Cowork wrapper) has died, leaving them
+    // reparented to launchd. The earlier version reaped any older
+    // mcp-stdio sharing our Claude.app *grandparent*; that tore down
+    // live *parallel Cowork sessions* (they all share the one Claude.app
+    // grandparent) — the "Server disconnected on first MCP call" reports.
+    // Orphan-status is the right discriminator: a leak has lost its
+    // parent, a live session has not. The duplicate-child glitch the old
+    // rule targeted is already handled by stdin-EOF. Safe no-op when no
+    // orphans exist; never touches live siblings.
+    let _ = housekeeping::kill_orphaned_mcp_stdio_children();
 
     let cfg = Arc::new(config::AppConfig::load_or_init().expect("config init"));
     logging::trace(&format!(
@@ -1542,6 +1585,24 @@ pub fn run() {
                 let app = window.app_handle();
                 let closed_label = window.label().to_string();
                 if closed_label == DIALOG_WINDOW_LABEL {
+                    // User closed the dialog window with the native X (or
+                    // ⌘W). Resolve any in-flight `/render` as cancelled
+                    // right here in Rust — we no longer depend on a
+                    // frontend CloseRequested handler, which in 0.4.45
+                    // could `preventDefault()` and then fail to complete
+                    // the close, stranding an empty, unclosable window
+                    // (Bug B, the 2026-05-29 overnight report). We do NOT
+                    // prevent the close: the window is allowed to go away.
+                    // The awaiting `/render` will run its end-of-handler
+                    // `destroy_dialog_window` (a no-op by then).
+                    if let Some(ds) = app.try_state::<Arc<dialog::DialogState>>() {
+                        let n = ds.cancel_all("window_closed");
+                        if n > 0 {
+                            log::debug!(
+                                "[aiui] dialog window X-closed — cancelled {n} pending dialog(s)"
+                            );
+                        }
+                    }
                     log::debug!(
                         "[aiui] dialog window closed — staying alive for further tool calls"
                     );
@@ -1653,6 +1714,12 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             {
                 if let tauri::RunEvent::Reopen { .. } = event {
+                    // Self-heal: if a stranded empty dialog window is
+                    // still up with no pending dialog, sweep it before
+                    // surfacing settings — this is exactly when the user
+                    // would otherwise be greeted by a leftover empty
+                    // frame (v0.4.46, Bug B+).
+                    sweep_orphan_dialog_window(app);
                     show_settings_window(app);
                 }
             }

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -150,6 +150,13 @@ pub(crate) fn destroy_dialog_window(app: &tauri::AppHandle) {
 /// it. Cheap (one mutex read + a window lookup); called on app
 /// re-activation, exactly when a user would otherwise notice a leftover
 /// empty frame.
+///
+/// Currently wired only to macOS `RunEvent::Reopen`; other platforms
+/// have no trigger yet (Windows surfaces the existing window via the
+/// single-instance plugin), so allow it to be unused there instead of
+/// `#[cfg]`-gating the whole fn — keeps it ready for a future Windows
+/// hook without tripping CI's `-D warnings` dead-code check.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn sweep_orphan_dialog_window(app: &tauri::AppHandle) {
     let pending = app
         .try_state::<Arc<dialog::DialogState>>()

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -686,6 +686,25 @@ async fn render_dialog(
                 .unwrap_or(0),
         });
     }
+    if resp.status() == reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+        // Invalid spec — http::render rejected it *before* showing any
+        // window (v0.4.46, Bug B+). Body shape: { error, detail, hint }.
+        // Surface detail+hint as the tool error so the agent understands
+        // exactly what's malformed and can fix the spec and retry — no
+        // confusing fallback window, no terse status code.
+        let body = resp.json::<Value>().await.unwrap_or(Value::Null);
+        let detail = body
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .unwrap_or("invalid dialog spec");
+        let hint = body.get("hint").and_then(|v| v.as_str()).unwrap_or("");
+        let msg = if hint.is_empty() {
+            format!("aiui rejected the dialog spec (invalid_spec): {detail}")
+        } else {
+            format!("aiui rejected the dialog spec (invalid_spec): {detail} — {hint}")
+        };
+        return Err(RenderError::Transport(msg));
+    }
     if !resp.status().is_success() {
         return Err(RenderError::Transport(format!(
             "render http {}",

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/companion/src/lib/DialogShell.svelte
+++ b/companion/src/lib/DialogShell.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { listen } from "@tauri-apps/api/event";
   import { invoke } from "@tauri-apps/api/core";
-  import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
   import { _ } from "svelte-i18n";
   import { onMount } from "svelte";
   import Ask from "./widgets/Ask.svelte";
@@ -160,27 +159,15 @@
 
     window.addEventListener("keydown", onKey);
 
-    // Window-close → cancel (v0.4.45, Bug #1). When the user closes the
-    // dialog window with the native red X (or Cmd-W), Tauri fires
-    // CloseRequested. Without handling it here, the Rust side's
-    // on_window_event returned without emitting `dialog_cancel`, so the
-    // pending `/render` call hung until DIALOG_TTL (2 h since 0.4.41) —
-    // the agent never learned the user dismissed the dialog. We now
-    // treat an X-close exactly like clicking Cancel: emit `dialog_cancel`
-    // for the in-flight dialog, then let the window close. The recursive
-    // `close_window` invoke inside handleCancel re-fires CloseRequested,
-    // but by then `current` is null so the guard below is a no-op and
-    // the close proceeds.
-    const win = getCurrentWebviewWindow();
-    const closeReqPromise = win.onCloseRequested(async (event) => {
-      if (current) {
-        // Stop the immediate destroy so the cancel reaches the backend
-        // before the window (and its WebView) goes away.
-        event.preventDefault();
-        await handleCancel();
-      }
-      // else: no live dialog — let Tauri close the window normally.
-    });
+    // Window-close (native red X / ⌘W) is owned by Rust as of v0.4.46
+    // (on_window_event): it cancels any in-flight dialog and lets the
+    // window close, and the `/render` handler destroys the window on
+    // every terminal outcome. We deliberately no longer register a
+    // frontend `onCloseRequested` here. The 0.4.45 version called
+    // `event.preventDefault()` and then, if its cancel/close path failed
+    // (empty/stale dialog state), left the window stranded — visible,
+    // empty, and unclosable (Bug B, the 2026-05-29 overnight report).
+    // Letting Rust own teardown removes that fragile round-trip.
 
     // Window-ready handshake (v0.4.30): tell the Rust render path
     // that our `dialog:show` listener is installed and we can safely
@@ -198,7 +185,6 @@
       clearTtlTimers();
       (await dialogPromise)();
       (await pingPromise)();
-      (await closeReqPromise)();
       window.removeEventListener("keydown", onKey);
     };
   });

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.4.45"
+version = "0.4.46"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Dialog-lifecycle hardening. Two field-reported regressions from the recent lifecycle work, both root-caused from a Cowork session's MCP log + aiui trace, plus a defensive pass so a malformed or stranded dialog can never leave the user staring at a dead window.

- **Bug A — new Cowork session disconnected aiui in the other sessions.** `kill_sibling_mcp_stdio_with_same_grandparent` (0.4.42) reaped any older `aiui --mcp-stdio` sharing the Claude.app *grandparent* — but all concurrent Cowork sessions share that one grandparent, so opening a new session SIGTERM'd the still-live aiui child of every other session ("MCP aiui: Server disconnected" on the first MCP call; trace: `killing older sibling pid=30384 (same grandparent=26243)`). Now `kill_orphaned_mcp_stdio_children` reaps only **orphaned** children (parent wrapper dead → `ppid==1`/absent). Live parallel sessions are spared; the original duplicate-child glitch is already covered by stdin-EOF.
- **Bug B — empty, unclosable dialog window.** The 0.4.45 X-close fix routed teardown through a frontend `onCloseRequested` that `preventDefault()`'d then ran the close itself; when that path failed (empty/stale state) the window sat empty and the red X did nothing (overnight report: blank window, 9 ignored X-clicks in the GUI log). Teardown is now **authoritative in Rust** — `/render` destroys the dialog window (`window.destroy()`, bypassing the CloseRequested→frontend round-trip) on *every* terminal outcome (submit/cancel/X/TTL/channel-drop), and `on_window_event` cancels the in-flight render directly on X. The fragile frontend `onCloseRequested` is removed.
- **Bug B+ — defensive render flow.** `validate_spec` rejects bad top-level/field kinds *before* opening a window and returns `invalid_spec` + detail/hint (surfaced by mcp-stdio as a clear tool error, no more "unknown_kind" placeholder window). `sweep_orphan_dialog_window` on `Reopen` self-heals a stranded empty frame. Every `/render` still resolves to exactly one terminal outcome.

## Test plan

- [x] `cargo test --lib` — 98/98 (new: orphan-reap matrix incl. concurrent-Cowork-sessions regression, `cancel_all`, `validate_spec`)
- [x] `cargo clippy --lib --all-targets` — clean
- [x] `svelte-check` — 0 errors
- [x] `npm run build` — ok
- [ ] Manual verify on reporter's Cowork setup after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)