### PR TITLE
docs: mirror aiui when-to-use heuristic into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,31 @@
 
 These rules apply to all AI agents working on this repository (Claude, Codex, Copilot, etc.).
 
+## When to use aiui (dogfooding)
+
+This repo dogfoods its own product. When you work here with aiui's MCP tools
+available — Claude Desktop, or Codex/Claude Code tunnelling to the maintainer's
+Mac — prefer a native dialog over asking in chat, the same rule the
+[aiui skill](docs/skill.md) gives end users. Defaults:
+
+- **Destructive or hard-to-undo yes/no** (delete, drop, force-push, rollback,
+  prod deploy, dispatch a release) → `confirm` with `destructive: true`, even
+  if loose approval was already given.
+- **Pick one of N options where per-option context matters** (which migration
+  path? which release flavour?) → `ask` with a per-option `description`.
+- **Multi-field input, a secret/token, a date or bounded number, or a sortable
+  ranking** → `form` (use a `password` field for secrets — never paste them in
+  chat).
+- **A flow/sequence/state you'd otherwise sketch in ASCII** → `form` with a
+  `mermaid` field.
+- **A completion signal that needs no answer** (tests green, release dispatched,
+  blocked on a conflict) while the maintainer may be tabbed away → `notify`.
+
+Chat still wins for content the user reads but doesn't answer — status,
+summaries, logs, single free-text replies. [`docs/skill.md`](docs/skill.md) is
+the source of truth for the full tool set and field types; keep this section in
+sync with it rather than forking the guidance.
+
 ## Git Workflow
 - **Never push directly to `main`.** All changes go through feature branches and pull requests.
 - **Branch naming:** `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`, `test/`, `release/`, `dev/` prefixes.


### PR DESCRIPTION
Closes #161 · Teil von #158.

Das „wann greife ich zu einem Dialog statt Chat"-Wissen lebt bisher nur im Claude-Skill (`docs/skill.md`). Codex/Copilot & Co. lesen `AGENTS.md`, nicht die Claude-Skills — sie sahen die Heuristik also nie und nutzten aiui nur auf Zuruf.

## Änderung

Kompakter **„When to use aiui (dogfooding)"**-Abschnitt in `AGENTS.md` mit den Kern-Triggern (`confirm`/`ask`/`form`/`notify`), abgeleitet aus `docs/skill.md`.

## Zwei bewusste Entscheidungen

- **Framing = Dogfooding, kein Kategoriefehler.** `AGENTS.md` in diesem Repo adressiert Agenten, die *an aiui arbeiten*, nicht Endnutzer-Agenten. Weil genau diese Repo-Arbeit real über den Reverse-Tunnel auf den Mac aiui nutzt (aiui ist in solchen Sessions verfügbar), ist der Abschnitt hier korrekt platziert und ehrlich als Dogfooding markiert.
- **Keine Divergenz.** Der Abschnitt verweist explizit auf `docs/skill.md` als Source of Truth und bittet, ihn synchron zu halten statt die Anleitung zu forken.

## Follow-up (nicht hier)

Ein *portabler* „paste this into your own AGENTS.md"-Snippet für **Endnutzer**, damit deren Codex aiui proaktiv nutzt, wäre der logische nächste Schritt — eigener Scope, bewusst außen vor. Sag Bescheid, wenn ich dafür ein Issue aufmachen soll.

Nur Doku.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789550547&installation_model_id=428086&pr_number=164&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F164&signature=451bb93daec10340b96d6dcf7ef84c0d1b6f86578281ea953d61fa1f4974685e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->