### PR TITLE
fix(windows): drop hardcoded `lsof` from backend http-bind-failure text

### DIFF
--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -1376,10 +1376,16 @@ pub fn run() {
                         "[aiui] http-bind-error on :{port_for_error}: {e} — degraded mode, surfacing settings banner"
                     ));
                     if let Ok(mut slot) = http_error_for_serve.lock() {
+                        // The OS-specific diagnostic command (`lsof`,
+                        // `Get-NetTCPConnection`, `ss`) lives in the
+                        // frontend's `settings.http_error.hint.{os}`
+                        // i18n string, rendered just below this text.
+                        // Keep the backend message platform-neutral so
+                        // Windows users don't see a confusing `lsof`
+                        // suggestion above the correct PowerShell one.
                         *slot = Some(format!(
                             "Konnte localhost:{port_for_error} nicht öffnen — \
-                             Port von einem anderen Prozess belegt. Schließe den \
-                             Prozess (lsof -i :{port_for_error}) und starte aiui neu. {e}"
+                             Port von einem anderen Prozess belegt. {e}"
                         ));
                     }
                     // Surface the Settings window so the http_error banner


### PR DESCRIPTION
## Summary

When the HTTP server fails to bind, `lib.rs::spawn_http_server` writes a plaintext error into `status.http_error` that the frontend renders verbatim — directly above the OS-specific `settings.http_error.hint.{os}` line. The plaintext included `lsof -i :{port}`. On Windows, the tester would see two contradictory suggestions stacked: Mac `lsof` from the backend, then the correct PowerShell `Get-NetTCPConnection` from the i18n hint.

Backend message is now platform-neutral; the OS-correct command stays in the frontend hint where it already lives.

## Why now

Audit of the v0.4.40 → v0.4.46 delta before handing the next NSIS build to the Windows tester. This is the only Windows-affecting regression I found in that range — `set_activation_policy(Accessory)`, `RunEvent::Reopen`, and the new `fs4` advisory-lock crate are all platform-clean.

## Test plan

- [x] cargo check / clippy `-D warnings` / test --lib (98/98) — clean on macOS arm64
- [ ] CI green on macOS arm64 + Windows x86_64
- [ ] Mac: no visible change in normal operation; bind-failure banner still shows port + underlying error
- [ ] Windows tester: bind-failure banner no longer mentions `lsof` above the PowerShell hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)