### PR TITLE
ci(release): idempotent tag + release step for recovery re-runs

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -257,8 +257,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
+          # Idempotent: a prior run may have pushed the tag but failed later
+          # (e.g. PyPI). Reuse the existing tag instead of aborting on re-run.
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "tag $TAG already on origin — reusing"
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          fi
           cat > notes.md <<NOTES_EOF
           ## aiui ${TAG}
 
@@ -275,15 +281,21 @@ jobs:
           if [ "${{ inputs.prerelease }}" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
           fi
-          gh release create "$TAG" \
-            "aiui-${VERSION}-arm64.dmg" \
-            "aiui-${VERSION}-arm64.zip" \
-            "aiui-${VERSION}-updater-arm64.tar.gz" \
-            "latest.json" \
-            --repo byte5ai/aiui \
-            --title "aiui ${TAG}" \
-            --notes-file notes.md \
-            $PRERELEASE_FLAG
+          # Idempotent: skip creation if the release already exists so a
+          # recovery re-run proceeds to the PyPI step instead of failing here.
+          if gh release view "$TAG" --repo byte5ai/aiui >/dev/null 2>&1; then
+            echo "release $TAG already exists — skipping create; PyPI step still runs"
+          else
+            gh release create "$TAG" \
+              "aiui-${VERSION}-arm64.dmg" \
+              "aiui-${VERSION}-arm64.zip" \
+              "aiui-${VERSION}-updater-arm64.tar.gz" \
+              "latest.json" \
+              --repo byte5ai/aiui \
+              --title "aiui ${TAG}" \
+              --notes-file notes.md \
+              $PRERELEASE_FLAG
+          fi
 
       # PyPI LAST, after the GitHub release succeeded — PyPI versions are
       # permanent. If this step fails, the Tauri side is already shipped;


### PR DESCRIPTION
## Problem

`release-macos.yml` was not re-runnable. A run that pushed the version tag and
created the GitHub release but then failed at the PyPI step — e.g. a rejected
`UV_PUBLISH_TOKEN` — could not be recovered by re-dispatching: the re-run
aborted at the tagging command because the tag already existed, so it never
reached the PyPI step it was re-dispatched for.

That is exactly the shape of failure the workflow's own comment anticipates
("recovery is re-running with the same version and publish-pypi only after
fixing the token"), but the tagging step made that recovery impossible.

## Change

Both halves of the "Tag + GitHub release" step become idempotent:

- **Tag:** probe `git ls-remote --exit-code --tags origin` first; reuse the
  existing tag instead of aborting.
- **Release:** probe `gh release view` first; skip creation when the release
  already exists, so the run proceeds to PyPI.

No behaviour change on a first, clean run.

## Notes

`uv publish` stays the safety net on the PyPI side — re-uploading an existing
version fails loudly rather than overwriting, so an accidental double-dispatch
still cannot silently republish.

## Test plan

- [ ] Next dispatch completes normally (first-run path unchanged).
- [ ] Recovery path exercised only if a real run fails mid-way — not worth a
      deliberate broken dispatch to prove.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790779775&installation_model_id=428086&pr_number=172&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F172&signature=5861cf37c403495ec02b9c892dc3ca656ef53e3a8c821fb52df802db127deeed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->