### PR TITLE
release: v0.10.1 — first Windows release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project are documented here.
 
+## [0.10.1] — 2026-08-31
+
+### Added
+
+- **First Windows release.** aiui ships a Windows installer for the first
+  time: `aiui_0.10.1_x64-setup.exe`, built and signed for the updater on a
+  `windows-latest` runner by `release-windows.yml`, attached to this
+  release alongside the macOS artifacts. `latest.json` now carries a
+  `windows-x86_64` entry, so the in-app updater serves Windows too — until
+  now it had only `darwin-aarch64`, and an update check on Windows landed
+  in the error path rather than reporting "up to date".
+
+  The Windows port itself has been buildable since v0.6.0 and was exercised
+  by beta testers on per-push CI installers; what was missing was the
+  release path, not the app. The installer is **not** Authenticode-signed,
+  so SmartScreen warns on first launch — "More info" → "Run anyway". That
+  is a deliberate v1 decision; an EV certificate is a separate concern.
+
+### Fixed
+
+- **The release workflow is re-runnable.** A run that pushed the version
+  tag and created the GitHub release but then failed at the PyPI step —
+  e.g. a rejected `UV_PUBLISH_TOKEN` — could not be recovered by
+  re-dispatching, because the re-run aborted at the tagging command. Both
+  halves now probe for existing state first, so a recovery dispatch
+  proceeds to the step it was re-dispatched for (#172).
+
+### Changed
+
+- **Release and Windows documentation corrected** (#173). CONTRIBUTING.md
+  still documented a local sign-and-notarize pipeline with its environment
+  variables as the way to ship, years after `scripts/release.sh` became a
+  stub that refuses to run; `release-windows.yml` told the reader the
+  GitHub release is created by that script "from the maintainer's
+  machine". Both now describe the two `workflow_dispatch` pipelines that
+  actually do the work. The README FAQ no longer claims interactive
+  Windows testing is outstanding.
+
 ## [0.10.0] — 2026-08-17
 
 ### Added

--- a/companion/src-tauri/Cargo.lock
+++ b/companion/src-tauri/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "aiui"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/companion/src-tauri/Cargo.toml
+++ b/companion/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aiui"
-version = "0.10.0"
+version = "0.10.1"
 description = "aiui companion — renders dialogs for remote Claude Code sessions"
 authors = ["byte5"]
 license = ""

--- a/companion/src-tauri/tauri.conf.json
+++ b/companion/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "aiui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "de.byte5.aiui",
   "build": {
     "frontendDist": "../dist",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui-mcp"
-version = "0.10.0"
+version = "0.10.1"
 description = "MCP server for aiui — native macOS dialogs from any Claude Code session, local or remote."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump to 0.10.1 across `companion/src-tauri/Cargo.toml`,
`companion/src-tauri/tauri.conf.json`, `python/pyproject.toml` and `Cargo.lock`,
so the version-sync gate passes, plus the changelog entry.

## Why this version exists

The Windows installer. The port has been buildable since v0.6.0 and beta testers
exercised the per-push CI builds, but no release has ever carried a Windows
artifact, and `latest.json` has only ever had a `darwin-aarch64` entry — so an
update check on Windows lands in the error path rather than reporting "up to
date". `release-windows.yml` has zero runs across the repo's entire history.

There is no functional change to the app in this version. That is deliberate:
shipping the existing, tested build through the release path is the deliverable.

## Release plan once this merges

1. `release-macos.yml` with `version=0.10.1` — cuts the tag and release, macOS
   artifacts, `latest.json`, PyPI.
2. `release-windows.yml` with `tag=v0.10.1` — builds the NSIS installer plus the
   signed updater bundle, attaches all three, patches `latest.json` with the
   `windows-x86_64` entry.

A pre-release was considered and rejected: GitHub's
`releases/latest/download/latest.json` — the updater endpoint — resolves to the
latest **non-prerelease** release, so a pre-release would not be served to
anyone and the update path would stay untested.

## Also in this version

Both already merged to main:

- #172 — the release workflow's tag and release steps are idempotent, so a run
  that fails at PyPI can be recovered by re-dispatching.
- #173 — release and Windows documentation corrected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/aiui/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790789371&installation_model_id=428086&pr_number=174&repository=byte5ai%2Faiui&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Faiui%2Fpull%2F174&signature=51a32a7ed5c0c25492e1237ef1ce0eacec06c37a591c2197e3190858c1f79d64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->