### PR TITLE
fix(windows): restart_claude_desktop — remove duplicate pre-lookup taskkill

### DIFF
--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -507,13 +507,6 @@ async fn restart_claude_desktop() -> Result<setup::StepResult, String> {
         use std::path::PathBuf;
         use std::process::Command;
 
-        // Best-effort graceful close (no `/F`). If Claude is already gone
-        // taskkill returns exit code 128 — we don't surface that.
-        let _ = no_window(
-            Command::new("taskkill").args(["/IM", "Claude.exe"]),
-        )
-        .output();
-
         // Capture the path of the running Claude.exe *before* we tell it
         // to quit — that's the most reliable way to find the right binary
         // (covers MSIX/Store installs, custom install dirs, renames),
@@ -525,6 +518,14 @@ async fn restart_claude_desktop() -> Result<setup::StepResult, String> {
         // existing candidate path, which silently picks the older binary
         // when both NSIS and MSIX installs coexist (mid-upgrade), and
         // misses Store-installed Claudes entirely.
+        //
+        // History: an earlier taskkill block was duplicated *above* the
+        // sysinfo lookup at some point between v0.4.40 and v0.4.46, which
+        // defeated the whole point — by the time sysinfo ran, Claude was
+        // already gone and the fallback paths ended up being the only
+        // resolution. Codex spotted the regression in the v0.4.40→main
+        // audit. The single, post-capture taskkill below is the
+        // intended order.
         let running_exe: Option<PathBuf> = {
             use sysinfo::{ProcessRefreshKind, RefreshKind, System};
             let sys = System::new_with_specifics(


### PR DESCRIPTION
## Summary

Codex audit of v0.4.40 → v0.4.46 flagged a regression in `restart_claude_desktop`: a duplicate `taskkill /IM Claude.exe` was added *above* the sysinfo-based path lookup at some point between v0.4.40 and v0.4.46. That kills Claude before sysinfo can read its executable path, so the lookup returns `None` and resolution silently falls back to the hardcoded `%LOCALAPPDATA%` candidates — defeating exactly the MSIX / Store / custom-install coverage we added in PR #128.

Removed the duplicate; the single post-lookup taskkill (with its "after capture" ordering comment) remains. New top-of-block comment records the regression so the duplicate can't slip back in.

## Why now

Tester is waiting on a fresh NSIS. Without this fix, every Restart-Claude-Desktop click on a Store-installed Claude (or any custom path) falls back to "Claude Desktop nicht gefunden" — even though sysinfo *would* have seen the right path if the order were preserved.

## Test plan

- [x] cargo check / clippy `-D warnings` / test --lib (98/98) — clean on macOS arm64
- [ ] CI green on macOS arm64 + Windows x86_64
- [ ] Windows tester: Restart-Claude-Desktop button now actually relaunches the Claude install they have, regardless of NSIS / Store / custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)