### PR TITLE
release: v0.8.3 — MCP 2026-07-28 forward-compat guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,11 @@ jobs:
           # initialize handshake — timeout after 2s
           (printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}}'; sleep 1) \
             | timeout 5 aiui-mcp | head -2
+          # MCP 2026-07-28 stdio backward-compat probe: modern clients send
+          # server/discover FIRST and fall back to initialize on any
+          # non-modern JSON-RPC error. The wheel must answer that probe
+          # deterministically with an error response (FastMCP: -32602) —
+          # silence or a hang would make modern clients treat aiui as dead
+          # instead of falling back to the legacy handshake.
+          (printf '%s\n' '{"jsonrpc":"2.0","id":9,"method":"server/discover","params":{}}'; sleep 1) \
+            | timeout 5 aiui-mcp | grep -q '"error"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this project are documented here.
 
+## [0.8.3] — 2026-07-29
+
+### Added
+
+- **Forward-compat guard for the MCP 2026-07-28 spec.** The new stateless
+  spec retires the `initialize` handshake; modern clients probe a stdio
+  server with `server/discover` first and fall back to `initialize` on
+  any non-modern JSON-RPC error. Both aiui servers already answer that
+  probe correctly (Rust: `-32601`, Python/FastMCP: `-32602`) — but
+  nothing pinned the behavior down. Now covered by unit tests on the
+  Rust dispatcher (probe → `-32601`; `initialize` → protocol version
+  `2025-06-18` + non-empty `instructions`) and a CI smoke assertion
+  against the built Python wheel, so a refactor can't silently break
+  the fallback signal modern clients rely on.
+
+### Changed
+
+- **Python `mcp` dependency capped at `<2`.** The MCP spec release
+  2026-07-28 makes the protocol stateless and comes with substantially
+  reworked SDKs ("SDK v2" / client-server split). Remote hosts install
+  `aiui-mcp` via `uvx aiui-mcp==<version>`, which re-resolves the open
+  `mcp>=1.26.0` dependency on every cold start — so a breaking 2.x SDK
+  release would have taken down every remote session without any change
+  on our side. The pin (`mcp>=1.26.0,<2`) freezes the remote path on the
+  1.x line until aiui migrates to the new spec deliberately.
+
+### Fixed
+
+- **Removing an unreachable remote reported red failures instead of
+  succeeding.** Deleting a host (or running a full uninstall) fires three
+  ssh-based cleanup steps — remote token, `~/.claude.json` entry, remote
+  skill. When the host is unreachable — which is often *exactly why* it's
+  being removed, e.g. its key no longer authenticates — each of those
+  steps failed with `Permission denied (publickey)` and surfaced as a red
+  error line, even though the local deregistration (ssh forward +
+  `remotes.json`) had already succeeded and the remote files are
+  untouchable anyway. Removal now probes reachability once
+  (`host_reachable`, a `BatchMode` ssh that treats exit 255 as
+  unreachable) and, for a dead host, emits a single calm "lokal
+  deregistriert, Remote-Cleanup übersprungen" line naming what was left
+  behind — instead of three failures for files aiui can't reach. Also
+  fixed a latent dishonesty in the skill-removal step, which used to
+  report green regardless of the ssh exit status; gated behind the same
+  probe, it now reports a real failure only when a *reachable* host's
+  removal genuinely fails.
+- **Contact address corrected in package metadata and SECURITY.md.**
+  Both carried a non-existent alias as author/security contact; they now
+  point to the real byte5 address. Wheels published before 0.8.3 keep
+  the old author field — PyPI metadata is immutable per release.
+
 ## [0.8.2] — 2026-06-08
 
 Targeted Cowork cold-start fix. (CHANGELOG entries for v0.5.0 – v0.8.1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Settings).
 
 **Please do not open a public issue for security vulnerabilities.**
 
-Email the details to <cw@byte5.de> with a clear subject line
+Email the details to <cwendler@byte5.de> with a clear subject line
 (`[aiui] security report — <brief summary>`) and include:
 
 - What the vulnerability is and where in the code it lives

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.8.2"
+version = "0.8.3"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/src/lib.rs
+++ b/companion/src-tauri/src/lib.rs
@@ -910,12 +910,19 @@ async fn remove_remote(
     // Stop the tunnel first so the forward port is freed before we touch
     // ssh config and remote token.
     tm.stop(&host_alias).await;
-    let results = vec![
-        setup::remove_ssh_forward(&host_alias, cfg.http_port),
-        setup::remove_token_from_remote(&host_alias),
-        setup::remove_claude_code_config_remote(&host_alias),
-        skill::remove_from_remote(&host_alias),
-    ];
+    // ssh-forward removal is local, so it always runs. The remaining three
+    // steps reach into the host over ssh; if the host is unreachable — which
+    // is often exactly why it's being removed — probe once and emit a single
+    // calm "skipped" line instead of three red failures. Local dereg below
+    // runs regardless, so the host still disappears from the list. See #142-ff.
+    let mut results = vec![setup::remove_ssh_forward(&host_alias, cfg.http_port)];
+    if setup::host_reachable(&host_alias) {
+        results.push(setup::remove_token_from_remote(&host_alias));
+        results.push(setup::remove_claude_code_config_remote(&host_alias));
+        results.push(skill::remove_from_remote(&host_alias));
+    } else {
+        results.push(setup::remote_cleanup_skipped(&host_alias));
+    }
     let list: Vec<String> = setup::load_remotes()
         .into_iter()
         .filter(|h| h != &host_alias)
@@ -953,9 +960,15 @@ async fn uninstall_all(
     results.push(setup::remove_claude_code_config());
     for host in setup::load_remotes() {
         results.push(setup::remove_ssh_forward(&host, cfg.http_port));
-        results.push(setup::remove_token_from_remote(&host));
-        results.push(setup::remove_claude_code_config_remote(&host));
-        results.push(skill::remove_from_remote(&host));
+        // Same reachability gate as remove_remote: unreachable hosts get one
+        // "skipped" line rather than three failures during a full uninstall.
+        if setup::host_reachable(&host) {
+            results.push(setup::remove_token_from_remote(&host));
+            results.push(setup::remove_claude_code_config_remote(&host));
+            results.push(skill::remove_from_remote(&host));
+        } else {
+            results.push(setup::remote_cleanup_skipped(&host));
+        }
     }
     results.push(skill::remove_locally());
     let _ = std::fs::remove_file(&cfg.token_path);

--- a/companion/src-tauri/src/mcp.rs
+++ b/companion/src-tauri/src/mcp.rs
@@ -220,6 +220,7 @@ pub async fn run_stdio(cfg: Arc<AppConfig>) {
     let _ = writer_task.await;
 }
 
+#[derive(Debug)]
 struct RpcError {
     code: i64,
     message: String,
@@ -1129,4 +1130,62 @@ fn prompts_get(params: Value) -> Result<Value, RpcError> {
             "content": { "type": "text", "text": text }
         }]
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_cfg() -> Arc<AppConfig> {
+        Arc::new(AppConfig {
+            token: "test-token".into(),
+            config_dir: PathBuf::from("/nonexistent"),
+            token_path: PathBuf::from("/nonexistent/token"),
+            http_port: 0,
+        })
+    }
+
+    /// MCP 2026-07-28 clients probe a stdio server with `server/discover`
+    /// before anything else and fall back to the legacy `initialize`
+    /// handshake on any error that is not a recognized modern error
+    /// (spec: basic/versioning, "Backward Compatibility"). Our
+    /// `-32601 method not found` IS that fallback signal — if a dispatcher
+    /// refactor ever answers `server/discover` differently (or swallows
+    /// unknown methods), modern clients lose the probe response and treat
+    /// aiui as broken instead of falling back.
+    #[tokio::test]
+    async fn server_discover_probe_gets_method_not_found() {
+        let (tx, _rx) = mpsc::channel(1);
+        let err = dispatch(
+            "server/discover",
+            json!({}),
+            &test_cfg(),
+            &reqwest::Client::new(),
+            &tx,
+        )
+        .await
+        .expect_err("server/discover must be rejected, not answered");
+        assert_eq!(err.code, -32601);
+    }
+
+    /// The legacy handshake aiui speaks until the 2026-07-28 migration:
+    /// protocol version pinned to 2025-06-18, and `instructions` present —
+    /// the one hook that breaks the model's chat-first default. Losing
+    /// either silently degrades every session.
+    #[tokio::test]
+    async fn initialize_advertises_legacy_protocol_and_instructions() {
+        let (tx, _rx) = mpsc::channel(1);
+        let res = dispatch(
+            "initialize",
+            json!({}),
+            &test_cfg(),
+            &reqwest::Client::new(),
+            &tx,
+        )
+        .await
+        .expect("initialize must succeed");
+        assert_eq!(res["protocolVersion"], "2025-06-18");
+        assert!(!res["instructions"].as_str().unwrap_or("").is_empty());
+    }
 }

--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -1197,6 +1197,54 @@ else:
     })
 }
 
+/// Cheap liveness probe run before remote cleanup in the removal/uninstall
+/// paths: a single `BatchMode` ssh that runs `true`. ssh exits 255 when it
+/// cannot establish or authenticate the connection — an unreachable host, a
+/// refused connection, or (the case that motivated this: the user removes a
+/// host precisely *because* its key no longer works) "Permission denied".
+/// Any exit code the remote command itself produced (0..=254) means we got
+/// in, so the host counts as reachable. A spawn failure or a signal-killed
+/// ssh (no exit code) is treated as unreachable — better to skip remote
+/// cleanup than to spew errors we can do nothing about. `ConnectTimeout`
+/// keeps a dead host from hanging the probe on the default TCP timeout.
+pub fn host_reachable(host_alias: &str) -> bool {
+    if !is_valid_host_alias(host_alias) {
+        return false;
+    }
+    no_window(Command::new("ssh").args([
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=6",
+        "--",
+        host_alias,
+        "true",
+    ]))
+    .output()
+    .map(|o| matches!(o.status.code(), Some(c) if c != 255))
+    .unwrap_or(false)
+}
+
+/// Informational step emitted in place of the three remote-cleanup steps when
+/// a host is unreachable (see [`host_reachable`]). The user's action — remove
+/// this host — has still succeeded locally (ssh forward + `remotes.json`),
+/// which is all that is meaningful for a host aiui can no longer reach. We
+/// say plainly what was left behind instead of reporting red "failed" lines
+/// for remote files we have no way to touch.
+pub fn remote_cleanup_skipped(host_alias: &str) -> StepResult {
+    StepResult {
+        ok: true,
+        message: format!(
+            "Host {host_alias} nicht erreichbar — lokal deregistriert, Remote-Cleanup übersprungen."
+        ),
+        details: Some(
+            "Token, ~/.claude.json-Eintrag und Skill verbleiben auf dem Host (harmlos). \
+             Sobald der Host wieder erreichbar ist, kann er dort manuell entfernt werden."
+                .into(),
+        ),
+    }
+}
+
 pub fn remove_token_from_remote(host_alias: &str) -> StepResult {
     if !is_valid_host_alias(host_alias) {
         return StepResult {
@@ -1262,6 +1310,18 @@ mod tests {
     #[test]
     fn classify_none() {
         assert!(classify_aiui_entry(None).is_none());
+    }
+
+    #[test]
+    fn remote_cleanup_skipped_is_a_non_error() {
+        // Removing an unreachable host is a success (deregistered locally),
+        // not a failure — it must not render as a red log line, and it must
+        // name the host and say what was left behind.
+        let r = remote_cleanup_skipped("dev@devhost");
+        assert!(r.ok);
+        assert!(r.message.contains("dev@devhost"));
+        assert!(r.message.contains("nicht erreichbar"));
+        assert!(r.details.is_some());
     }
 
     #[test]

--- a/companion/src-tauri/src/skill.rs
+++ b/companion/src-tauri/src/skill.rs
@@ -163,6 +163,15 @@ pub fn remove_from_remote(host_alias: &str) -> StepResult {
             message: format!("ssh {host_alias} failed"),
             details: Some(e.to_string()),
         },
+        // Report the ssh exit status honestly: callers gate this behind a
+        // reachability probe, so a non-success here means the host answered
+        // but the removal itself failed — that deserves a red line, not the
+        // unconditional green this used to return.
+        Ok(o) if !o.status.success() => StepResult {
+            ok: false,
+            message: format!("Skill-Entfernung auf {host_alias} fehlgeschlagen"),
+            details: Some(String::from_utf8_lossy(&o.stderr).to_string()),
+        },
         Ok(_) => StepResult {
             ok: true,
             message: format!("Skill auf {host_alias} entfernt."),

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "aiui-mcp"
-version = "0.8.2"
+version = "0.8.3"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [
-    { name = "byte5 GmbH", email = "cw@byte5.de" },
+    { name = "byte5 GmbH", email = "cwendler@byte5.de" },
 ]
 keywords = ["mcp", "claude", "ui", "dialog", "macos", "tauri"]
 classifiers = [
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: User Interfaces",
 ]
 dependencies = [
-    "mcp>=1.26.0",
+    "mcp>=1.26.0,<2",
     "httpx>=0.27",
 ]
 


### PR DESCRIPTION
## Summary

Prepares aiui for the MCP 2026-07-28 spec rollout without changing runtime behavior, and bundles the pending unreachable-remote fix.

- **Forward-compat guard:** Modern (2026-07-28) clients probe stdio servers with `server/discover` and fall back to `initialize` on any non-modern JSON-RPC error. New Rust unit tests pin the dispatcher contract (`server/discover` → `-32601`; `initialize` → `2025-06-18` + non-empty `instructions`), and the CI wheel smoke test now asserts the Python server answers the probe with a deterministic error (FastMCP: `-32602`, verified live).
- **`mcp>=1.26.0,<2` pin:** remote hosts re-resolve deps via `uvx` on every cold start; a breaking 2.x SDK release must not take down remote sessions.
- **fix(remotes):** removing an unreachable host no longer reports red failures for cleanup steps that cannot run.
- **Contact fix:** author/security contact corrected in package metadata and SECURITY.md.
- Version bump 0.8.2 → 0.8.3 (Cargo.toml, tauri.conf.json, pyproject.toml, Cargo.lock).

## Test notes

Rust tests could not be executed locally (Linux devhost lacks GTK; aiui targets macOS) — macOS CI validates them in this PR. The Python probe behavior was verified locally against the real package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787906545&installation_model_id=428086&pr_number=143&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F143&signature=3000044949c956aa3d65dc6bc0590091a6d97c31eeff7fbd50a89f3d5bf34187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->