### PR TITLE
docs(agents): add basic-memory recall pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 These rules apply to all AI agents working on this repository (Claude, Codex, Copilot, etc.).
 
+## Memory
+
+Durable memory lives in the `basic-memory` MCP server — call `recall` before acting, `write_note` to save.
+
 ## Git Workflow
 - **Never push directly to `main`.** All changes go through feature branches and pull requests.
 - **Branch naming:** `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`, `test/`, `release/`, `dev/` prefixes.


### PR DESCRIPTION
## Was
Ergänzt die eine kanonische durable-memory-Zeile als `## Memory`-Abschnitt in `AGENTS.md`.

## Warum
Codex & andere Harnesses haben keine User-Ebene — `AGENTS.md` ist ihre einzige Tür zu `recall`/`write_note`. Ohne den Zeiger behaupten Sessions, sie hätten keinen Zugriff auf private Repos, und suchen nach PATs, statt `recall`/`gho` zu nutzen.

Teil des projektübergreifenden Memory-/Auth-Rollouts: jede `AGENTS.md` trägt die eine Zeile, wörtlich. Kein Notiz-Titel/Permalink (die sind im Vault volatil) — der Einstieg ist die Situation, nach der man `recall`t.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789392133&installation_model_id=428086&pr_number=157&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F157&signature=fba026ffed171f37f4413712f9a81441eca3d41288f7cca193204d1243a00cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->