### PR TITLE
docs: Codex / ChatGPT als unterstützten aiui-Host dokumentieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,48 @@ settings.
 | `/aiui:update` | Agent calls the `update` tool; aiui checks the release feed, silently installs any available update, and reports the version delta back. Responds before the background relaunch, so the agent always gets the answer. |
 | `/aiui:version` | Reports the currently installed aiui version in one line. |
 
+## Using aiui with Codex / ChatGPT
+
+aiui isn't Claude-specific. The companion speaks the [Model Context
+Protocol](https://modelcontextprotocol.io) over `127.0.0.1:7777`, so any
+MCP-capable client can render the same native dialogs. OpenAI's **Codex**
+(the ChatGPT coding agent) is supported today — it discovers and drives
+aiui's `confirm` / `ask` / `form` tools with no Claude-specific glue.
+
+Two things differ from the Claude Desktop path:
+
+- **No auto-registration.** The companion auto-installs itself only for
+  Claude Desktop. For Codex you register the MCP server once, by hand.
+- **The companion must be running.** Dialogs are rendered by `aiui.app`,
+  so keep it open (launch it from Finder). The Codex-side server only
+  forwards specs to it over `127.0.0.1:7777`.
+
+### Setup
+
+1. Install and launch `aiui.app` once (see [Install](#install)) so it's
+   listening on `127.0.0.1:7777` and the pairing token exists at
+   `~/.config/aiui/token`.
+2. Add the server to Codex's `~/.codex/config.toml`:
+
+   ```toml
+   [mcp_servers.aiui]
+   command = "uvx"
+   args = ["aiui-mcp"]
+   ```
+
+   That's the whole config on the Mac that runs the companion — `aiui-mcp`
+   finds the token and the `127.0.0.1:7777` endpoint on its own. This path
+   needs `uv`/`uvx` on that machine (unlike the drag-and-drop Claude
+   Desktop install, which ships the server natively).
+3. Start Codex and ask it to confirm something with aiui — the native
+   dialog opens on your Mac.
+
+Running Codex on a **remote SSH host**? Same reverse-tunnel story as Claude
+Code: register the host in aiui's settings (it scp's the token and forwards
+`127.0.0.1:7777` to that host), then the same `config.toml` block on the
+remote picks it up. Point `AIUI_ENDPOINT` at a different address only if you
+tunnel to a non-default one.
+
 ## FAQ
 
 **Is it safe?** aiui is open source (MIT), builds reproducibly, is Apple
@@ -156,20 +198,23 @@ the Rust core and CI build already target Windows; interactive E2E testing
 and a first release are still outstanding. Follow
 [#118](https://github.com/byte5ai/aiui/pull/118) for status.
 
-**Can I use aiui without Claude Desktop?** The companion is
-auto-spawned by Claude Desktop via its MCP registration, so in the
-default setup, no. You can launch `aiui.app` manually though — as long
-as `localhost:7777` is reachable, any MCP client can render dialogs.
+**Can I use aiui without Claude Desktop?** Yes. Launch `aiui.app`
+manually and point any MCP client at `127.0.0.1:7777` — see
+[Using aiui with Codex / ChatGPT](#using-aiui-with-codex--chatgpt) for a
+worked example. In the default Claude Desktop setup the companion is
+auto-spawned for you, so there you don't have to.
 
 **Why not just use Claude Desktop's built-in AskUserQuestion?** It's
 great for single yes/no or single-choice questions, but doesn't cover
 multi-field forms, sortable lists, colour pickers, date ranges, or
 hierarchical pickers. aiui complements it.
 
-**Does aiui work in other MCP-capable clients?** The `aiui-mcp` server
-is a standard MCP server, so technically yes. The companion is Claude
-Desktop-specific in how it auto-installs, but the HTTP protocol on
-`localhost:7777` is client-agnostic.
+**Does aiui work in other MCP-capable clients?** Yes. `aiui-mcp` is a
+standard MCP server and the companion's `127.0.0.1:7777` protocol is
+client-agnostic. OpenAI's Codex is supported today — see
+[Using aiui with Codex / ChatGPT](#using-aiui-with-codex--chatgpt). Only
+the auto-install is Claude Desktop-specific; every other client registers
+the server by hand.
 
 ## Known limitations
 

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -4,7 +4,7 @@
 
 ## Was aiui ist
 
-aiui ist ein Kanal, über den Coding-Agenten auf dem Mac des Users echte UI rendern — strukturierte Eingaben, die im Chat zu unhandlich oder zu fehleranfällig wären. Topologie heute: Tauri-Companion am Mac, läuft als lokaler MCP-Server in Claude Desktop; Remote-Agenten (Claude Code via SSH) erreichen ihn über Reverse-Tunnel und POSTen Dialog-Specs an `localhost:7777`.
+aiui ist ein Kanal, über den Coding-Agenten auf dem Mac des Users echte UI rendern — strukturierte Eingaben, die im Chat zu unhandlich oder zu fehleranfällig wären. Topologie heute: Tauri-Companion am Mac, der einen host-agnostischen MCP-/HTTP-Kontrakt auf `localhost:7777` exponiert. Lokale MCP-Hosts (Claude Desktop, Codex/ChatGPT) sprechen ihn direkt an; Remote-Agenten (Claude Code oder Codex via SSH) erreichen ihn über Reverse-Tunnel und POSTen Dialog-Specs an `localhost:7777`. Der Companion auto-registriert sich heute nur bei Claude Desktop; andere Hosts binden sich über einen manuellen MCP-Eintrag (z. B. Codex' `~/.codex/config.toml`) an denselben Kontrakt an. Genau diese Host-Agnostik ist der Hebel: dieselbe Capability ist über jeden MCP-fähigen Host portabel, ohne dass je gegen einen einzelnen Client gebaut wurde.
 
 ## Designregel
 


### PR DESCRIPTION
Closes #160 · Teil von #158.

Hebt Codex/ChatGPT in der Doku von „geht technisch" zu **first-class MCP-Host**.

## Änderungen

- **README:** neuer Abschnitt **„Using aiui with Codex / ChatGPT"** mit copy-paste-`~/.codex/config.toml`-Block (`uvx aiui-mcp`), plus die Hinweise „kein Auto-Register" und „Companion muss laufen". Der Config-Block ist aus dem `aiui-mcp`-Server abgeleitet: auf dem Companion-Mac genügen Defaults (Token `~/.config/aiui/token`, Endpoint `127.0.0.1:7777`), Remote läuft über denselben Reverse-Tunnel wie Claude Code.
- **README FAQ:** die zwei einschlägigen Antworten („Can I use aiui without Claude Desktop?" / „Does aiui work in other MCP-capable clients?") zeigen jetzt auf den neuen Abschnitt und nennen Codex als unterstützt.
- **`docs/strategy.md`:** Topologie-Absatz von Claude-Desktop-zentriert auf host-agnostisch erweitert, Codex explizit genannt.

## Bewusst nicht in diesem PR

- Der **Live-Durchtest** aller drei Tools aus einer echten Codex-Session bleibt #159 (braucht Mac + laufenden Companion, nicht auf dem devhost machbar). Der dokumentierte Config-Block ist code-abgeleitet, nicht hands-on gegengeprüft — #159 schließt das ab.
- AGENTS.md-Spiegelung → #161, CI-Smoke-Test → #162.

Nur Doku, kein Code-Pfad berührt.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789550364&installation_model_id=428086&pr_number=163&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F163&signature=09f497d3e589455b8b066b46f9ba1f36a5095600452299c1e41f118e125ff2c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->