### PR TITLE
release: v0.10.0 — Codex support + installed-host gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project are documented here.
 
+## [0.10.0] — 2026-08-17
+
+### Added
+
+- **OpenAI Codex / ChatGPT is now a first-class host (#168).** aiui
+  registers itself with Codex the same self-contained way it already does
+  with Claude Desktop and Claude Code — on launch it writes its own
+  `~/.codex/config.toml` entry (`[mcp_servers.aiui]`, pointing at the
+  bundled `--mcp-stdio` server, no `uv`/`uvx`). No manual config, no
+  Claude-specific glue: install aiui.app and Codex sees the
+  `confirm`/`ask`/`form` dialogs immediately. The `~/.codex/config.toml`
+  edit is format-preserving (`toml_edit`), so any comments and other MCP
+  servers the user has are left untouched.
+
+### Changed
+
+- **Host registration is now gated on detection (#168).** aiui writes a
+  host's MCP config only when that host is actually installed — Claude
+  Desktop (app bundle or config dir), Claude Code (`~/.claude.json` /
+  `~/.claude/` / `claude` on `PATH`), or Codex (`~/.codex/` / `codex` on
+  `PATH`) — instead of writing the Claude configs unconditionally. No more
+  phantom config files for hosts you don't use. It re-checks on every
+  launch, so a host you install later is picked up automatically on the
+  next start.
+
+### Fixed
+
+- aiui no longer rewrites `~/.codex/config.toml` (and drops a fresh
+  timestamped `.bak`) on every launch when the entry is already correct —
+  the same idempotent short-circuit the Claude paths already had (#170).
+
 ## [0.9.0] — 2026-08-02
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.9.0"
+version = "0.10.0"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.9.0"
+version = "0.10.0"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump to **0.10.0** across Cargo.toml / tauri.conf.json / pyproject.toml (+ Cargo.lock aiui entry) so the release workflow's version-sync check passes, plus the CHANGELOG section.

Ships the Codex work merged since 0.9.0 was staged: #168 (self-contained Codex registration + installed-host gating, #169) and #170 (idempotent config write).

After merge I dispatch `release-macos.yml` with `version=0.10.0, prerelease=true, publish-pypi=false` (validate-first: signed + notarized build, GitHub **pre-release**, **no** PyPI publish) so a signed build is available to test #159 on the Mac.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789560335&installation_model_id=428086&pr_number=171&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F171&signature=2080055c564bdb3276aacfc96f588d882828b8041a40b39843c7cf5e8409dbe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->