### PR TITLE
docs: correct Windows status and the CI-only release path

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -13,7 +13,7 @@
 # the same release and rewrites `latest.json` to add the
 # `windows-x86_64` platform entry.
 #
-# One-time setup (see also: scripts/release.sh header):
+# Prerequisites:
 #
 #   1. Repo → Settings → Secrets and variables → Actions:
 #        - TAURI_SIGNING_PRIVATE_KEY        (literal content of the
@@ -22,14 +22,17 @@
 #        - TAURI_SIGNING_PRIVATE_KEY_PASSWORD
 #                                           (empty string if the key has
 #                                            no password)
+#      Both are shared with `release-macos.yml` and already configured.
 #
-#   2. The release for `vX.Y.Z` must already exist on GitHub (created
-#      by `scripts/release.sh X.Y.Z` from the maintainer's machine).
+#   2. The release for `vX.Y.Z` must already exist on GitHub — created by
+#      `release-macos.yml`, which is the only path that cuts a release.
+#      aiui is never built or released locally; `scripts/release.sh` is a
+#      stub that refuses to run. See CONTRIBUTING.md → "Releasing".
 #
 # Usage:
 #
-#   GitHub UI → Actions → "release-windows" → Run workflow → enter tag
-#   `v0.5.0` → Run.
+#   gh workflow run release-windows.yml -f tag=v0.5.0 --repo byte5ai/aiui
+#   # or: GitHub UI → Actions → "release-windows" → Run workflow
 #
 # What the run produces:
 #
@@ -39,10 +42,17 @@
 #   - latest.json patched in-place with the new windows-x86_64 entry
 #
 # Code signing for the `.exe` itself (Authenticode / SmartScreen) is
-# explicitly NOT done here — the v1 plan calls for unsigned shipping
-# with SmartScreen-Nag accepted (see plan-doc Phase 4). Adding an EV
-# cert later is a separate concern that touches the `tauri build`
-# invocation only; the rest of this workflow stays unchanged.
+# explicitly NOT done here — the v1 plan calls for unsigned shipping with
+# the SmartScreen nag accepted (Phase 4 of the port plan in PR #118).
+# Adding an EV cert later is a separate concern that touches the
+# `tauri build` invocation only; the rest of this workflow stays unchanged.
+#
+# Note on coverage: the installer produced here differs from the one CI
+# uploads per-push. CI builds with `tauri.ci.conf.json`
+# (`createUpdaterArtifacts: false`), so it yields the `.exe` only — the
+# signed `.nsis.zip` + `.sig` that the updater feed needs are produced
+# *only* by this workflow. Beta feedback on a CI artifact therefore says
+# nothing about the update path.
 
 name: release-windows
 
@@ -137,7 +147,7 @@ jobs:
 
       # Patch the existing latest.json to add the windows-x86_64 entry,
       # then upload it back to the release (overwriting the macOS-only
-      # version that scripts/release.sh produced earlier).
+      # version that release-macos.yml produced earlier).
       - name: Update latest.json with windows-x86_64 entry
         shell: pwsh
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,15 +22,15 @@ aiui/
 │   └── skill.md              Agent-facing widget catalog (shipped into
 │                             ~/.claude/skills/aiui/)
 ├── scripts/
-│   └── release.sh            Local sign + notarize + updater feed pipeline
+│   └── release.sh            Stub that refuses to run — releases are CI-only
 ├── assets/                   Brand assets (icon, logo, dmg background)
 └── CHANGELOG.md
 ```
 
 ## Building locally
 
-Prerequisites: Rust (stable), Node.js ≥ 20, Xcode command-line tools,
-[uv](https://docs.astral.sh/uv/).
+Prerequisites: Rust (stable), Node.js ≥ 20, [uv](https://docs.astral.sh/uv/),
+plus Xcode command-line tools on macOS.
 
 ```sh
 cd companion
@@ -40,6 +40,19 @@ npx tauri build --target aarch64-apple-darwin
 
 Output: `companion/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/aiui.app`
 
+On Windows, build the NSIS installer the same way CI does — the config
+override skips the updater bundle, which needs the signing key:
+
+```sh
+cd companion
+npm install
+npx tauri build --target x86_64-pc-windows-msvc --bundles nsis \
+  --config src-tauri/tauri.ci.conf.json
+```
+
+A local build like this is fine for development. It is not a release —
+see "Releasing" below.
+
 For the Python side:
 
 ```sh
@@ -47,33 +60,56 @@ cd python
 uv build    # produces dist/aiui_mcp-*.whl + .tar.gz
 ```
 
-## Signing / notarising / releasing
+## Releasing
 
-The release pipeline lives in `scripts/release.sh` and is tuned for the
-byte5 Developer ID. If you fork aiui, copy `.env.release.example` (if
-present) or read the script; the required environment variables are:
+**Releases run exclusively in GitHub Actions.** Not locally, not on the
+maintainer's machine. All signing material lives in Actions secrets
+(`MACOS_*`, `TAURI_SIGNING_PRIVATE_KEY*`, `UV_PUBLISH_TOKEN`) — never in a
+local keychain, never in the repo. `scripts/release.sh` is a stub that
+refuses to run; it exists only to stop anyone from reinventing a local
+build path. If Actions is down, wait for it.
 
-- `APPLE_SIGNING_IDENTITY`, `NOTARY_PROFILE`,
-  `BUILD_KEYCHAIN`, `BUILD_KEYCHAIN_PASS_FILE` — Apple codesign + notary
-- `TAURI_SIGNING_PRIVATE_KEY_PATH` — Ed25519 key for the updater feed
-- `UV_PUBLISH_TOKEN` — PyPI API token (project-scoped to `aiui-mcp`).
-  Without it, `scripts/release.sh` aborts before any work is done — that
-  guard exists because shipping the Tauri side without the matching PyPI
-  bump produces silent slash-command-mismatch on remote hosts.
+Before dispatching, bump the version in `companion/src-tauri/Cargo.toml`,
+`companion/src-tauri/tauri.conf.json`, and `python/pyproject.toml` so all
+three agree — the workflow's first step hard-fails on drift.
 
-A single run of `scripts/release.sh 0.2.3` performs the full pipeline:
+### macOS — `release-macos.yml`
 
-1. Pre-flight checks — `.env.release` loaded, all required env present,
-   versions agree across `Cargo.toml`, `tauri.conf.json`, and
-   `python/pyproject.toml`.
-2. Tauri companion: build, codesign, notarize, staple, DMG, updater
-   bundle + signature, `latest.json`.
-3. Python `aiui-mcp`: `uv build` produces wheel + sdist into
-   `python/dist/`. Done before the dry-run gate so dry runs catch
-   packaging breakage too.
-4. Tag, push, GitHub release.
-5. `uv publish` from `python/` — pushes the wheel + sdist to PyPI so
-   `uvx aiui-mcp` resolves to the matching version on remote hosts.
+Builds on a `macos-14` runner, Developer-ID-signs + notarizes via the App
+Store Connect API key, produces the DMG + signed updater bundle +
+`latest.json`, cuts the GitHub release, and publishes `aiui-mcp` to PyPI.
+
+```sh
+gh workflow run release-macos.yml -f version=X.Y.Z --repo byte5ai/aiui
+
+# validate-first (no PyPI, GitHub pre-release):
+gh workflow run release-macos.yml -f version=X.Y.Z \
+  -f prerelease=true -f publish-pypi=false --repo byte5ai/aiui
+```
+
+PyPI runs last, after the GitHub release succeeded, because PyPI versions
+are permanent. The tag and release steps are idempotent, so a run that
+failed at PyPI can be re-dispatched with the same version to recover.
+
+### Windows — `release-windows.yml`
+
+Run **after** the macOS workflow, against the tag it created. Builds the
+NSIS installer plus the signed updater bundle, attaches all three
+artifacts to the existing release, and patches `latest.json` with the
+`windows-x86_64` entry.
+
+```sh
+gh workflow run release-windows.yml -f tag=vX.Y.Z --repo byte5ai/aiui
+```
+
+The Windows `.exe` ships **unsigned** — no Authenticode certificate, so
+SmartScreen warns on first launch. That is a deliberate v1 decision, not
+an oversight.
+
+Note that this differs from the per-push CI build: CI uses
+`tauri.ci.conf.json` (`createUpdaterArtifacts: false`) and produces the
+`.exe` only. The signed `.nsis.zip` + `.sig` that the updater feed needs
+come from `release-windows.yml` alone.
 
 ## Issues
 
@@ -84,7 +120,7 @@ saves us a round of „which version are you on?".
 For bug reports, please include:
 
 - aiui version (visible in Settings as a chip, e.g. `v0.2.0`)
-- macOS version
+- Your OS and version (macOS, or Windows if you're on a port build)
 - Whether you hit it locally or via a remote host setup
 - What you did / expected / saw
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,15 @@ The underlying WebKit view loads only while a dialog is on screen.
 Intel support isn't on the immediate roadmap — [open an issue](https://github.com/byte5ai/aiui/issues/new)
 if you need it.
 
-**Does it work on Linux or Windows?** Linux: no. Windows: in progress —
-the Rust core and CI build already target Windows; interactive E2E testing
-and a first release are still outstanding. Follow
-[#118](https://github.com/byte5ai/aiui/pull/118) for status.
+**Does it work on Linux or Windows?** Linux: no. Windows: the port builds
+and runs — the Rust core is platform-clean, CI builds an NSIS installer on
+every push, and beta testers have installed and used that build. What's
+still missing is the release itself: no GitHub release carries a Windows
+build yet, and `latest.json` has no `windows-x86_64` entry, so the in-app
+updater can't serve Windows (an update check there currently reports a
+failure rather than "up to date"). When the first Windows build ships it
+will be unsigned — no Authenticode certificate — so SmartScreen will warn
+on first launch; "More info" → "Run anyway" gets past it.
 
 **Can I use aiui without Claude Desktop?** The companion is
 auto-spawned by Claude Desktop via its MCP registration, so in the


### PR DESCRIPTION
Documentation only — no behaviour change. Three things were saying something
untrue about how aiui ships.

## 1. The release path docs described a pipeline that no longer exists

`scripts/release.sh` has been a refusing stub for a while, but the docs hadn't
caught up:

- **CONTRIBUTING.md** documented its required env vars (`APPLE_SIGNING_IDENTITY`,
  `NOTARY_PROFILE`, `BUILD_KEYCHAIN`, …) and its five-step run as *the* way to
  release. Anyone following it would have tried to sign locally — exactly what
  the stub exists to prevent.
- **release-windows.yml**'s header told the reader the GitHub release "must
  already exist … created by `scripts/release.sh X.Y.Z` from the maintainer's
  machine", and repeated the claim in the `latest.json` step.

Both now describe the two `workflow_dispatch` pipelines that actually do the
work, with the dispatch commands and the macOS-then-Windows ordering.

## 2. The README FAQ understated where the Windows port stands

It said interactive E2E testing was outstanding. It isn't — beta testers have
installed and used the CI-built NSIS installer, with positive feedback.

What *is* outstanding is narrower, and the FAQ now says it precisely: no GitHub
release carries a Windows build, `latest.json` has no `windows-x86_64` entry,
and an update check on Windows consequently lands in the error branch of
`updater.ts` and reports a failure rather than "up to date".

The stale pointer to #118 (merged) is gone.

## 3. Beta coverage vs. the update path

Recorded in the workflow header, because it is easy to get wrong: CI builds
with `tauri.ci.conf.json` (`createUpdaterArtifacts: false`) and yields the
`.exe` only. The signed `.nsis.zip` + `.sig` that the updater feed needs are
produced by `release-windows.yml` alone — which has never run. So positive beta
feedback on a CI artifact says nothing about updates.

Also states the unsigned / SmartScreen situation in both places a reader would
look for it (README FAQ and CONTRIBUTING), since it is a deliberate v1 decision
rather than an oversight and will otherwise arrive as a support question.

## Also

- CONTRIBUTING gained the Windows local-build command, and its prerequisites no
  longer imply Xcode is needed on every platform.
- The bug-report checklist asked for "macOS version"; now asks for the OS.

## Not in scope

Untouched on purpose: the historical `scripts/release.sh` mentions in
CHANGELOG.md and `docs/reviews/` (dated records), and the "CI port of
scripts/release.sh" provenance line atop `release-macos.yml`.

## Verification

- `release-windows.yml` still parses as YAML.
- No remaining reference outside the historical records describes the stub as a
  working pipeline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790779913&installation_model_id=428086&pr_number=173&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F173&signature=c93bbc538c38bd58d5f98cb587f9d32244f3ffc7cc196f7012b74eb4a4e76883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->