### PR TITLE
fix: don't rewrite ~/.codex/config.toml when already correct

### DIFF
--- a/companion/src-tauri/src/setup.rs
+++ b/companion/src-tauri/src/setup.rs
@@ -468,15 +468,6 @@ pub fn patch_codex_config(app_binary_path: &str) -> StepResult {
             }
         }
     };
-    let had_entry = existing
-        .as_deref()
-        .and_then(|s| s.parse::<toml_edit::DocumentMut>().ok())
-        .and_then(|d| {
-            d.get("mcp_servers")
-                .and_then(|i| i.as_table())
-                .map(|t| t.contains_key("aiui"))
-        })
-        .unwrap_or(false);
     let new_toml = match codex_toml_upsert(existing.as_deref(), app_binary_path) {
         Ok(s) => s,
         Err(e) => {
@@ -487,6 +478,19 @@ pub fn patch_codex_config(app_binary_path: &str) -> StepResult {
             }
         }
     };
+    // Idempotent: if the on-disk file already matches, don't rewrite it — and
+    // don't drop a fresh timestamped `.bak` — on every GUI launch. Mirrors the
+    // already-correct short-circuit in `patch_claude_code_config`. Because
+    // `codex_toml_upsert` is stable (see the idempotency test), this settles
+    // after at most one write.
+    if existing.as_deref() == Some(new_toml.as_str()) {
+        return StepResult {
+            ok: true,
+            message: "aiui already registered in ~/.codex/config.toml".into(),
+            details: None,
+        };
+    }
+    let was_new = existing.is_none();
     if let Err(e) = backup(&path) {
         return StepResult {
             ok: false,
@@ -497,10 +501,10 @@ pub fn patch_codex_config(app_binary_path: &str) -> StepResult {
     match atomic_write(&path, new_toml.as_bytes()) {
         Ok(_) => StepResult {
             ok: true,
-            message: if had_entry {
-                "Updated aiui entry in ~/.codex/config.toml".into()
-            } else {
+            message: if was_new {
                 "Added aiui to ~/.codex/config.toml — available in every Codex session".into()
+            } else {
+                "Updated aiui entry in ~/.codex/config.toml".into()
             },
             details: Some(format!("Datei: {}", path.display())),
         },


### PR DESCRIPTION
Follow-up-Fix zu #169.

**Problem:** `patch_codex_config` schrieb `~/.codex/config.toml` (und legte via `backup()` eine neue `config.toml.bak.<timestamp>` an) bei **jedem** GUI-Start — auch wenn der aiui-Eintrag schon exakt korrekt war. Anders als die anderen Hosts:
- Claude Desktop: in `lib.rs` durch `!is_claude_config_current(&bin)` gegatet.
- Claude Code: interner `already_correct`-Kurzschluss vor dem Schreiben.

Auf einem Host, auf dem aiui oft (re)startet — u.a. nach jedem Auto-Update-Restart — würde sich `~/.codex/` mit `.bak`-Dateien zumüllen.

**Fix:** derselbe Idempotenz-Kurzschluss — gewünschtes TOML berechnen und `backup()` + `atomic_write()` überspringen, wenn es byte-gleich zum Ist-Stand ist. Da `codex_toml_upsert` stabil ist (Idempotenz-Test), pendelt sich das nach höchstens einem Write ein. Entfernt nebenbei einen redundanten Parse.

Companion-only; CI (macOS/Windows) verifiziert.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789559563&installation_model_id=428086&pr_number=170&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F170&signature=8d9ca6f7802ef0a5d1758f96988b4b052759d5cfe1f515b1bbead1c54789c955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->