### PR TITLE
chore: keep agent guidance (AGENTS.md) out of the public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ latest.json
 # local release credentials
 .env.release
 .claude/
+
+# agent guidance is kept private in the project wrapper (one level above the
+# repo), never in this public repo — guard against accidental re-adds
+/AGENTS.md
+/CLAUDE.md

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,7 @@
 #
 # This script exists only to stop agents and humans from reinventing a
 # local build path. If GitHub Actions is down, wait for it — do not sign
-# aiui locally. See AGENTS.md -> Releases.
+# aiui locally. See CONTRIBUTING.md -> Signing / notarising / releasing.
 set -euo pipefail
 cat >&2 <<'MSG'
 ✋ aiui does not release locally.
@@ -29,6 +29,6 @@ Validate-first (no PyPI publish, marked as GitHub pre-release):
   gh workflow run release-macos.yml -f version=<X.Y.Z> \
     -f prerelease=true -f publish-pypi=false --repo byte5ai/aiui
 
-Details: AGENTS.md -> Releases
+Details: CONTRIBUTING.md -> Signing / notarising / releasing
 MSG
 exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,7 @@
 # aiui does NOT release locally — not on CI-less machines, not on anyone's Mac.
 #
 # Releases run exclusively in GitHub Actions, on a GitHub-hosted macOS
-# runner, exactly like every other devhost project (***, ***):
+# runner, exactly like every other project of ours:
 # Developer-ID signing + notarization (App Store Connect API key), DMG +
 # signed updater bundle + latest.json, GitHub release, PyPI publish. The
 # signing material lives in GitHub Actions secrets — never in a local


### PR DESCRIPTION
## Warum

`AGENTS.md` ist Guidance für Agenten, die *an aiui arbeiten* — interner Workflow, Release-Mechanik, Speicherorte von Secrets. In einem **public** Repo ist das öffentlich. Diese Datei (und ein etwaiges `CLAUDE.md`) gehört in den **privaten Projekt-Wrapper** eine Ebene über dem Repo, der kein Git-Repo ist und daher nie von GitHub erfasst wird. Agenten, die im Repo-Verzeichnis arbeiten, lesen sie weiterhin über die Parent-Directory-Traversierung (Claude Code via `CLAUDE.md`, Codex via `AGENTS.md`).

## Änderungen

- `AGENTS.md` aus dem Repo entfernt.
- `.gitignore`: `/AGENTS.md` + `/CLAUDE.md` als Guard gegen versehentliches Wieder-Committen.
- `scripts/release.sh`: die zwei „AGENTS.md → Releases"-Verweise zeigen jetzt auf `CONTRIBUTING.md → Signing / notarising / releasing` (öffentlich, deckt denselben Inhalt).

Der Inhalt liegt inhaltsgleich (plus der „when to use aiui"-Dogfooding-Abschnitt aus #161) im Wrapper auf devhost — mit `CLAUDE.md`-Symlink, damit Claude Code und Codex dieselbe Datei lesen.

## ⚠️ Wichtig — Git-History

Dieser PR entfernt die Datei nur aus **HEAD**. Sie bleibt in der **Git-History** abrufbar (das Repo ist bereits public gewesen). Wer die Datei komplett aus der History tilgen will, braucht einen separaten History-Rewrite (`git filter-repo` + force-push) — bewusst **nicht** Teil dieses PRs.

## Ersetzt

- Schließt die Neu-Verortung von #161 (die frühere Variante — Abschnitt *ins* Repo-AGENTS.md, PR #164 — wurde als falsche Richtung geschlossen).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789551214&installation_model_id=428086&pr_number=165&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F165&signature=ba7757aa559eb0b081027a6ee748204368d0ff6783fe320562bfc6af1ae9e23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->